### PR TITLE
feat: improve macro for splitting crates and generate client

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -81,6 +81,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
+name = "client"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "futures",
+ "quic-rpc",
+ "quinn",
+ "rustls",
+ "serde",
+ "tokio",
+ "types",
+]
+
+[[package]]
 name = "convert_case"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -732,6 +746,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "server"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "async-stream",
+ "futures",
+ "quic-rpc",
+ "quinn",
+ "rcgen",
+ "rustls",
+ "serde",
+ "tokio",
+ "types",
+]
+
+[[package]]
 name = "signal-hook-registry"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -938,6 +968,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24eb03ba0eab1fd845050058ce5e616558e8f8d8fca633e6b163fe25c797213a"
 dependencies = [
  "once_cell",
+]
+
+[[package]]
+name = "types"
+version = "0.1.0"
+dependencies = [
+ "derive_more",
+ "quic-rpc",
+ "serde",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -975,6 +975,7 @@ name = "types"
 version = "0.1.0"
 dependencies = [
  "derive_more",
+ "futures",
  "quic-rpc",
  "serde",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,3 +32,6 @@ quinn = "0.9.0"
 rcgen = "0.10.0"
 rustls = "0.20.7"
 thousands = "0.2.0"
+
+[workspace]
+members = ["examples/split/types", "examples/split/server", "examples/split/client"]

--- a/examples/macro.rs
+++ b/examples/macro.rs
@@ -1,5 +1,5 @@
 mod store_rpc {
-    use quic_rpc::derive_rpc_service;
+    use quic_rpc::rpc_service;
     use serde::{Deserialize, Serialize};
     use std::fmt::Debug;
 
@@ -34,7 +34,7 @@ mod store_rpc {
     #[derive(Debug, Serialize, Deserialize)]
     pub struct ConvertFileResponse(pub Vec<u8>);
 
-    derive_rpc_service! {
+    rpc_service! {
         Request = StoreRequest;
         Response = StoreResponse;
         Service = StoreService;

--- a/examples/macro.rs
+++ b/examples/macro.rs
@@ -34,20 +34,17 @@ mod store_rpc {
     #[derive(Debug, Serialize, Deserialize)]
     pub struct ConvertFileResponse(pub Vec<u8>);
 
-    use super::Store;
     derive_rpc_service! {
-        service Store {
-            Request = StoreRequest;
-            Response = StoreResponse;
-            Service = StoreService;
-            RequestHandler = dispatch_request;
+        Request = StoreRequest;
+        Response = StoreResponse;
+        Service = StoreService;
+        CreateDispatch = create_store_dispatch;
 
-            Rpc put = Put, _ -> PutResponse;
-            Rpc get = Get, _ -> GetResponse;
-            ClientStreaming put_file = PutFile, PutFileUpdate -> PutFileResponse;
-            ServerStreaming get_file = GetFile, _ -> GetFileResponse;
-            BidiStreaming convert_file = ConvertFile, ConvertFileUpdate -> ConvertFileResponse;
-        }
+        Rpc put = Put, _ -> PutResponse;
+        Rpc get = Get, _ -> GetResponse;
+        ClientStreaming put_file = PutFile, PutFileUpdate -> PutFileResponse;
+        ServerStreaming get_file = GetFile, _ -> GetFileResponse;
+        BidiStreaming convert_file = ConvertFile, ConvertFileUpdate -> ConvertFileResponse;
     }
 }
 
@@ -102,6 +99,8 @@ impl Store {
     }
 }
 
+create_store_dispatch!(Store, dispatch_store_request);
+
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     let (client, server) = mem::connection::<StoreResponse, StoreRequest>(1);
@@ -112,9 +111,8 @@ async fn main() -> anyhow::Result<()> {
         MemChannelTypes,
         server,
         target,
-        store_rpc::dispatch_request,
-    )
-    .await;
+        dispatch_store_request,
+    );
 
     // a rpc call
     for i in 0..3 {

--- a/examples/macro.rs
+++ b/examples/macro.rs
@@ -39,6 +39,7 @@ mod store_rpc {
         Response = StoreResponse;
         Service = StoreService;
         CreateDispatch = create_store_dispatch;
+        CreateClient = create_store_client;
 
         Rpc put = Put, _ -> PutResponse;
         Rpc get = Get, _ -> GetResponse;
@@ -100,11 +101,11 @@ impl Store {
 }
 
 create_store_dispatch!(Store, dispatch_store_request);
+create_store_client!(StoreClient);
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     let (client, server) = mem::connection::<StoreResponse, StoreRequest>(1);
-    let mut client = RpcClient::<StoreService, MemChannelTypes>::new(client);
     let target = Store;
     let server_handle = spawn_server(
         StoreService,
@@ -113,27 +114,29 @@ async fn main() -> anyhow::Result<()> {
         target,
         dispatch_store_request,
     );
+    let client = RpcClient::<StoreService, MemChannelTypes>::new(client);
+    let mut client = StoreClient(client);
 
     // a rpc call
     for i in 0..3 {
         println!("a rpc call [{i}]");
-        let client = client.clone();
+        let mut client = client.clone();
         tokio::task::spawn(async move {
-            let res = client.rpc(Get([0u8; 32])).await;
+            let res = client.get(Get([0u8; 32])).await;
             println!("rpc res [{i}]: {:?}", res);
         });
     }
 
     // server streaming call
     println!("a server streaming call");
-    let mut s = client.server_streaming(GetFile([0u8; 32])).await?;
+    let mut s = client.get_file(GetFile([0u8; 32])).await?;
     while let Some(res) = s.next().await {
         println!("streaming res: {:?}", res);
     }
 
     // client streaming call
     println!("a client streaming call");
-    let (mut send, recv) = client.client_streaming(PutFile).await?;
+    let (mut send, recv) = client.put_file(PutFile).await?;
     tokio::task::spawn(async move {
         for i in 0..3 {
             send.send(PutFileUpdate(vec![i])).await.unwrap();
@@ -144,7 +147,7 @@ async fn main() -> anyhow::Result<()> {
 
     // bidi streaming call
     println!("a bidi streaming call");
-    let (mut send, mut recv) = client.bidi(ConvertFile).await?;
+    let (mut send, mut recv) = client.convert_file(ConvertFile).await?;
     tokio::task::spawn(async move {
         for i in 0..3 {
             send.send(ConvertFileUpdate(vec![i])).await.unwrap();

--- a/examples/split/client/Cargo.toml
+++ b/examples/split/client/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "client"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+anyhow = "1"
+futures = "0.3.25"
+quic-rpc = { path = "../../.." }
+quinn = "0.9.0"
+rustls = { version = "0.20.7", features = ["dangerous_configuration"] }
+serde = { version = "1", features = ["derive"] }
+tokio = { version = "1", features = ["full"] }
+types = { path = "../types" }

--- a/examples/split/client/src/main.rs
+++ b/examples/split/client/src/main.rs
@@ -1,0 +1,85 @@
+use futures::sink::SinkExt;
+use futures::stream::StreamExt;
+use quic_rpc::{quinn::QuinnChannelTypes, RpcClient};
+use quinn::{ClientConfig, Endpoint};
+use std::net::SocketAddr;
+use std::sync::Arc;
+use types::store::*;
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    let server_addr: SocketAddr = "127.0.0.1:12345".parse()?;
+    let endpoint = make_insecure_client_endpoint("0.0.0.0:0".parse()?)?;
+    let client = endpoint.connect(server_addr, "localhost")?.await?;
+    let client = quic_rpc::quinn::Channel::new(client);
+    let mut client = RpcClient::<StoreService, QuinnChannelTypes>::new(client);
+
+    // a rpc call
+    for i in 0..3 {
+        println!("a rpc call [{i}]");
+        let client = client.clone();
+        tokio::task::spawn(async move {
+            let res = client.rpc(Get([0u8; 32])).await;
+            println!("rpc res [{i}]: {:?}", res);
+        });
+    }
+
+    // server streaming call
+    println!("a server streaming call");
+    let mut s = client.server_streaming(GetFile([0u8; 32])).await?;
+    while let Some(res) = s.next().await {
+        println!("streaming res: {:?}", res);
+    }
+
+    // client streaming call
+    println!("a client streaming call");
+    let (mut send, recv) = client.client_streaming(PutFile).await?;
+    tokio::task::spawn(async move {
+        for i in 0..3 {
+            send.send(PutFileUpdate(vec![i])).await.unwrap();
+        }
+    });
+    let res = recv.await?;
+    println!("client stremaing res: {:?}", res);
+
+    // bidi streaming call
+    println!("a bidi streaming call");
+    let (mut send, mut recv) = client.bidi(ConvertFile).await?;
+    tokio::task::spawn(async move {
+        for i in 0..3 {
+            send.send(ConvertFileUpdate(vec![i])).await.unwrap();
+        }
+    });
+    while let Some(res) = recv.next().await {
+        println!("bidi res: {:?}", res);
+    }
+
+    Ok(())
+}
+
+pub fn make_insecure_client_endpoint(bind_addr: SocketAddr) -> anyhow::Result<Endpoint> {
+    let crypto = rustls::ClientConfig::builder()
+        .with_safe_defaults()
+        .with_custom_certificate_verifier(Arc::new(SkipServerVerification))
+        .with_no_client_auth();
+
+    let client_cfg = ClientConfig::new(Arc::new(crypto));
+    let mut endpoint = Endpoint::client(bind_addr)?;
+    endpoint.set_default_client_config(client_cfg);
+    Ok(endpoint)
+}
+
+struct SkipServerVerification;
+impl rustls::client::ServerCertVerifier for SkipServerVerification {
+    fn verify_server_cert(
+        &self,
+        _end_entity: &rustls::Certificate,
+        _intermediates: &[rustls::Certificate],
+        _server_name: &rustls::ServerName,
+        _scts: &mut dyn Iterator<Item = &[u8]>,
+        _ocsp_response: &[u8],
+        _now: std::time::SystemTime,
+    ) -> Result<rustls::client::ServerCertVerified, rustls::Error> {
+        Ok(rustls::client::ServerCertVerified::assertion())
+    }
+}

--- a/examples/split/client/src/main.rs
+++ b/examples/split/client/src/main.rs
@@ -6,34 +6,37 @@ use std::net::SocketAddr;
 use std::sync::Arc;
 use types::store::*;
 
+types::create_store_client!(StoreClient);
+
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     let server_addr: SocketAddr = "127.0.0.1:12345".parse()?;
     let endpoint = make_insecure_client_endpoint("0.0.0.0:0".parse()?)?;
     let client = endpoint.connect(server_addr, "localhost")?.await?;
     let client = quic_rpc::quinn::Channel::new(client);
-    let mut client = RpcClient::<StoreService, QuinnChannelTypes>::new(client);
+    let client = RpcClient::<StoreService, QuinnChannelTypes>::new(client);
+    let mut client = StoreClient(client);
 
     // a rpc call
     for i in 0..3 {
         println!("a rpc call [{i}]");
-        let client = client.clone();
+        let mut client = client.clone();
         tokio::task::spawn(async move {
-            let res = client.rpc(Get([0u8; 32])).await;
+            let res = client.get(Get([0u8; 32])).await;
             println!("rpc res [{i}]: {:?}", res);
         });
     }
 
     // server streaming call
     println!("a server streaming call");
-    let mut s = client.server_streaming(GetFile([0u8; 32])).await?;
+    let mut s = client.get_file(GetFile([0u8; 32])).await?;
     while let Some(res) = s.next().await {
         println!("streaming res: {:?}", res);
     }
 
     // client streaming call
     println!("a client streaming call");
-    let (mut send, recv) = client.client_streaming(PutFile).await?;
+    let (mut send, recv) = client.put_file(PutFile).await?;
     tokio::task::spawn(async move {
         for i in 0..3 {
             send.send(PutFileUpdate(vec![i])).await.unwrap();
@@ -44,7 +47,7 @@ async fn main() -> anyhow::Result<()> {
 
     // bidi streaming call
     println!("a bidi streaming call");
-    let (mut send, mut recv) = client.bidi(ConvertFile).await?;
+    let (mut send, mut recv) = client.convert_file(ConvertFile).await?;
     tokio::task::spawn(async move {
         for i in 0..3 {
             send.send(ConvertFileUpdate(vec![i])).await.unwrap();

--- a/examples/split/server/Cargo.toml
+++ b/examples/split/server/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "server"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+anyhow = "1"
+async-stream = "0.3.3"
+futures = "0.3.25"
+quic-rpc = { path = "../../.." }
+quinn = "0.9.0"
+rcgen = "0.10.0"
+rustls = "0.20.7"
+serde = { version = "1", features = ["derive"] }
+tokio = { version = "1", features = ["full"] }
+types = { path = "../types" }

--- a/examples/split/server/src/main.rs
+++ b/examples/split/server/src/main.rs
@@ -1,0 +1,94 @@
+use anyhow::Context;
+use async_stream::stream;
+use futures::stream::{Stream, StreamExt};
+use quic_rpc::{quinn::QuinnChannelTypes, server::spawn_server};
+use quinn::{Endpoint, ServerConfig};
+use std::net::SocketAddr;
+use std::sync::Arc;
+
+use types::store::*;
+
+#[derive(Clone)]
+pub struct Store;
+
+types::create_store_dispatch!(Store, dispatch_store_request);
+
+impl Store {
+    async fn put(self, _put: Put) -> PutResponse {
+        PutResponse([0; 32])
+    }
+
+    async fn get(self, _get: Get) -> GetResponse {
+        GetResponse(vec![])
+    }
+
+    async fn put_file(
+        self,
+        _put: PutFile,
+        updates: impl Stream<Item = PutFileUpdate>,
+    ) -> PutFileResponse {
+        tokio::pin!(updates);
+        while let Some(_update) = updates.next().await {}
+        PutFileResponse([0; 32])
+    }
+
+    fn get_file(self, _get: GetFile) -> impl Stream<Item = GetFileResponse> + Send + 'static {
+        stream! {
+            for i in 0..3 {
+                yield GetFileResponse(vec![i]);
+            }
+        }
+    }
+
+    fn convert_file(
+        self,
+        _convert: ConvertFile,
+        updates: impl Stream<Item = ConvertFileUpdate> + Send + 'static,
+    ) -> impl Stream<Item = ConvertFileResponse> + Send + 'static {
+        stream! {
+            tokio::pin!(updates);
+            while let Some(msg) = updates.next().await {
+                yield ConvertFileResponse(msg.0);
+            }
+        }
+    }
+}
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    let server_addr: SocketAddr = "127.0.0.1:12345".parse()?;
+    let (server, _server_certs) = make_server_endpoint(server_addr)?;
+    let target = Store;
+    let accept = server.accept().await.context("accept failed")?.await?;
+    let connection = quic_rpc::quinn::Channel::new(accept);
+    let server_handle = spawn_server(
+        StoreService,
+        QuinnChannelTypes,
+        connection,
+        target,
+        dispatch_store_request,
+    );
+    server_handle.await??;
+    Ok(())
+}
+
+fn make_server_endpoint(bind_addr: SocketAddr) -> anyhow::Result<(Endpoint, Vec<u8>)> {
+    let (server_config, server_cert) = configure_server()?;
+    let endpoint = Endpoint::server(server_config, bind_addr)?;
+    Ok((endpoint, server_cert))
+}
+
+fn configure_server() -> anyhow::Result<(ServerConfig, Vec<u8>)> {
+    let cert = rcgen::generate_simple_self_signed(vec!["localhost".into()])?;
+    let cert_der = cert.serialize_der()?;
+    let priv_key = cert.serialize_private_key_der();
+    let priv_key = rustls::PrivateKey(priv_key);
+    let cert_chain = vec![rustls::Certificate(cert_der.clone())];
+
+    let mut server_config = ServerConfig::with_single_cert(cert_chain, priv_key)?;
+    Arc::get_mut(&mut server_config.transport)
+        .unwrap()
+        .max_concurrent_uni_streams(0_u8.into());
+
+    Ok((server_config, cert_der))
+}

--- a/examples/split/types/Cargo.toml
+++ b/examples/split/types/Cargo.toml
@@ -7,5 +7,6 @@ edition = "2021"
 
 [dependencies]
 derive_more = "0.99.17"
+futures = "0.3.25"
 quic-rpc = { path = "../../.." }
 serde = { version = "1", features = ["derive"] }

--- a/examples/split/types/Cargo.toml
+++ b/examples/split/types/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "types"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+derive_more = "0.99.17"
+quic-rpc = { path = "../../.." }
+serde = { version = "1", features = ["derive"] }

--- a/examples/split/types/src/lib.rs
+++ b/examples/split/types/src/lib.rs
@@ -1,0 +1,49 @@
+pub mod store {
+    use quic_rpc::derive_rpc_service;
+    use serde::{Deserialize, Serialize};
+    use std::fmt::Debug;
+
+    pub type Cid = [u8; 32];
+
+    #[derive(Debug, Serialize, Deserialize)]
+    pub struct Put(pub Vec<u8>);
+    #[derive(Debug, Serialize, Deserialize)]
+    pub struct PutResponse(pub Cid);
+
+    #[derive(Debug, Serialize, Deserialize)]
+    pub struct Get(pub Cid);
+    #[derive(Debug, Serialize, Deserialize)]
+    pub struct GetResponse(pub Vec<u8>);
+
+    #[derive(Debug, Serialize, Deserialize)]
+    pub struct PutFile;
+    #[derive(Debug, Serialize, Deserialize)]
+    pub struct PutFileUpdate(pub Vec<u8>);
+    #[derive(Debug, Serialize, Deserialize)]
+    pub struct PutFileResponse(pub Cid);
+
+    #[derive(Debug, Serialize, Deserialize)]
+    pub struct GetFile(pub Cid);
+    #[derive(Debug, Serialize, Deserialize)]
+    pub struct GetFileResponse(pub Vec<u8>);
+
+    #[derive(Debug, Serialize, Deserialize)]
+    pub struct ConvertFile;
+    #[derive(Debug, Serialize, Deserialize)]
+    pub struct ConvertFileUpdate(pub Vec<u8>);
+    #[derive(Debug, Serialize, Deserialize)]
+    pub struct ConvertFileResponse(pub Vec<u8>);
+
+    derive_rpc_service! {
+        Request = StoreRequest;
+        Response = StoreResponse;
+        Service = StoreService;
+        CreateDispatch = create_store_dispatch;
+
+        Rpc put = Put, _ -> PutResponse;
+        Rpc get = Get, _ -> GetResponse;
+        ClientStreaming put_file = PutFile, PutFileUpdate -> PutFileResponse;
+        ServerStreaming get_file = GetFile, _ -> GetFileResponse;
+        BidiStreaming convert_file = ConvertFile, ConvertFileUpdate -> ConvertFileResponse;
+    }
+}

--- a/examples/split/types/src/lib.rs
+++ b/examples/split/types/src/lib.rs
@@ -39,6 +39,7 @@ pub mod store {
         Response = StoreResponse;
         Service = StoreService;
         CreateDispatch = create_store_dispatch;
+        CreateClient = create_store_client;
 
         Rpc put = Put, _ -> PutResponse;
         Rpc get = Get, _ -> GetResponse;

--- a/examples/split/types/src/lib.rs
+++ b/examples/split/types/src/lib.rs
@@ -1,5 +1,5 @@
 pub mod store {
-    use quic_rpc::derive_rpc_service;
+    use quic_rpc::rpc_service;
     use serde::{Deserialize, Serialize};
     use std::fmt::Debug;
 
@@ -34,7 +34,7 @@ pub mod store {
     #[derive(Debug, Serialize, Deserialize)]
     pub struct ConvertFileResponse(pub Vec<u8>);
 
-    derive_rpc_service! {
+    rpc_service! {
         Request = StoreRequest;
         Response = StoreResponse;
         Service = StoreService;

--- a/examples/split/types/src/lib.rs
+++ b/examples/split/types/src/lib.rs
@@ -1,50 +1,46 @@
-pub mod store {
+pub mod compute {
     use quic_rpc::rpc_service;
     use serde::{Deserialize, Serialize};
     use std::fmt::Debug;
 
-    pub type Cid = [u8; 32];
+    /// compute the square of a number
+    #[derive(Debug, Serialize, Deserialize)]
+    pub struct Sqr(pub u64);
+    #[derive(Debug, Serialize, Deserialize, PartialEq, Eq)]
+    pub struct SqrResponse(pub u128);
 
+    /// sum a stream of numbers
     #[derive(Debug, Serialize, Deserialize)]
-    pub struct Put(pub Vec<u8>);
+    pub struct Sum;
     #[derive(Debug, Serialize, Deserialize)]
-    pub struct PutResponse(pub Cid);
+    pub struct SumUpdate(pub u64);
+    #[derive(Debug, Serialize, Deserialize, PartialEq, Eq)]
+    pub struct SumResponse(pub u128);
 
+    /// compute the fibonacci sequence as a stream
     #[derive(Debug, Serialize, Deserialize)]
-    pub struct Get(pub Cid);
+    pub struct Fibonacci(pub u64);
     #[derive(Debug, Serialize, Deserialize)]
-    pub struct GetResponse(pub Vec<u8>);
+    pub struct FibonacciResponse(pub u128);
 
+    /// multiply a stream of numbers, returning a stream
     #[derive(Debug, Serialize, Deserialize)]
-    pub struct PutFile;
+    pub struct Multiply(pub u64);
     #[derive(Debug, Serialize, Deserialize)]
-    pub struct PutFileUpdate(pub Vec<u8>);
+    pub struct MultiplyUpdate(pub u64);
     #[derive(Debug, Serialize, Deserialize)]
-    pub struct PutFileResponse(pub Cid);
-
-    #[derive(Debug, Serialize, Deserialize)]
-    pub struct GetFile(pub Cid);
-    #[derive(Debug, Serialize, Deserialize)]
-    pub struct GetFileResponse(pub Vec<u8>);
-
-    #[derive(Debug, Serialize, Deserialize)]
-    pub struct ConvertFile;
-    #[derive(Debug, Serialize, Deserialize)]
-    pub struct ConvertFileUpdate(pub Vec<u8>);
-    #[derive(Debug, Serialize, Deserialize)]
-    pub struct ConvertFileResponse(pub Vec<u8>);
+    pub struct MultiplyResponse(pub u128);
 
     rpc_service! {
-        Request = StoreRequest;
-        Response = StoreResponse;
-        Service = StoreService;
-        CreateDispatch = create_store_dispatch;
-        CreateClient = create_store_client;
+        Request = ComputeRequest;
+        Response = ComputeResponse;
+        Service = ComputeService;
+        CreateDispatch = create_compute_dispatch;
+        CreateClient = create_compute_client;
 
-        Rpc put = Put, _ -> PutResponse;
-        Rpc get = Get, _ -> GetResponse;
-        ClientStreaming put_file = PutFile, PutFileUpdate -> PutFileResponse;
-        ServerStreaming get_file = GetFile, _ -> GetFileResponse;
-        BidiStreaming convert_file = ConvertFile, ConvertFileUpdate -> ConvertFileResponse;
+        Rpc square = Sqr, _ -> SqrResponse;
+        ClientStreaming sum = Sum, SumUpdate -> SumResponse;
+        ServerStreaming fibonacci = Fibonacci, _ -> FibonacciResponse;
+        BidiStreaming multiply = Multiply, MultiplyUpdate -> MultiplyResponse;
     }
 }

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -3,6 +3,56 @@
 /// Derive a set of RPC types and message implementation from a declaration.
 ///
 /// See [./examples/macro.rs](examples/macro.rs) for an example.
+///
+/// Use as follows:
+/// ```no_run
+/// derive_rpc_service! {
+///     Request = MyRequest;
+///     Response = MyResponse;
+///     Service = MyService;
+///     CreateDispatch = create_my_dispatch;
+///     CreateClient = create_my_client;
+///
+///     Rpc add = Add, _ = Sum
+///     ClientStreaming stream = Input, Update = Output
+/// }
+/// ```
+///
+/// This will generate a request enum `MyRequest`, a response enum `MyRespone`
+/// and a service declaration `MyService`.
+///
+/// It will also generate two macros to create an RPC client and a dispatch function.
+///
+/// To use the client, invoke the macro with a name. The macro will generate a struct that
+/// takes a client channel and exposes typesafe methods for each RPC method.
+///
+/// ```no_run
+/// create_store_client!(MyClient);
+/// let client = quic_rpc::quinn::Channel::new(client);
+/// let client = quic_rpc::client::RpcClient::<MyService, QuinnChannelTypes>::new(client);
+/// let mut client = MyClient(client);
+/// let sum = client.add(Add(3, 4)).await?;
+/// ```
+///
+/// To use the dispatch function, invoke the macro with a struct that implements your RPC
+/// methods and the name of the generated function. You can then use this dispatch function
+/// to dispatch the RPC calls to the methods on your target struct.
+/// See [./examples/macro.rs](examples/macro.rs) for a full example.
+///
+/// The generation of these macros is optional. If you don't need them, pass `_` instead:
+/// ```no_run
+/// derive_rpc_service! {
+///     Request = MyRequest;
+///     Response = MyResponse;
+///     Service = MyService;
+///     CreateDispatch = _;
+///     CreateClient = _;
+///
+///     Rpc add = Add, _ = Sum
+///     ClientStreaming stream = Input, Update = Output
+/// }
+/// ```
+/// `
 #[macro_export]
 macro_rules! derive_rpc_service {
     (

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -260,48 +260,59 @@ macro_rules! __derive_create_client{
 #[macro_export]
 macro_rules! __rpc_method {
     (Rpc, $service:ident, $m_name:ident, $m_input:ident, $m_output:ident, _) => {
-        pub async fn $m_name(&mut self, input: $m_input) -> ::std::result::Result<$m_output, $crate::client::RpcClientError<C>> {
+        pub async fn $m_name(
+            &mut self,
+            input: $m_input,
+        ) -> ::std::result::Result<$m_output, $crate::client::RpcClientError<C>> {
             self.0.rpc(input).await
         }
     };
     (ClientStreaming, $service:ident, $m_name:ident, $m_input:ident, $m_output:ident, $m_update:ident) => {
         pub async fn $m_name(
             &mut self,
-            input: $m_input
-    ) -> ::std::result::Result<
-        (
-            $crate::client::UpdateSink<$service, C, $m_input>,
-            ::futures::future::BoxFuture<'static, ::std::result::Result<$m_output, $crate::client::ClientStreamingItemError<C>>>,
-        ),
-        $crate::client::ClientStreamingError<C>
-    > {
+            input: $m_input,
+        ) -> ::std::result::Result<
+            (
+                $crate::client::UpdateSink<$service, C, $m_input>,
+                ::futures::future::BoxFuture<
+                    'static,
+                    ::std::result::Result<$m_output, $crate::client::ClientStreamingItemError<C>>,
+                >,
+            ),
+            $crate::client::ClientStreamingError<C>,
+        > {
             self.0.client_streaming(input).await
         }
     };
     (ServerStreaming, $service:ident, $m_name:ident, $m_input:ident, $m_output:ident, _) => {
         pub async fn $m_name(
             &mut self,
-            input: $m_input
-    ) -> ::std::result::Result<
-        ::futures::stream::BoxStream<'static, ::std::result::Result<$m_output, $crate::client::StreamingResponseItemError<C>>>,
-        $crate::client::StreamingResponseError<C>
-    > {
+            input: $m_input,
+        ) -> ::std::result::Result<
+            ::futures::stream::BoxStream<
+                'static,
+                ::std::result::Result<$m_output, $crate::client::StreamingResponseItemError<C>>,
+            >,
+            $crate::client::StreamingResponseError<C>,
+        > {
             self.0.server_streaming(input).await
         }
     };
     (BidiStreaming, $service:ident, $m_name:ident, $m_input:ident, $m_output:ident, $m_update:ident) => {
         pub async fn $m_name(
             &mut self,
-            input: $m_input
-    ) -> ::std::result::Result<
-        (
-            $crate::client::UpdateSink<$service, C, $m_input>,
-            ::futures::stream::BoxStream<'static, ::std::result::Result<$m_output, $crate::client::BidiItemError<C>>>,
-        ),
-        $crate::client::BidiError<C>
-    > {
+            input: $m_input,
+        ) -> ::std::result::Result<
+            (
+                $crate::client::UpdateSink<$service, C, $m_input>,
+                ::futures::stream::BoxStream<
+                    'static,
+                    ::std::result::Result<$m_output, $crate::client::BidiItemError<C>>,
+                >,
+            ),
+            $crate::client::BidiError<C>,
+        > {
             self.0.bidi(input).await
         }
-     };
- }
-
+    };
+}

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -29,7 +29,7 @@
 ///
 /// // Derive the RPC types.
 ///
-/// derive_rpc_service! {
+/// rpc_service! {
 ///     // Name of the created request enum.
 ///     Request = MyRequest;
 ///     // Name of the created response enum.
@@ -121,7 +121,7 @@
 ///
 /// ```ignore
 /// # use quic_rpc::*;
-/// derive_rpc_service! {
+/// rpc_service! {
 ///     Request = MyRequest;
 ///     Response = MyResponse;
 ///     Service = MyService;
@@ -134,7 +134,7 @@
 /// ```
 /// `
 #[macro_export]
-macro_rules! derive_rpc_service {
+macro_rules! rpc_service {
     (
         Request = $request:ident;
         Response = $response:ident;
@@ -203,7 +203,7 @@ macro_rules! __derive_create_dispatch {
         $create_dispatch:ident,
         [ $($m_pattern:ident $m_name:ident = $m_input:ident, $m_update:tt -> $m_output:ident);+ ]
     ) => {
-        #[doc = concat!("Create an RPC request dispatch function for ", stringify!($service), "\n\nSee the docs for [quic_rpc::derive_rpc_service] for usage docs.")]
+        #[doc = concat!("Create an RPC request dispatch function for ", stringify!($service), "\n\nSee the docs for [quic_rpc::rpc_service] for usage docs.")]
         #[macro_export]
         macro_rules! $create_dispatch {
             ($target:ident, $handler:ident) => {
@@ -316,7 +316,7 @@ macro_rules! __derive_create_client{
         $create_client:tt,
         [ $($m_pattern:ident $m_name:ident = $m_input:ident, $m_update:tt -> $m_output:ident);+ ]
     ) => {
-        #[doc = concat!("Create an RPC client for ", stringify!($service), "\n\nSee the docs for [quic_rpc::derive_rpc_service] for usage docs.")]
+        #[doc = concat!("Create an RPC client for ", stringify!($service), "\n\nSee the docs for [quic_rpc::rpc_service] for usage docs.")]
         #[macro_export]
         macro_rules! $create_client {
             ($struct:ident) => {

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -320,7 +320,7 @@ macro_rules! __derive_create_client{
         #[macro_export]
         macro_rules! $create_client {
             ($struct:ident) => {
-                #[derive(::std::clone::Clone)]
+                #[derive(::std::clone::Clone, ::std::fmt::Debug)]
                 pub struct $struct<C: $crate::ChannelTypes>(pub $crate::client::RpcClient<$service, C>);
 
                 impl<C: $crate::ChannelTypes> $struct<C> {

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -3,16 +3,19 @@
 /// Derive a set of RPC types and message implementation from a declaration.
 ///
 /// The macros are completely optional. They generate the request and response
-/// message enums, the service zerosized struct.
+/// message enums and the service zerosized struct.
 /// Optionally, a function can be created to dispatch RPC calls to methods
 /// on a struct of your choice.
-/// Finally, it can also create a type-safe RPC client for the service.
+/// It can also create a type-safe RPC client for the service.
 ///
 /// Usage is as follows:
 ///
 /// ```no_run
 /// # use serde::{Serialize,Deserialize};
 /// # use quic_rpc::*;
+///
+/// // Define your message types
+///
 /// #[derive(Debug, Serialize, Deserialize)]
 /// struct Add(pub i32, pub i32);
 /// #[derive(Debug, Serialize, Deserialize)]
@@ -23,6 +26,8 @@
 /// pub struct MultiplyUpdate(pub i32);
 /// #[derive(Debug, Serialize, Deserialize)]
 /// pub struct MultiplyOutput(pub i32);
+///
+/// // Derive the RPC types.
 ///
 /// derive_rpc_service! {
 ///     // Name of the created request enum.
@@ -52,7 +57,6 @@
 /// takes a client channel and exposes typesafe methods for each RPC method.
 ///
 /// ```ignore
-/// # use quic_rpc::{*, quin::*, client::*};
 /// create_store_client!(MyClient);
 /// let client = quic_rpc::quinn::Channel::new(client);
 /// let client = quic_rpc::client::RpcClient::<MyService, QuinnChannelTypes>::new(client);
@@ -70,8 +74,6 @@
 /// to dispatch the RPC calls to the methods on your target struct.
 ///
 /// ```ignore
-/// # use futures::stream::{Stream, StreamExt};
-/// # use async_stream::stream;
 /// #[derive(Clone)]
 /// pub struct Calculator;
 /// impl Calculator {

--- a/src/server.rs
+++ b/src/server.rs
@@ -315,7 +315,7 @@ async fn race2<T, A: Future<Output = T>, B: Future<Output = T>>(f1: A, f2: B) ->
 /// Spawn a server loop, invoking a handler callback for each request.
 ///
 /// Requests will be handled sequentially.
-pub async fn spawn_server<S, C, T, F, Fut>(
+pub fn spawn_server<S, C, T, F, Fut>(
     _service_type: S,
     _channel_type: C,
     conn: C::Channel<S::Req, S::Res>,

--- a/src/server.rs
+++ b/src/server.rs
@@ -8,7 +8,6 @@ use crate::{
 use futures::{channel::oneshot, task, task::Poll, Future, FutureExt, SinkExt, Stream, StreamExt};
 use pin_project::pin_project;
 use std::{error, fmt, fmt::Debug, marker::PhantomData, pin::Pin, result};
-use tokio::task::JoinHandle;
 
 /// A server channel for a specific service
 ///
@@ -312,16 +311,16 @@ async fn race2<T, A: Future<Output = T>, B: Future<Output = T>>(f1: A, f2: B) ->
     }
 }
 
-/// Spawn a server loop, invoking a handler callback for each request.
+/// Run a server loop, invoking a handler callback for each request.
 ///
 /// Requests will be handled sequentially.
-pub fn spawn_server<S, C, T, F, Fut>(
+pub async fn run_server_loop<S, C, T, F, Fut>(
     _service_type: S,
     _channel_type: C,
     conn: C::Channel<S::Req, S::Res>,
     target: T,
     mut handler: F,
-) -> JoinHandle<Result<(), RpcServerError<C>>>
+) -> Result<(), RpcServerError<C>>
 where
     S: Service,
     C: ChannelTypes,
@@ -332,13 +331,9 @@ where
     Fut: Future<Output = Result<RpcServer<S, C>, RpcServerError<C>>> + Send + 'static,
 {
     let mut server = RpcServer::<S, C>::new(conn);
-    tokio::task::spawn({
-        async move {
-            loop {
-                let (req, chan) = server.accept_one().await?;
-                let target = target.clone();
-                server = handler(server, req, chan, target).await?;
-            }
-        }
-    })
+    loop {
+        let (req, chan) = server.accept_one().await?;
+        let target = target.clone();
+        server = handler(server, req, chan, target).await?;
+    }
 }


### PR DESCRIPTION
It is often useful to have the RPC types in a seperate crate, so that a client-only usage does not have to import the server implemenation.

This makes this possible while keeping the macros to reduce boilerplate.

The generation of the dispatch function is made optional, and moved into a *generated macro*. This allows to only create the dispatch function in the *server* part, while the *client* part only uses the generated types.

The macro example is updated accordingly. A new *split* example demonstrates the full client-server usage flow over quic.