### PR TITLE
refactor: get rid of the lifetimes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,7 @@ hyper-transport = ["flume", "hyper", "bincode", "bytes"]
 quinn-transport = ["flume", "quinn", "bincode", "tokio-serde", "tokio-util"]
 flume-transport = ["flume"]
 combined-transport = []
-default = ["quinn-transport", "flume-transport", "hyper-transport"]
+default = ["quinn-transport", "combined-transport", "flume-transport", "hyper-transport"]
 
 [workspace]
 members = ["examples/split/types", "examples/split/server", "examples/split/client"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,7 @@ hyper-transport = ["flume", "hyper", "bincode", "bytes"]
 quinn-transport = ["flume", "quinn", "bincode", "tokio-serde", "tokio-util"]
 flume-transport = ["flume"]
 combined-transport = []
-default = ["quinn-transport", "combined-transport", "flume-transport", "hyper-transport"]
+default = ["quinn-transport", "flume-transport", "hyper-transport"]
 
 [workspace]
 members = ["examples/split/types", "examples/split/server", "examples/split/client"]

--- a/src/transport/combined.rs
+++ b/src/transport/combined.rs
@@ -1,9 +1,9 @@
 //! Transport that combines two other transports
-use super::{Connection, ConnectionErrors, LocalAddr, ServerEndpoint};
+use super::{Connection, ConnectionCommon, ConnectionErrors, LocalAddr, ServerEndpoint};
 use crate::RpcMessage;
 use futures::{
     future::{self, BoxFuture},
-    FutureExt, Sink, Stream, TryFutureExt, TryStream,
+    FutureExt, Sink, Stream, TryFutureExt,
 };
 use pin_project::pin_project;
 use std::{
@@ -55,7 +55,7 @@ impl<A: Debug, B: Debug, In: RpcMessage, Out: RpcMessage> Debug
     for CombinedConnection<A, B, In, Out>
 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("Connection")
+        f.debug_struct("CombinedConnection")
             .field("a", &self.a)
             .field("b", &self.b)
             .finish()
@@ -122,7 +122,7 @@ impl<A: Debug, B: Debug, In: RpcMessage, Out: RpcMessage> Debug
     for CombinedServerEndpoint<A, B, In, Out>
 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("Channel")
+        f.debug_struct("CombinedServerEndpoint")
             .field("a", &self.a)
             .field("b", &self.b)
             .finish()
@@ -131,15 +131,24 @@ impl<A: Debug, B: Debug, In: RpcMessage, Out: RpcMessage> Debug
 
 /// Send sink for combined channels
 #[pin_project(project = SendSinkProj)]
-pub enum SendSink<A: Connection<In, Out>, B: Connection<In, Out>, In: RpcMessage, Out: RpcMessage> {
+pub enum SendSink<
+    A: ConnectionCommon<In, Out>,
+    B: ConnectionCommon<In, Out>,
+    In: RpcMessage,
+    Out: RpcMessage,
+> {
     /// A variant
     A(#[pin] A::SendSink),
     /// B variant
     B(#[pin] B::SendSink),
 }
 
-impl<A: Connection<In, Out>, B: Connection<In, Out>, In: RpcMessage, Out: RpcMessage> Sink<Out>
-    for SendSink<A, B, In, Out>
+impl<
+        A: ConnectionCommon<In, Out>,
+        B: ConnectionCommon<In, Out>,
+        In: RpcMessage,
+        Out: RpcMessage,
+    > Sink<Out> for SendSink<A, B, In, Out>
 {
     type Error = self::SendError<A, B>;
 
@@ -174,23 +183,31 @@ impl<A: Connection<In, Out>, B: Connection<In, Out>, In: RpcMessage, Out: RpcMes
 
 /// RecvStream for combined channels
 #[pin_project(project = ResStreamProj)]
-pub enum RecvStream<A, B> {
+pub enum RecvStream<
+    A: ConnectionCommon<In, Out>,
+    B: ConnectionCommon<In, Out>,
+    In: RpcMessage,
+    Out: RpcMessage,
+> {
     /// A variant
-    A(#[pin] A),
+    A(#[pin] A::RecvStream),
     /// B variant
-    B(#[pin] B),
+    B(#[pin] B::RecvStream),
 }
 
-impl<T, E, A: TryStream<Item = T>, B: TryStream<Item = T>> Stream for RecvStream<A, B>
-where
-    E: From<A::Error> + From<B::Error>,
+impl<
+        A: ConnectionCommon<In, Out>,
+        B: ConnectionCommon<In, Out>,
+        In: RpcMessage,
+        Out: RpcMessage,
+    > Stream for RecvStream<A, B, In, Out>
 {
-    type Item = Result<T, E>;
+    type Item = Result<In, RecvError<A, B>>;
 
     fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
         match self.project() {
-            ResStreamProj::A(stream) => stream.poll_next(cx).map_err(E::from),
-            ResStreamProj::B(stream) => stream.poll_next(cx).map_err(E::from),
+            ResStreamProj::A(stream) => stream.poll_next(cx).map_err(RecvError::<A, B>::A),
+            ResStreamProj::B(stream) => stream.poll_next(cx).map_err(RecvError::<A, B>::B),
         }
     }
 }
@@ -266,8 +283,8 @@ impl<A: ConnectionErrors, B: ConnectionErrors> fmt::Display for AcceptBiError<A,
 impl<A: ConnectionErrors, B: ConnectionErrors> error::Error for AcceptBiError<A, B> {}
 
 /// Future returned by open_bi
-pub type OpenBiFuture<'a, A, B, In, Out> =
-    BoxFuture<'a, result::Result<Socket<A, B, In, Out>, self::OpenBiError<A, B>>>;
+pub type OpenBiFuture<A, B, In, Out> =
+    BoxFuture<'static, result::Result<Socket<A, B, In, Out>, self::OpenBiError<A, B>>>;
 
 /// Future returned by accept_bi
 pub type AcceptBiFuture<A, B, In, Out> =
@@ -287,15 +304,23 @@ impl<A: ConnectionErrors, B: ConnectionErrors, In: RpcMessage, Out: RpcMessage> 
 }
 
 impl<A: Connection<In, Out>, B: Connection<In, Out>, In: RpcMessage, Out: RpcMessage>
+    ConnectionCommon<In, Out> for CombinedConnection<A, B, In, Out>
+{
+    type RecvStream = self::RecvStream<A, B, In, Out>;
+    type SendSink = self::SendSink<A, B, In, Out>;
+}
+
+impl<A: Connection<In, Out>, B: Connection<In, Out>, In: RpcMessage, Out: RpcMessage>
     Connection<In, Out> for CombinedConnection<A, B, In, Out>
 {
-    fn open_bi(&self) -> OpenBiFuture<'_, A, B, In, Out> {
+    fn open_bi(&self) -> OpenBiFuture<A, B, In, Out> {
+        let this = self.clone();
         async {
             // try a first, then b
-            if let Some(a) = &self.a {
+            if let Some(a) = this.a {
                 let (send, recv) = a.open_bi().await.map_err(OpenBiError::A)?;
                 Ok((SendSink::A(send), RecvStream::A(recv)))
-            } else if let Some(b) = &self.b {
+            } else if let Some(b) = this.b {
                 let (send, recv) = b.open_bi().await.map_err(OpenBiError::B)?;
                 Ok((SendSink::B(send), RecvStream::B(recv)))
             } else {
@@ -305,11 +330,7 @@ impl<A: Connection<In, Out>, B: Connection<In, Out>, In: RpcMessage, Out: RpcMes
         .boxed()
     }
 
-    type RecvStream = self::RecvStream<A, B, In, Out>;
-
-    type SendSink = self::SendSink<A, B, In, Out>;
-
-    type OpenBiFut<'a> = OpenBiFuture<'a, A, B, In, Out>;
+    type OpenBiFut = OpenBiFuture<A, B, In, Out>;
 }
 
 impl<A: ConnectionErrors, B: ConnectionErrors, In: RpcMessage, Out: RpcMessage> ConnectionErrors
@@ -321,11 +342,18 @@ impl<A: ConnectionErrors, B: ConnectionErrors, In: RpcMessage, Out: RpcMessage> 
 }
 
 impl<A: ServerEndpoint<In, Out>, B: ServerEndpoint<In, Out>, In: RpcMessage, Out: RpcMessage>
+    ConnectionCommon<In, Out> for CombinedServerEndpoint<A, B, In, Out>
+{
+    type RecvStream = self::RecvStream<A, B, In, Out>;
+    type SendSink = self::SendSink<A, B, In, Out>;
+}
+
+impl<A: ServerEndpoint<In, Out>, B: ServerEndpoint<In, Out>, In: RpcMessage, Out: RpcMessage>
     ServerEndpoint<In, Out> for CombinedServerEndpoint<A, B, In, Out>
 {
     fn accept_bi(&self) -> AcceptBiFuture<A, B, In, Out> {
         let a_fut = if let Some(a) = &self.a {
-            a.open_bi()
+            a.accept_bi()
                 .map_ok(|(send, recv)| {
                     (
                         SendSink::<A, B, In, Out>::A(send),
@@ -338,7 +366,7 @@ impl<A: ServerEndpoint<In, Out>, B: ServerEndpoint<In, Out>, In: RpcMessage, Out
             future::pending().right_future()
         };
         let b_fut = if let Some(b) = &self.b {
-            b.open_bi()
+            b.accept_bi()
                 .map_ok(|(send, recv)| {
                     (
                         SendSink::<A, B, In, Out>::B(send),
@@ -358,10 +386,6 @@ impl<A: ServerEndpoint<In, Out>, B: ServerEndpoint<In, Out>, In: RpcMessage, Out
         }
         .boxed()
     }
-
-    type RecvStream = self::RecvStream<A, B, In, Out>;
-
-    type SendSink = self::SendSink<A, B, In, Out>;
 
     type AcceptBiFut = AcceptBiFuture<A, B, In, Out>;
 

--- a/src/transport/flume.rs
+++ b/src/transport/flume.rs
@@ -127,19 +127,19 @@ impl<In: RpcMessage, Out: RpcMessage> ConnectionErrors for FlumeServerEndpoint<I
 type Socket<In, Out> = (self::SendSink<Out>, self::RecvStream<In>);
 
 /// Future returned by [FlumeConnection::open_bi]
-pub struct OpenBiFuture<'a, In: RpcMessage, Out: RpcMessage> {
-    inner: flume::r#async::SendFut<'a, Socket<Out, In>>,
+pub struct OpenBiFuture<In: RpcMessage, Out: RpcMessage> {
+    inner: flume::r#async::SendFut<'static, Socket<Out, In>>,
     res: Option<Socket<In, Out>>,
 }
 
-impl<'a, In: RpcMessage, Out: RpcMessage> fmt::Debug for OpenBiFuture<'a, In, Out> {
+impl<In: RpcMessage, Out: RpcMessage> fmt::Debug for OpenBiFuture<In, Out> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("OpenBiFuture").finish()
     }
 }
 
-impl<'a, In: RpcMessage, Out: RpcMessage> OpenBiFuture<'a, In, Out> {
-    fn new(inner: flume::r#async::SendFut<'a, Socket<Out, In>>, res: Socket<In, Out>) -> Self {
+impl<In: RpcMessage, Out: RpcMessage> OpenBiFuture<In, Out> {
+    fn new(inner: flume::r#async::SendFut<'static, Socket<Out, In>>, res: Socket<In, Out>) -> Self {
         Self {
             inner,
             res: Some(res),
@@ -147,7 +147,7 @@ impl<'a, In: RpcMessage, Out: RpcMessage> OpenBiFuture<'a, In, Out> {
     }
 }
 
-impl<'a, In: RpcMessage, Out: RpcMessage> Future for OpenBiFuture<'a, In, Out> {
+impl<In: RpcMessage, Out: RpcMessage> Future for OpenBiFuture<In, Out> {
     type Output = result::Result<Socket<In, Out>, self::OpenBiError>;
 
     fn poll(
@@ -167,18 +167,18 @@ impl<'a, In: RpcMessage, Out: RpcMessage> Future for OpenBiFuture<'a, In, Out> {
 }
 
 /// Future returned by [FlumeServerEndpoint::accept_bi]
-pub struct AcceptBiFuture<'a, In: RpcMessage, Out: RpcMessage> {
-    wrapped: flume::r#async::RecvFut<'a, (SendSink<Out>, RecvStream<In>)>,
+pub struct AcceptBiFuture<In: RpcMessage, Out: RpcMessage> {
+    wrapped: flume::r#async::RecvFut<'static, (SendSink<Out>, RecvStream<In>)>,
     _p: PhantomData<(In, Out)>,
 }
 
-impl<'a, In: RpcMessage, Out: RpcMessage> fmt::Debug for AcceptBiFuture<'a, In, Out> {
+impl<In: RpcMessage, Out: RpcMessage> fmt::Debug for AcceptBiFuture<In, Out> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("AcceptBiFuture").finish()
     }
 }
 
-impl<'a, In: RpcMessage, Out: RpcMessage> Future for AcceptBiFuture<'a, In, Out> {
+impl<In: RpcMessage, Out: RpcMessage> Future for AcceptBiFuture<In, Out> {
     type Output = result::Result<(SendSink<Out>, RecvStream<In>), AcceptBiError>;
 
     fn poll(mut self: Pin<&mut Self>, cx: &mut std::task::Context<'_>) -> Poll<Self::Output> {
@@ -194,11 +194,11 @@ impl<In: RpcMessage, Out: RpcMessage> ServerEndpoint<In, Out> for FlumeServerEnd
     type SendSink = SendSink<Out>;
     type RecvStream = RecvStream<In>;
 
-    type AcceptBiFut<'a> = AcceptBiFuture<'a, In, Out>;
+    type AcceptBiFut = AcceptBiFuture<In, Out>;
 
-    fn accept_bi(&self) -> Self::AcceptBiFut<'_> {
+    fn accept_bi(&self) -> Self::AcceptBiFut {
         AcceptBiFuture {
-            wrapped: self.stream.recv_async(),
+            wrapped: self.stream.clone().into_recv_async(),
             _p: PhantomData,
         }
     }
@@ -220,9 +220,9 @@ impl<In: RpcMessage, Out: RpcMessage> Connection<In, Out> for FlumeConnection<In
     type SendSink = SendSink<Out>;
     type RecvStream = RecvStream<In>;
 
-    type OpenBiFut<'a> = OpenBiFuture<'a, In, Out>;
+    type OpenBiFut = OpenBiFuture<In, Out>;
 
-    fn open_bi(&self) -> Self::OpenBiFut<'_> {
+    fn open_bi(&self) -> Self::OpenBiFut {
         let (local_send, remote_recv) = flume::bounded::<Out>(128);
         let (remote_send, local_recv) = flume::bounded::<In>(128);
         let remote_chan = (
@@ -233,7 +233,7 @@ impl<In: RpcMessage, Out: RpcMessage> Connection<In, Out> for FlumeConnection<In
             SendSink(local_send.into_sink()),
             RecvStream(local_recv.into_stream()),
         );
-        OpenBiFuture::new(self.sink.send_async(remote_chan), local_chan)
+        OpenBiFuture::new(self.sink.clone().into_send_async(remote_chan), local_chan)
     }
 }
 

--- a/src/transport/flume.rs
+++ b/src/transport/flume.rs
@@ -9,6 +9,8 @@ use core::fmt;
 use futures::{Future, FutureExt, Sink, SinkExt, Stream, StreamExt};
 use std::{error, fmt::Display, marker::PhantomData, pin::Pin, result, task::Poll};
 
+use super::ConnectionCommon;
+
 /// Error when receiving from a channel
 ///
 /// This type has zero inhabitants, so it is always safe to unwrap a result with this error type.
@@ -190,10 +192,12 @@ impl<In: RpcMessage, Out: RpcMessage> Future for AcceptBiFuture<In, Out> {
     }
 }
 
-impl<In: RpcMessage, Out: RpcMessage> ServerEndpoint<In, Out> for FlumeServerEndpoint<In, Out> {
+impl<In: RpcMessage, Out: RpcMessage> ConnectionCommon<In, Out> for FlumeServerEndpoint<In, Out> {
     type SendSink = SendSink<Out>;
     type RecvStream = RecvStream<In>;
+}
 
+impl<In: RpcMessage, Out: RpcMessage> ServerEndpoint<In, Out> for FlumeServerEndpoint<In, Out> {
     type AcceptBiFut = AcceptBiFuture<In, Out>;
 
     fn accept_bi(&self) -> Self::AcceptBiFut {
@@ -216,10 +220,12 @@ impl<In: RpcMessage, Out: RpcMessage> ConnectionErrors for FlumeConnection<In, O
     type OpenError = self::OpenBiError;
 }
 
-impl<In: RpcMessage, Out: RpcMessage> Connection<In, Out> for FlumeConnection<In, Out> {
+impl<In: RpcMessage, Out: RpcMessage> ConnectionCommon<In, Out> for FlumeConnection<In, Out> {
     type SendSink = SendSink<Out>;
     type RecvStream = RecvStream<In>;
+}
 
+impl<In: RpcMessage, Out: RpcMessage> Connection<In, Out> for FlumeConnection<In, Out> {
     type OpenBiFut = OpenBiFuture<In, Out>;
 
     fn open_bi(&self) -> Self::OpenBiFut {

--- a/src/transport/hyper.rs
+++ b/src/transport/hyper.rs
@@ -22,6 +22,8 @@ use tokio::sync::mpsc;
 use tokio::task::JoinHandle;
 use tracing::{debug, event, trace, Level};
 
+use super::ConnectionCommon;
+
 struct HyperConnectionInner {
     client: Box<dyn Requester>,
     config: Arc<ChannelConfig>,
@@ -762,11 +764,13 @@ impl<In: RpcMessage, Out: RpcMessage> ConnectionErrors for HyperConnection<In, O
     type OpenError = OpenBiError;
 }
 
-impl<In: RpcMessage, Out: RpcMessage> Connection<In, Out> for HyperConnection<In, Out> {
+impl<In: RpcMessage, Out: RpcMessage> ConnectionCommon<In, Out> for HyperConnection<In, Out> {
     type RecvStream = self::RecvStream<In>;
 
     type SendSink = self::SendSink<Out>;
+}
 
+impl<In: RpcMessage, Out: RpcMessage> Connection<In, Out> for HyperConnection<In, Out> {
     type OpenBiFut = OpenBiFuture<In, Out>;
 
     fn open_bi(&self) -> Self::OpenBiFut {
@@ -782,11 +786,12 @@ impl<In: RpcMessage, Out: RpcMessage> ConnectionErrors for HyperServerEndpoint<I
     type OpenError = AcceptBiError;
 }
 
-impl<In: RpcMessage, Out: RpcMessage> ServerEndpoint<In, Out> for HyperServerEndpoint<In, Out> {
+impl<In: RpcMessage, Out: RpcMessage> ConnectionCommon<In, Out> for HyperServerEndpoint<In, Out> {
     type RecvStream = self::RecvStream<In>;
-
     type SendSink = self::SendSink<Out>;
+}
 
+impl<In: RpcMessage, Out: RpcMessage> ServerEndpoint<In, Out> for HyperServerEndpoint<In, Out> {
     type AcceptBiFut = AcceptBiFuture<In, Out>;
 
     fn local_addr(&self) -> &[LocalAddr] {

--- a/src/transport/hyper.rs
+++ b/src/transport/hyper.rs
@@ -562,7 +562,7 @@ impl std::error::Error for OpenBiError {}
 /// Future returned by [open_bi](crate::transport::Connection::open_bi).
 #[allow(clippy::type_complexity)]
 #[pin_project]
-pub struct OpenBiFuture<'a, In, Out> {
+pub struct OpenBiFuture<In, Out> {
     chan: Option<
         Result<
             (
@@ -573,11 +573,11 @@ pub struct OpenBiFuture<'a, In, Out> {
             OpenBiError,
         >,
     >,
-    _p: PhantomData<&'a (In, Out)>,
+    _p: PhantomData<(In, Out)>,
 }
 
 #[allow(clippy::type_complexity)]
-impl<'a, In: RpcMessage, Out: RpcMessage> OpenBiFuture<'a, In, Out> {
+impl<In: RpcMessage, Out: RpcMessage> OpenBiFuture<In, Out> {
     fn new(
         value: Result<
             (
@@ -595,7 +595,7 @@ impl<'a, In: RpcMessage, Out: RpcMessage> OpenBiFuture<'a, In, Out> {
     }
 }
 
-impl<'a, In: RpcMessage, Out: RpcMessage> Future for OpenBiFuture<'a, In, Out> {
+impl<In: RpcMessage, Out: RpcMessage> Future for OpenBiFuture<In, Out> {
     type Output = result::Result<self::Socket<In, Out>, OpenBiError>;
 
     fn poll(
@@ -658,10 +658,10 @@ impl error::Error for AcceptBiError {}
 /// Future returned by [accept_bi](crate::transport::ServerEndpoint::accept_bi).
 #[allow(clippy::type_complexity)]
 #[pin_project]
-pub struct AcceptBiFuture<'a, In, Out> {
+pub struct AcceptBiFuture<In: RpcMessage, Out: RpcMessage> {
     chan: Option<(
         RecvFut<
-            'a,
+            'static,
             (
                 Receiver<result::Result<In, RecvError>>,
                 Sender<io::Result<Bytes>>,
@@ -672,11 +672,11 @@ pub struct AcceptBiFuture<'a, In, Out> {
     _p: PhantomData<(In, Out)>,
 }
 
-impl<'a, In: RpcMessage, Out: RpcMessage> AcceptBiFuture<'a, In, Out> {
+impl<In: RpcMessage, Out: RpcMessage> AcceptBiFuture<In, Out> {
     #[allow(clippy::type_complexity)]
     fn new(
         fut: RecvFut<
-            'a,
+            'static,
             (
                 Receiver<result::Result<In, RecvError>>,
                 Sender<io::Result<Bytes>>,
@@ -691,7 +691,7 @@ impl<'a, In: RpcMessage, Out: RpcMessage> AcceptBiFuture<'a, In, Out> {
     }
 }
 
-impl<'a, In: RpcMessage, Out: RpcMessage> Future for AcceptBiFuture<'a, In, Out> {
+impl<In: RpcMessage, Out: RpcMessage> Future for AcceptBiFuture<In, Out> {
     type Output = result::Result<self::Socket<In, Out>, AcceptBiError>;
 
     fn poll(
@@ -723,7 +723,7 @@ impl<'a, In: RpcMessage, Out: RpcMessage> Future for AcceptBiFuture<'a, In, Out>
     }
 }
 
-impl<'a, In, Out> FusedFuture for AcceptBiFuture<'a, In, Out>
+impl<In, Out> FusedFuture for AcceptBiFuture<In, Out>
 where
     In: RpcMessage,
     Out: RpcMessage,
@@ -737,7 +737,7 @@ where
 }
 
 impl<In: RpcMessage, Out: RpcMessage> HyperConnection<In, Out> {
-    fn open_bi(&self) -> OpenBiFuture<'_, In, Out> {
+    fn open_bi(&self) -> OpenBiFuture<In, Out> {
         event!(Level::TRACE, "open_bi {}", self.inner.uri);
         let (out_tx, out_rx) = flume::bounded::<io::Result<Bytes>>(32);
         let req: Result<Request<Body>, OpenBiError> = Request::post(&self.inner.uri)
@@ -767,9 +767,9 @@ impl<In: RpcMessage, Out: RpcMessage> Connection<In, Out> for HyperConnection<In
 
     type SendSink = self::SendSink<Out>;
 
-    type OpenBiFut<'a> = OpenBiFuture<'a, In, Out>;
+    type OpenBiFut = OpenBiFuture<In, Out>;
 
-    fn open_bi(&self) -> Self::OpenBiFut<'_> {
+    fn open_bi(&self) -> Self::OpenBiFut {
         self.open_bi()
     }
 }
@@ -787,13 +787,13 @@ impl<In: RpcMessage, Out: RpcMessage> ServerEndpoint<In, Out> for HyperServerEnd
 
     type SendSink = self::SendSink<Out>;
 
-    type AcceptBiFut<'a> = AcceptBiFuture<'a, In, Out>;
+    type AcceptBiFut = AcceptBiFuture<In, Out>;
 
     fn local_addr(&self) -> &[LocalAddr] {
         &self.local_addr
     }
 
-    fn accept_bi(&self) -> Self::AcceptBiFut<'_> {
-        AcceptBiFuture::new(self.channel.recv_async(), self.config.clone())
+    fn accept_bi(&self) -> Self::AcceptBiFut {
+        AcceptBiFuture::new(self.channel.clone().into_recv_async(), self.config.clone())
     }
 }

--- a/src/transport/misc/mod.rs
+++ b/src/transport/misc/mod.rs
@@ -25,10 +25,9 @@ impl<In: RpcMessage, Out: RpcMessage> ServerEndpoint<In, Out> for DummyServerEnd
 
     type SendSink = Box<dyn Sink<Out, Error = Self::SendError> + Unpin + Send>;
 
-    type AcceptBiFut<'a> =
-        future::Pending<Result<(Self::SendSink, Self::RecvStream), Self::OpenError>>;
+    type AcceptBiFut = future::Pending<Result<(Self::SendSink, Self::RecvStream), Self::OpenError>>;
 
-    fn accept_bi(&self) -> Self::AcceptBiFut<'_> {
+    fn accept_bi(&self) -> Self::AcceptBiFut {
         futures::future::pending()
     }
 

--- a/src/transport/misc/mod.rs
+++ b/src/transport/misc/mod.rs
@@ -7,6 +7,8 @@ use crate::{
 use futures::{future, stream, Sink};
 use std::convert::Infallible;
 
+use super::ConnectionCommon;
+
 /// A dummy server endpoint that does nothing
 ///
 /// This can be useful as a default if you want to configure
@@ -20,11 +22,12 @@ impl ConnectionErrors for DummyServerEndpoint {
     type SendError = Infallible;
 }
 
-impl<In: RpcMessage, Out: RpcMessage> ServerEndpoint<In, Out> for DummyServerEndpoint {
+impl<In: RpcMessage, Out: RpcMessage> ConnectionCommon<In, Out> for DummyServerEndpoint {
     type RecvStream = stream::Pending<Result<In, Self::RecvError>>;
-
     type SendSink = Box<dyn Sink<Out, Error = Self::SendError> + Unpin + Send>;
+}
 
+impl<In: RpcMessage, Out: RpcMessage> ServerEndpoint<In, Out> for DummyServerEndpoint {
     type AcceptBiFut = future::Pending<Result<(Self::SendSink, Self::RecvStream), Self::OpenError>>;
 
     fn accept_bi(&self) -> Self::AcceptBiFut {

--- a/src/transport/mod.rs
+++ b/src/transport/mod.rs
@@ -37,13 +37,10 @@ pub trait Connection<In, Out>: ConnectionErrors {
     /// Send side of a bidirectional typed channel
     type SendSink: Sink<Out, Error = Self::SendError> + Send + Unpin + 'static;
     /// The future that will resolve to a substream or an error
-    type OpenBiFut<'a>: Future<Output = Result<(Self::SendSink, Self::RecvStream), Self::OpenError>>
-        + Send
-        + 'a
-    where
-        Self: 'a;
+    type OpenBiFut: Future<Output = Result<(Self::SendSink, Self::RecvStream), Self::OpenError>>
+        + Send;
     /// Open a channel to the remote
-    fn open_bi(&self) -> Self::OpenBiFut<'_>;
+    fn open_bi(&self) -> Self::OpenBiFut;
 }
 
 /// A server endpoint that listens for connections
@@ -56,15 +53,12 @@ pub trait ServerEndpoint<In, Out>: ConnectionErrors {
     /// Send side of a bidirectional typed channel
     type SendSink: Sink<Out, Error = Self::SendError> + Send + Unpin + 'static;
     /// The future that will resolve to a substream or an error
-    type AcceptBiFut<'a>: Future<Output = Result<(Self::SendSink, Self::RecvStream), Self::OpenError>>
-        + Send
-        + 'a
-    where
-        Self: 'a;
+    type AcceptBiFut: Future<Output = Result<(Self::SendSink, Self::RecvStream), Self::OpenError>>
+        + Send;
 
     /// Accept a new typed bidirectional channel on any of the connections we
     /// have currently opened.
-    fn accept_bi(&self) -> Self::AcceptBiFut<'_>;
+    fn accept_bi(&self) -> Self::AcceptBiFut;
 
     /// The local addresses this endpoint is bound to.
     fn local_addr(&self) -> &[LocalAddr];

--- a/src/transport/quinn.rs
+++ b/src/transport/quinn.rs
@@ -13,7 +13,10 @@ use std::sync::Arc;
 use std::task::{Context, Poll};
 use std::{fmt, io, marker::PhantomData, pin::Pin, result};
 
-use super::util::{FramedBincodeRead, FramedBincodeWrite};
+use super::{
+    util::{FramedBincodeRead, FramedBincodeWrite},
+    ConnectionCommon,
+};
 
 type Socket<In, Out> = (SendSink<Out>, RecvStream<In>);
 
@@ -179,10 +182,12 @@ impl<In: RpcMessage, Out: RpcMessage> ConnectionErrors for QuinnServerEndpoint<I
     type OpenError = quinn::ConnectionError;
 }
 
-impl<In: RpcMessage, Out: RpcMessage> ServerEndpoint<In, Out> for QuinnServerEndpoint<In, Out> {
+impl<In: RpcMessage, Out: RpcMessage> ConnectionCommon<In, Out> for QuinnServerEndpoint<In, Out> {
     type RecvStream = self::RecvStream<In>;
     type SendSink = self::SendSink<Out>;
+}
 
+impl<In: RpcMessage, Out: RpcMessage> ServerEndpoint<In, Out> for QuinnServerEndpoint<In, Out> {
     type AcceptBiFut = AcceptBiFuture<In, Out>;
 
     fn accept_bi(&self) -> Self::AcceptBiFut {
@@ -336,9 +341,12 @@ impl<In: RpcMessage, Out: RpcMessage> ConnectionErrors for QuinnConnection<In, O
     type OpenError = quinn::ConnectionError;
 }
 
-impl<In: RpcMessage, Out: RpcMessage> Connection<In, Out> for QuinnConnection<In, Out> {
+impl<In: RpcMessage, Out: RpcMessage> ConnectionCommon<In, Out> for QuinnConnection<In, Out> {
     type SendSink = self::SendSink<Out>;
     type RecvStream = self::RecvStream<In>;
+}
+
+impl<In: RpcMessage, Out: RpcMessage> Connection<In, Out> for QuinnConnection<In, Out> {
     type OpenBiFut = OpenBiFuture<In, Out>;
 
     fn open_bi(&self) -> Self::OpenBiFut {


### PR DESCRIPTION
This makes things a bit less efficient, but for both flume and quinn cloning a channel is just cloning an arc, so the cost is limited.

The biggest downside is that this makes it slightly harder to implement new transports. But I think for s2n_quic we have to wrap in an arc anyway. So maybe 🤷‍♂️  ?

The main benefit of this is that we no longer need rust 1.65. 1.63 or even older works just fine.