### PR TITLE
feat: Expose local address of ServerChannel

### DIFF
--- a/examples/split/server/src/main.rs
+++ b/examples/split/server/src/main.rs
@@ -61,12 +61,13 @@ impl Compute {
 async fn main() -> anyhow::Result<()> {
     let server_addr: SocketAddr = "127.0.0.1:12345".parse()?;
     let (server, _server_certs) = make_server_endpoint(server_addr)?;
+    let local_addr = server.local_addr()?;
     loop {
         let accept = server.accept().await.context("accept failed")?.await?;
         tokio::task::spawn(async move {
             let remote = accept.remote_address();
             eprintln!("new connection from {remote}");
-            let connection = quic_rpc::transport::quinn::ServerChannel::new(accept);
+            let connection = quic_rpc::transport::quinn::ServerChannel::new(accept, local_addr);
             let target = Compute;
             match run_server_loop(
                 ComputeService,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -173,6 +173,7 @@ pub trait ServerChannel<In: RpcMessage, Out: RpcMessage, T: ChannelTypes>:
 ///
 /// Returned by [`ServerChannel::local_addr`].
 #[derive(Debug, Clone)]
+#[non_exhaustive]
 pub enum LocalAddr {
     /// A local socket.
     Socket(SocketAddr),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -59,7 +59,7 @@
 use futures::{Future, Sink, Stream};
 use serde::{de::DeserializeOwned, Serialize};
 use std::{
-    fmt::{Debug, Display},
+    fmt::{self, Debug, Display},
     net::SocketAddr,
     result,
 };
@@ -172,6 +172,8 @@ pub trait ServerChannel<In: RpcMessage, Out: RpcMessage, T: ChannelTypes>:
 /// The kinds of local addresses a [`ServerChannel`] can be bound to.
 ///
 /// Returned by [`ServerChannel::local_addr`].
+///
+/// [`Display`]: fmt::Display
 #[derive(Debug, Clone)]
 #[non_exhaustive]
 pub enum LocalAddr {
@@ -179,4 +181,13 @@ pub enum LocalAddr {
     Socket(SocketAddr),
     /// An in-memory address.
     Mem,
+}
+
+impl Display for LocalAddr {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            LocalAddr::Socket(sockaddr) => write!(f, "{sockaddr}"),
+            LocalAddr::Mem => write!(f, "mem"),
+        }
+    }
 }

--- a/src/transport/combined.rs
+++ b/src/transport/combined.rs
@@ -79,14 +79,6 @@ impl<A: CT, B: CT, In: RpcMessage, Out: RpcMessage> ServerChannel<A, B, In, Out>
         }
         Self { a, b, local_addr }
     }
-
-    /// Returns the local addresses this server is bound to.
-    ///
-    /// This is useful when the listen address uses a random port, `:0`, to find out which
-    /// port was bound by the kernel.
-    pub fn local_addrs(&self) -> &[LocalAddr] {
-        todo!()
-    }
 }
 
 impl<A: CT, B: CT, In: RpcMessage, Out: RpcMessage> Clone for ServerChannel<A, B, In, Out> {

--- a/src/transport/combined.rs
+++ b/src/transport/combined.rs
@@ -1,5 +1,5 @@
 //! Channel that combines two other channels
-use crate::{ChannelTypes as CT, RpcMessage};
+use crate::{ChannelTypes as CT, LocalAddr, RpcMessage, ServerChannel as ServerChannelTrait};
 use futures::{
     future::{self, BoxFuture},
     FutureExt, Sink, Stream, TryFutureExt,
@@ -34,7 +34,6 @@ impl<A: CT, B: CT, In: RpcMessage, Out: RpcMessage> ClientChannel<A, B, In, Out>
         Self { a, b }
     }
 }
-
 impl<A: CT, B: CT, In: RpcMessage, Out: RpcMessage> Clone for ClientChannel<A, B, In, Out> {
     fn clone(&self) -> Self {
         Self {
@@ -57,6 +56,7 @@ impl<A: CT, B: CT, In: RpcMessage, Out: RpcMessage> Debug for ClientChannel<A, B
 pub struct ServerChannel<A: CT, B: CT, In: RpcMessage, Out: RpcMessage> {
     a: Option<A::ServerChannel<In, Out>>,
     b: Option<B::ServerChannel<In, Out>>,
+    local_addr: Vec<LocalAddr>,
 }
 
 impl<A: CT, B: CT, In: RpcMessage, Out: RpcMessage> ServerChannel<A, B, In, Out> {
@@ -70,7 +70,22 @@ impl<A: CT, B: CT, In: RpcMessage, Out: RpcMessage> ServerChannel<A, B, In, Out>
     /// be listened on, and the first to receive a connection will be used. If no channels are
     /// configured, accept_bi will wait forever.
     pub fn new(a: Option<A::ServerChannel<In, Out>>, b: Option<B::ServerChannel<In, Out>>) -> Self {
-        Self { a, b }
+        let mut local_addr = Vec::new();
+        if let Some(ref a) = a {
+            local_addr.extend_from_slice(a.local_addr());
+        }
+        if let Some(ref b) = b {
+            local_addr.extend_from_slice(b.local_addr());
+        }
+        Self { a, b, local_addr }
+    }
+
+    /// Returns the local addresses this server is bound to.
+    ///
+    /// This is useful when the listen address uses a random port, `:0`, to find out which
+    /// port was bound by the kernel.
+    pub fn local_addrs(&self) -> &[LocalAddr] {
+        todo!()
     }
 }
 
@@ -79,6 +94,7 @@ impl<A: CT, B: CT, In: RpcMessage, Out: RpcMessage> Clone for ServerChannel<A, B
         Self {
             a: self.a.clone(),
             b: self.b.clone(),
+            local_addr: self.local_addr.clone(),
         }
     }
 }
@@ -286,6 +302,10 @@ impl<A: CT, B: CT, In: RpcMessage, Out: RpcMessage>
 impl<A: CT, B: CT, In: RpcMessage, Out: RpcMessage>
     crate::ServerChannel<In, Out, ChannelTypes<A, B>> for ServerChannel<A, B, In, Out>
 {
+    fn local_addr(&self) -> &[crate::LocalAddr] {
+        &self.local_addr
+    }
+
     fn accept_bi(&self) -> AcceptBiFuture<'_, A, B, In, Out> {
         let a_fut = if let Some(a) = &self.a {
             a.accept_bi()

--- a/src/transport/http2.rs
+++ b/src/transport/http2.rs
@@ -176,7 +176,7 @@ pub struct ServerChannel<In: RpcMessage, Out: RpcMessage> {
     ///
     /// This is useful when the listen address uses a random port, `:0`, to find out which
     /// port was bound by the kernel.
-    local_addr: Vec<LocalAddr>,
+    local_addr: [LocalAddr; 1],
 }
 
 impl<In: RpcMessage, Out: RpcMessage> ServerChannel<In, Out> {
@@ -227,7 +227,7 @@ impl<In: RpcMessage, Out: RpcMessage> ServerChannel<In, Out> {
         Ok(Self {
             channel: accept_rx,
             stop_tx,
-            local_addr: vec![LocalAddr::Socket(local_addr)],
+            local_addr: [LocalAddr::Socket(local_addr)],
         })
     }
 

--- a/src/transport/mem.rs
+++ b/src/transport/mem.rs
@@ -54,14 +54,12 @@ pub(crate) type Socket<In, Out> = (self::SendSink<Out>, self::RecvStream<In>);
 /// A mem channel
 pub struct ServerChannel<In: RpcMessage, Out: RpcMessage> {
     stream: flume::Receiver<Socket<In, Out>>,
-    local_addr: Vec<LocalAddr>,
 }
 
 impl<In: RpcMessage, Out: RpcMessage> Clone for ServerChannel<In, Out> {
     fn clone(&self) -> Self {
         Self {
             stream: self.stream.clone(),
-            local_addr: self.local_addr.clone(),
         }
     }
 }
@@ -304,7 +302,7 @@ impl<In: RpcMessage, Out: RpcMessage> crate::ServerChannel<In, Out, ChannelTypes
     }
 
     fn local_addr(&self) -> &[crate::LocalAddr] {
-        &self.local_addr
+        &[LocalAddr::Mem]
     }
 }
 
@@ -315,11 +313,5 @@ pub fn connection<Req: RpcMessage, Res: RpcMessage>(
     buffer: usize,
 ) -> (ServerChannel<Req, Res>, ClientChannel<Res, Req>) {
     let (sink, stream) = flume::bounded::<Socket<Req, Res>>(buffer);
-    (
-        ServerChannel {
-            stream,
-            local_addr: vec![LocalAddr::Mem],
-        },
-        ClientChannel { sink },
-    )
+    (ServerChannel { stream }, ClientChannel { sink })
 }

--- a/src/transport/quinn.rs
+++ b/src/transport/quinn.rs
@@ -14,7 +14,7 @@ type Socket<In, Out> = (SendSink<Out>, RecvStream<In>);
 #[derive(Debug)]
 pub struct ServerChannel<In: RpcMessage, Out: RpcMessage> {
     connection: quinn::Connection,
-    local_addr: Vec<LocalAddr>,
+    local_addr: [LocalAddr; 1],
     _phantom: PhantomData<(In, Out)>,
 }
 
@@ -23,7 +23,7 @@ impl<In: RpcMessage, Out: RpcMessage> ServerChannel<In, Out> {
     pub fn new(conn: quinn::Connection, local_addr: SocketAddr) -> Self {
         Self {
             connection: conn,
-            local_addr: vec![LocalAddr::Socket(local_addr)],
+            local_addr: [LocalAddr::Socket(local_addr)],
             _phantom: PhantomData,
         }
     }

--- a/tests/quinn.rs
+++ b/tests/quinn.rs
@@ -94,9 +94,9 @@ pub fn make_endpoints() -> anyhow::Result<Endpoints> {
 
 fn run_server(server: quinn::Endpoint) -> JoinHandle<anyhow::Result<()>> {
     tokio::task::spawn(async move {
-        let connection = quic_rpc::transport::quinn::ServerChannel::new(
-            server.accept().await.context("accept failed")?.await?,
-        );
+        let local_addr = server.local_addr()?;
+        let conn = server.accept().await.context("accept failed")?.await?;
+        let connection = quic_rpc::transport::quinn::ServerChannel::new(conn, local_addr);
         let server = RpcServer::<ComputeService, QuinnChannelTypes>::new(connection);
         ComputeService::server(server).await?;
         anyhow::Ok(())


### PR DESCRIPTION
This adds the ability to expose the local address the ServerChannel is bound to.  This allows binding to wildcard ports and still knowing which address is used.