### PR TITLE
test(http2): add mem channel test

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -603,6 +603,7 @@ dependencies = [
  "tokio",
  "tokio-serde",
  "tokio-util",
+ "tower",
  "tracing",
 ]
 
@@ -1048,6 +1049,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "tower"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8fa9be0de6cf49e536ce1851f987bd21a43b771b09473c3549a6c853db37c1c"
+dependencies = [
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tower-layer"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c20c8dbed6283a09604c3e69b4b7eeb54e298b8a600d4d5ecb5ad39de609f1d0"
+
+[[package]]
 name = "tower-service"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1060,6 +1078,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ce8c33a8d48bd45d624a6e523445fd21ec13d3653cd51f681abf67418f54eb8"
 dependencies = [
  "cfg-if",
+ "log",
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,7 @@ quinn = "0.9.0"
 rcgen = "0.10.0"
 rustls = "0.20.7"
 thousands = "0.2.0"
+tower = "0.4.13"
 
 [features]
 http2 = ["hyper", "bincode", "bytes"]

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -17,7 +17,7 @@
 /// // Define your message types
 ///
 /// #[derive(Debug, Serialize, Deserialize)]
-/// struct Add(pub i32, pub i32);
+/// pub struct Add(pub i32, pub i32);
 /// #[derive(Debug, Serialize, Deserialize)]
 /// pub struct Sum(pub i32);
 /// #[derive(Debug, Serialize, Deserialize)]

--- a/src/transport/http2.rs
+++ b/src/transport/http2.rs
@@ -62,11 +62,10 @@ impl<In: RpcMessage, Out: RpcMessage> ClientChannel<In, Out> {
     }
 
     /// create a client given an uri and a custom configuration
-    pub fn new_with_connector<C: Connect + Clone + Send + Sync + 'static>(
-        connector: C,
-        uri: Uri,
-        config: Arc<ChannelConfig>,
-    ) -> Self {
+    pub fn new_with_connector<C>(connector: C, uri: Uri, config: Arc<ChannelConfig>) -> Self
+    where
+        C: Connect + Clone + Send + Sync + 'static,
+    {
         let client = Client::builder()
             .http2_only(true)
             .http2_initial_connection_window_size(Some(config.max_frame_size))


### PR DESCRIPTION
This also serves as an example how to use the fully custom constructors for http2 server and client, like you would do for the UDS transport.

We could now change all tests to mem tests, but I think it is nice that they do use a real tcp channel, so I will leave them alone.