### PR TITLE
ref: Rename main structs not conflict with trait names

### DIFF
--- a/examples/errors.rs
+++ b/examples/errors.rs
@@ -1,5 +1,5 @@
 use derive_more::{Display, From, TryInto};
-use quic_rpc::{message::RpcMsg, transport::mem::ChannelTypes, RpcClient, RpcServer, Service};
+use quic_rpc::{message::RpcMsg, transport::mem::MemChannelTypes, RpcClient, RpcServer, Service};
 use serde::{Deserialize, Serialize};
 use std::result;
 
@@ -56,8 +56,8 @@ impl Fs {
 async fn main() -> anyhow::Result<()> {
     let fs = Fs;
     let (server, client) = quic_rpc::transport::mem::connection(1);
-    let client = RpcClient::<IoService, ChannelTypes>::new(client);
-    let server = RpcServer::<IoService, ChannelTypes>::new(server);
+    let client = RpcClient::<IoService, MemChannelTypes>::new(client);
+    let server = RpcServer::<IoService, MemChannelTypes>::new(server);
     let handle = tokio::task::spawn(async move {
         for _ in 0..1 {
             let (req, chan) = server.accept_one().await?;

--- a/examples/macro.rs
+++ b/examples/macro.rs
@@ -53,7 +53,7 @@ use async_stream::stream;
 use futures::{SinkExt, Stream, StreamExt};
 use quic_rpc::client::RpcClient;
 use quic_rpc::server::run_server_loop;
-use quic_rpc::transport::mem::{self, ChannelTypes};
+use quic_rpc::transport::mem::{self, MemChannelTypes};
 use store_rpc::*;
 
 #[derive(Clone)]
@@ -110,14 +110,14 @@ async fn main() -> anyhow::Result<()> {
         let target = Store;
         run_server_loop(
             StoreService,
-            ChannelTypes,
+            MemChannelTypes,
             server,
             target,
             dispatch_store_request,
         )
         .await
     });
-    let client = RpcClient::<StoreService, ChannelTypes>::new(client);
+    let client = RpcClient::<StoreService, MemChannelTypes>::new(client);
     let mut client = StoreClient(client);
 
     // a rpc call

--- a/examples/split/client/src/main.rs
+++ b/examples/split/client/src/main.rs
@@ -14,7 +14,7 @@ async fn main() -> anyhow::Result<()> {
     let server_addr: SocketAddr = "127.0.0.1:12345".parse()?;
     let endpoint = make_insecure_client_endpoint("0.0.0.0:0".parse()?)?;
     let client = endpoint.connect(server_addr, "localhost")?.await?;
-    let client = quic_rpc::transport::quinn::ClientChannel::new(client);
+    let client = quic_rpc::transport::quinn::QuinnClientChannel::new(client);
     let client = RpcClient::<ComputeService, QuinnChannelTypes>::new(client);
     let mut client = ComputeClient(client);
 

--- a/examples/split/server/src/main.rs
+++ b/examples/split/server/src/main.rs
@@ -67,7 +67,8 @@ async fn main() -> anyhow::Result<()> {
         tokio::task::spawn(async move {
             let remote = accept.remote_address();
             eprintln!("new connection from {remote}");
-            let connection = quic_rpc::transport::quinn::ServerChannel::new(accept, local_addr);
+            let connection =
+                quic_rpc::transport::quinn::QuinnServerChannel::new(accept, local_addr);
             let target = Compute;
             match run_server_loop(
                 ComputeService,

--- a/examples/store.rs
+++ b/examples/store.rs
@@ -6,7 +6,7 @@ use message::RpcMsg;
 use quic_rpc::{
     message::{BidiStreaming, ClientStreaming, Msg, ServerStreaming},
     server::RpcServerError,
-    transport::mem::{self, ChannelTypes},
+    transport::mem::{self, MemChannelTypes},
     ClientChannel, *,
 };
 use serde::{Deserialize, Serialize};
@@ -179,8 +179,8 @@ impl Store {
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     async fn server_future(
-        server: RpcServer<StoreService, ChannelTypes>,
-    ) -> result::Result<(), RpcServerError<ChannelTypes>> {
+        server: RpcServer<StoreService, MemChannelTypes>,
+    ) -> result::Result<(), RpcServerError<MemChannelTypes>> {
         let s = server;
         let store = Store;
         loop {
@@ -201,8 +201,8 @@ async fn main() -> anyhow::Result<()> {
     }
 
     let (server, client) = mem::connection::<StoreRequest, StoreResponse>(1);
-    let client = RpcClient::<StoreService, ChannelTypes>::new(client);
-    let server = RpcServer::<StoreService, ChannelTypes>::new(server);
+    let client = RpcClient::<StoreService, MemChannelTypes>::new(client);
+    let server = RpcServer::<StoreService, MemChannelTypes>::new(server);
     let server_handle = tokio::task::spawn(server_future(server));
 
     // a rpc call

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -158,7 +158,11 @@ pub trait ClientChannel<In: RpcMessage, Out: RpcMessage, T: ChannelTypes>:
 pub trait ServerChannel<In: RpcMessage, Out: RpcMessage, T: ChannelTypes>:
     Debug + Clone + Send + Sync + 'static
 {
-    /// Accept a bidirectional stream
+    /// Accepts a bidirectional stream.
+    ///
+    /// This returns a future who's `Output` is a tuple of a sender sink and receiver stream
+    /// to send and receive messages to and from the client respectively.  The sink and
+    /// stream `Item`s are the whole `In` and `Out` messages, an [`RpcMessage`].
     fn accept_bi(&self) -> T::AcceptBiFuture<'_, In, Out>;
 
     /// The local addresses this server is bound to.

--- a/src/transport/mod.rs
+++ b/src/transport/mod.rs
@@ -10,11 +10,11 @@ pub mod quinn;
 
 #[cfg(feature = "quic")]
 /// Alias for quinn channel types
-pub use self::quinn::ChannelTypes as QuinnChannelTypes;
+pub use self::quinn::QuinnChannelTypes;
 /// Alias for combined channel types
-pub use combined::ChannelTypes as CombinedChannelTypes;
+pub use combined::CombinedChannelTypes;
 #[cfg(feature = "http2")]
 /// Alias for http2 channel types
-pub use http2::ChannelTypes as Http2ChannelTypes;
+pub use http2::Http2ChannelTypes;
 /// Alias for mem channel types
-pub use mem::ChannelTypes as MemChannelTypes;
+pub use mem::MemChannelTypes;

--- a/tests/mem.rs
+++ b/tests/mem.rs
@@ -4,10 +4,10 @@ use quic_rpc::{server::RpcServerError, transport::mem, RpcClient, RpcServer};
 
 #[tokio::test]
 async fn mem_channel_bench() -> anyhow::Result<()> {
-    type C = mem::ChannelTypes;
+    type C = mem::MemChannelTypes;
     let (server, client) = mem::connection::<ComputeRequest, ComputeResponse>(1);
 
-    let server = RpcServer::<ComputeService, mem::ChannelTypes>::new(server);
+    let server = RpcServer::<ComputeService, mem::MemChannelTypes>::new(server);
     let server_handle = tokio::task::spawn(ComputeService::server(server));
     let client = RpcClient::<ComputeService, C>::new(client);
     bench(client, 1000000).await?;
@@ -24,9 +24,9 @@ async fn mem_channel_bench() -> anyhow::Result<()> {
 async fn mem_channel_smoke() -> anyhow::Result<()> {
     let (server, client) = mem::connection::<ComputeRequest, ComputeResponse>(1);
 
-    let server = RpcServer::<ComputeService, mem::ChannelTypes>::new(server);
+    let server = RpcServer::<ComputeService, mem::MemChannelTypes>::new(server);
     let server_handle = tokio::task::spawn(ComputeService::server(server));
-    smoke_test::<mem::ChannelTypes>(client).await?;
+    smoke_test::<mem::MemChannelTypes>(client).await?;
 
     // dropping the client will cause the server to terminate
     match server_handle.await? {

--- a/tests/quinn.rs
+++ b/tests/quinn.rs
@@ -96,7 +96,7 @@ fn run_server(server: quinn::Endpoint) -> JoinHandle<anyhow::Result<()>> {
     tokio::task::spawn(async move {
         let local_addr = server.local_addr()?;
         let conn = server.accept().await.context("accept failed")?.await?;
-        let connection = quic_rpc::transport::quinn::ServerChannel::new(conn, local_addr);
+        let connection = quic_rpc::transport::quinn::QuinnServerChannel::new(conn, local_addr);
         let server = RpcServer::<ComputeService, QuinnChannelTypes>::new(connection);
         ComputeService::server(server).await?;
         anyhow::Ok(())
@@ -113,7 +113,7 @@ async fn quinn_channel_bench() -> anyhow::Result<()> {
     } = make_endpoints()?;
     let server_handle = run_server(server);
     let client = client.connect(server_addr, "localhost")?.await?;
-    let client = quic_rpc::transport::quinn::ClientChannel::new(client);
+    let client = quic_rpc::transport::quinn::QuinnClientChannel::new(client);
     let client = RpcClient::<ComputeService, C>::new(client);
     bench(client, 50000).await?;
     println!("waiting for server");
@@ -132,7 +132,7 @@ async fn quinn_channel_smoke() -> anyhow::Result<()> {
     } = make_endpoints()?;
     let server_handle = run_server(server);
     let client_connection = client.connect(server_addr, "localhost")?.await?;
-    let client_connection = quic_rpc::transport::quinn::ClientChannel::new(client_connection);
+    let client_connection = quic_rpc::transport::quinn::QuinnClientChannel::new(client_connection);
     smoke_test::<C>(client_connection).await?;
     check_termination_anyhow::<C>(server_handle).await?;
     Ok(())


### PR DESCRIPTION
This is certainly opinionated, and I will only be a little sad if we
don't decide to do this.  It changes the names of the ServerChannel
and ClientChannel to include the type.  Crucially the types now have
different names than the traits they implement.

This was already done at the
transport mod.rs for ChannelTypes, kind of showing this is generally
not bad.  It is also how I've seen most Rust code.

It is a bit more verbose for writing, but this does help (me) a lot
while reading the code, which is what counts.