### PR TITLE
feat: add optional macros to reduce boilerplate

### DIFF
--- a/examples/macro.rs
+++ b/examples/macro.rs
@@ -1,0 +1,158 @@
+mod store_rpc {
+    use quic_rpc::derive_rpc_service;
+    use serde::{Deserialize, Serialize};
+    use std::fmt::Debug;
+
+    pub type Cid = [u8; 32];
+
+    #[derive(Debug, Serialize, Deserialize)]
+    pub struct Put(pub Vec<u8>);
+    #[derive(Debug, Serialize, Deserialize)]
+    pub struct PutResponse(pub Cid);
+
+    #[derive(Debug, Serialize, Deserialize)]
+    pub struct Get(pub Cid);
+    #[derive(Debug, Serialize, Deserialize)]
+    pub struct GetResponse(pub Vec<u8>);
+
+    #[derive(Debug, Serialize, Deserialize)]
+    pub struct PutFile;
+    #[derive(Debug, Serialize, Deserialize)]
+    pub struct PutFileUpdate(pub Vec<u8>);
+    #[derive(Debug, Serialize, Deserialize)]
+    pub struct PutFileResponse(pub Cid);
+
+    #[derive(Debug, Serialize, Deserialize)]
+    pub struct GetFile(pub Cid);
+    #[derive(Debug, Serialize, Deserialize)]
+    pub struct GetFileResponse(pub Vec<u8>);
+
+    #[derive(Debug, Serialize, Deserialize)]
+    pub struct ConvertFile;
+    #[derive(Debug, Serialize, Deserialize)]
+    pub struct ConvertFileUpdate(pub Vec<u8>);
+    #[derive(Debug, Serialize, Deserialize)]
+    pub struct ConvertFileResponse(pub Vec<u8>);
+
+    use super::Store;
+    derive_rpc_service! {
+        service Store {
+            Request = StoreRequest;
+            Response = StoreResponse;
+            Service = StoreService;
+            RequestHandler = dispatch_request;
+
+            Rpc put = Put, _ -> PutResponse;
+            Rpc get = Get, _ -> GetResponse;
+            ClientStreaming put_file = PutFile, PutFileUpdate -> PutFileResponse;
+            ServerStreaming get_file = GetFile, _ -> GetFileResponse;
+            BidiStreaming convert_file = ConvertFile, ConvertFileUpdate -> ConvertFileResponse;
+        }
+    }
+}
+
+use async_stream::stream;
+use futures::{SinkExt, Stream, StreamExt};
+use quic_rpc::mem::{self, MemChannelTypes};
+use quic_rpc::server::spawn_server_loop;
+use quic_rpc::client::RpcClient;
+use store_rpc::*;
+
+#[derive(Clone)]
+pub struct Store;
+
+impl Store {
+    async fn put(self, _put: Put) -> PutResponse {
+        PutResponse([0; 32])
+    }
+
+    async fn get(self, _get: Get) -> GetResponse {
+        GetResponse(vec![])
+    }
+
+    async fn put_file(
+        self,
+        _put: PutFile,
+        updates: impl Stream<Item = PutFileUpdate>,
+    ) -> PutFileResponse {
+        tokio::pin!(updates);
+        while let Some(_update) = updates.next().await {}
+        PutFileResponse([0; 32])
+    }
+
+    fn get_file(self, _get: GetFile) -> impl Stream<Item = GetFileResponse> + Send + 'static {
+        stream! {
+            for i in 0..3 {
+                yield GetFileResponse(vec![i]);
+            }
+        }
+    }
+
+    fn convert_file(
+        self,
+        _convert: ConvertFile,
+        updates: impl Stream<Item = ConvertFileUpdate> + Send + 'static,
+    ) -> impl Stream<Item = ConvertFileResponse> + Send + 'static {
+        stream! {
+            tokio::pin!(updates);
+            while let Some(msg) = updates.next().await {
+                yield ConvertFileResponse(msg.0);
+            }
+        }
+    }
+}
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    let (client, server) = mem::connection::<StoreResponse, StoreRequest>(1);
+    let mut client = RpcClient::<StoreService, MemChannelTypes>::new(client);
+    let context = Store;
+    let server_handle = spawn_server_loop(
+        StoreService,
+        MemChannelTypes,
+        server,
+        context,
+        store_rpc::dispatch_request,
+    )
+    .await;
+
+    // a rpc call
+    println!("a rpc call");
+    let res = client.rpc(Get([0u8; 32])).await?;
+    println!("{:?}", res);
+
+    // server streaming call
+    println!("a server streaming call");
+    let mut s = client.server_streaming(GetFile([0u8; 32])).await?;
+    while let Some(res) = s.next().await {
+        println!("{:?}", res);
+    }
+
+    // client streaming call
+    println!("a client streaming call");
+    let (mut send, recv) = client.client_streaming(PutFile).await?;
+    tokio::task::spawn(async move {
+        for i in 0..3 {
+            send.send(PutFileUpdate(vec![i])).await.unwrap();
+        }
+    });
+    let res = recv.await?;
+    println!("{:?}", res);
+
+    // bidi streaming call
+    println!("a bidi streaming call");
+    let (mut send, mut recv) = client.bidi(ConvertFile).await?;
+    tokio::task::spawn(async move {
+        for i in 0..3 {
+            send.send(ConvertFileUpdate(vec![i])).await.unwrap();
+        }
+    });
+    while let Some(res) = recv.next().await {
+        println!("{:?}", res);
+    }
+
+    // dropping the client will cause the server to terminate
+    drop(client);
+    server_handle.await??;
+    Ok(())
+}

--- a/examples/macro.rs
+++ b/examples/macro.rs
@@ -106,12 +106,12 @@ impl Store {
 async fn main() -> anyhow::Result<()> {
     let (client, server) = mem::connection::<StoreResponse, StoreRequest>(1);
     let mut client = RpcClient::<StoreService, MemChannelTypes>::new(client);
-    let context = Store;
+    let target = Store;
     let server_handle = spawn_server_loop(
         StoreService,
         MemChannelTypes,
         server,
-        context,
+        target,
         store_rpc::dispatch_request,
     )
     .await;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -64,6 +64,7 @@ use std::{
 };
 pub mod client;
 pub mod combined;
+pub mod macros;
 pub mod mem;
 pub mod message;
 pub mod quinn;

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -1,0 +1,126 @@
+//! Macros to reduce boilerplate for RPC implementations.
+
+/// Derive a set of RPC types and message implementation from a declaration.
+///
+/// See [./examples/macro.rs](examples/macro.rs) for an example.
+#[macro_export]
+macro_rules! derive_rpc_service {
+    (
+        service $target:ident {
+            Request = $request:ident;
+            Response = $response:ident;
+            Service = $service:ident;
+            RequestHandler = $handler:ident;
+            $($m_pattern:ident $m_name:ident = $m_input:ident, $m_update:tt -> $m_output:ident);+$(;)?
+        }
+    ) => {
+        $crate::__request_enum! {
+            $request {
+                $($m_input,)*
+                $($m_update,)*
+            }
+        }
+
+        #[derive(::std::fmt::Debug, ::derive_more::From, ::derive_more::TryInto, ::serde::Serialize, ::serde::Deserialize)]
+        pub enum $response {
+            $($m_output($m_output),)*
+        }
+
+        $(
+            $crate::__rpc_message!($service, $m_pattern, $m_input, $m_update, $m_output);
+        )*
+
+        #[derive(::std::clone::Clone, ::std::fmt::Debug)]
+        pub struct $service;
+
+        impl $crate::Service for $service {
+            type Req = $request;
+            type Res = $response;
+        }
+
+        pub async fn $handler<C: $crate::ChannelTypes>(
+            mut server: $crate::server::RpcServer<$service, C>,
+            target: $target,
+        ) -> Result<$crate::server::RpcServer<$service, C>, $crate::server::RpcServerError<C>> {
+            let (req, chan) = server.accept_one().await?;
+            let target = target.clone();
+            match req {
+                $(
+                    $request::$m_input(msg) => { $crate::__rpc_invoke!($m_pattern, $m_name, $target, server, msg, chan, target) },
+                )*
+                _ => Err($crate::server::RpcServerError::<C>::UnexpectedStartMessage)?,
+            }?;
+            Ok(server)
+        }
+    };
+}
+
+#[doc(hidden)]
+#[macro_export]
+macro_rules! __request_enum {
+    // User entry points.
+    ($enum_name:ident { $variant_name:ident $($tt:tt)* }) => {
+        $crate::__request_enum!(@ {[$enum_name] [$variant_name]} $($tt)*);
+    };
+
+    // Internal rules to categorize each value
+    // This also filters out _ placeholders from non-streaming methods.
+    (@ {[$enum_name:ident] [$($agg:ident)*]} $(,)? $(_$(,)?)* $variant_name:ident $($tt:tt)*) => {
+        $crate::__request_enum!(@ {[$enum_name] [$($agg)* $variant_name]} $($tt)*);
+    };
+
+    // Internal rules to categorize each value
+    (@ {[$enum_name:ident] [$($agg:ident)*]} $(,)? $variant_name:ident $($tt:tt)*) => {
+        $crate::__request_enum!(@ {[$enum_name] [$($agg)* $variant_name]} $($tt)*);
+    };
+
+    // Final internal rule that generates the enum from the categorized input
+    (@ {[$enum_name:ident] [$($n:ident)*]} $(,)? $(_$(,)?)*) => {
+        #[derive(::std::fmt::Debug, ::derive_more::From, ::derive_more::TryInto, ::serde::Serialize, ::serde::Deserialize)]
+        pub enum $enum_name {
+            $($n($n),)*
+        }
+    };
+}
+
+#[doc(hidden)]
+#[macro_export]
+macro_rules! __rpc_message {
+    ($service:ident, Rpc, $m_input:ident, _, $m_output:ident) => {
+        impl $crate::message::RpcMsg<$service> for $m_input {
+            type Response = $m_output;
+        }
+    };
+    ($service:ident, ServerStreaming, $m_input:ident, _, $m_output:ident) => {
+        impl $crate::message::Msg<$service> for $m_input {
+            type Pattern = $crate::message::ServerStreaming;
+            type Response = $m_output;
+            type Update = $m_input;
+        }
+    };
+    ($service:ident, $m_pattern:ident, $m_input:ident, $m_update:ident, $m_output:ident) => {
+        impl $crate::message::Msg<$service> for $m_input {
+            type Pattern = $crate::message::$m_pattern;
+            type Response = $m_output;
+            type Update = $m_update;
+        }
+    };
+}
+
+#[doc(hidden)]
+#[macro_export]
+macro_rules! __rpc_invoke {
+    (Rpc, $m_name:ident, $target_ty:ident, $server:ident, $msg:ident, $chan:ident, $target:ident) => {
+        $server.rpc($msg, $chan, $target, $target_ty::$m_name).await
+    };
+    (ClientStreaming, $m_name:ident, $target_ty:ident, $server:ident, $msg:ident, $chan:ident, $target:ident) => {
+        $server.client_streaming($msg, $chan, $target, $target_ty::$m_name).await
+    };
+    (ServerStreaming, $m_name:ident, $target_ty:ident, $server:ident, $msg:ident, $chan:ident, $target:ident) => {
+        $server.server_streaming($msg, $chan, $target, $target_ty::$m_name).await
+    };
+    (BidiStreaming, $m_name:ident, $target_ty:ident, $server:ident, $msg:ident, $chan:ident, $target:ident) => {
+        $server.bidi_streaming($msg, $chan, $target, $target_ty::$m_name).await
+    };
+}
+

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -39,12 +39,12 @@ macro_rules! derive_rpc_service {
         }
 
         pub async fn $handler<C: $crate::ChannelTypes>(
-            mut server: $crate::server::RpcServer<$service, C>,
+            server: $crate::server::RpcServer<$service, C>,
+            msg: <$service as $crate::Service>::Req,
+            chan: (C::SendSink<<$service as $crate::Service>::Res>, C::RecvStream<<$service as $crate::Service>::Req>),
             target: $target,
         ) -> Result<$crate::server::RpcServer<$service, C>, $crate::server::RpcServerError<C>> {
-            let (req, chan) = server.accept_one().await?;
-            let target = target.clone();
-            match req {
+            match msg {
                 $(
                     $request::$m_input(msg) => { $crate::__rpc_invoke!($m_pattern, $m_name, $target, server, msg, chan, target) },
                 )*

--- a/src/server.rs
+++ b/src/server.rs
@@ -313,27 +313,27 @@ async fn race2<T, A: Future<Output = T>, B: Future<Output = T>>(f1: A, f2: B) ->
 }
 
 /// Spawn a server loop, invoking a handler callback for each request.
-pub async fn spawn_server_loop<C, S, F, Fut, Ctx>(
+pub async fn spawn_server_loop<C, S, F, Fut, T>(
     _service_type: S,
     _channel_type: C,
     server: C::Channel<S::Req, S::Res>,
-    context: Ctx,
+    target: T,
     mut handler: F,
 ) ->
     JoinHandle<Result<(), RpcServerError<C>>>
 where
     S: Service,
     C: ChannelTypes,
-    F: FnMut(RpcServer<S, C>, Ctx) -> Fut + Send + 'static,
+    F: FnMut(RpcServer<S, C>, T) -> Fut + Send + 'static,
     Fut: Future<Output = Result<RpcServer<S,C>, RpcServerError<C>>> + Send + 'static,
-    Ctx: Clone + Send + 'static,
+    T: Clone + Send + 'static,
 {
     let mut server = RpcServer::<S, C>::new(server);
     tokio::task::spawn({
         async move {
             loop {
-                let context = context.clone();
-                server = handler(server, context).await?;
+                let target = target.clone();
+                server = handler(server, target).await?;
             }
         }
     })


### PR DESCRIPTION
I digged out some macro_rules code for RPC interface declarations that I wrote for an RPC experiment a while back. It was quite straightforward to adapt to quic-rpc, combined it with the `request_enum` macro from `examples/store.rs` and then got lost a bit and made the `store` example work.

The macros are completely optional. They also do not introduce any traits, because async traits would require boxing the futures, and so far `quic-rpc` works without, which is nice.

All idents have to be passed in the macro call. I think that's a feature because less magic. The invocation of `derive_rpc_service!` in `examples/macro.rs`  quite literally creates the code that can be seen in `examples/store.rs`.