### PR TITLE
feat(http2): Shut down the hyper server on drop.

### DIFF
--- a/src/transport/http2.rs
+++ b/src/transport/http2.rs
@@ -138,7 +138,7 @@ pub struct ServerChannel<In: RpcMessage, Out: RpcMessage> {
 
 impl<In: RpcMessage, Out: RpcMessage> ServerChannel<In, Out> {
     /// Creates a server listening on the [`SocketAddr`].
-    pub fn new(addr: &SocketAddr) -> hyper::Result<Self> {
+    pub fn serve(addr: &SocketAddr) -> hyper::Result<Self> {
         let (accept_tx, accept_rx) = flume::bounded(32);
 
         // The hyper "MakeService" which is called for each connection that is made to the

--- a/tests/http2.rs
+++ b/tests/http2.rs
@@ -10,7 +10,7 @@ use math::*;
 mod util;
 
 fn run_server(addr: &SocketAddr) -> JoinHandle<anyhow::Result<()>> {
-    let channel = http2::ServerChannel::<ComputeRequest, ComputeResponse>::new(addr).unwrap();
+    let channel = http2::ServerChannel::<ComputeRequest, ComputeResponse>::serve(addr).unwrap();
     let server = RpcServer::<ComputeService, http2::ChannelTypes>::new(channel);
     tokio::spawn(async move {
         loop {

--- a/tests/http2.rs
+++ b/tests/http2.rs
@@ -10,10 +10,8 @@ use math::*;
 mod util;
 
 fn run_server(addr: &SocketAddr) -> JoinHandle<anyhow::Result<()>> {
-    let (channel, hyper) =
-        http2::ServerChannel::<ComputeRequest, ComputeResponse>::new(addr).unwrap();
+    let channel = http2::ServerChannel::<ComputeRequest, ComputeResponse>::new(addr).unwrap();
     let server = RpcServer::<ComputeService, http2::ChannelTypes>::new(channel);
-    tokio::spawn(hyper);
     tokio::spawn(async move {
         loop {
             let server = server.clone();


### PR DESCRIPTION
This will terminate the hyper server when the ServerChannel is
dropped.  Previously it kept running in a task.

Closes #14 