### PR TITLE
chore(docs): enable all features for docs.rs builds

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,6 +56,9 @@ combined-transport = []
 macros = []
 default = []
 
+[package.metadata.docs.rs]
+all-features = true
+
 [[example]]
 name = "errors"
 required-features = ["flume-transport"]

--- a/tests/hyper.rs
+++ b/tests/hyper.rs
@@ -1,5 +1,5 @@
 #![cfg(feature = "hyper-transport")]
-use std::{net::SocketAddr, result};
+use std::{assert, net::SocketAddr, result};
 
 use ::hyper::Uri;
 use derive_more::{From, TryInto};
@@ -283,7 +283,7 @@ async fn hyper_channel_errors() -> anyhow::Result<()> {
 
     // response small - should succeed
     let res = client.rpc(BigResponseRequest(10_000_000)).await;
-    assert_matches!(res, Ok(_));
+    assert!(res.is_ok());
     assert_server_result!(Ok(()));
 
     // response big - should fail


### PR DESCRIPTION
This enables all features for doc.rs builds, this should make sure all
the optional features are documented.

Fixes #59