### PR TITLE
fix: nightly failures

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ futures = "0.3"
 hyper = { version = "0.14.16", features = ["full"], optional = true }
 pin-project = "1"
 quinn = { version = "0.10", optional = true }
-serde = { version = "1.0.103" }
+serde = { version = "1.0.183" }
 tokio = { version = "1", default-features = false, features = ["macros"] }
 tokio-serde = { version = "0.8", features = ["bincode"], optional = true }
 tokio-util = { version = "0.7", features = ["codec"], optional = true }
@@ -35,7 +35,7 @@ tracing = "0.1"
 version = "0.4.20"
 
 [dev-dependencies]
-anyhow = "1"
+anyhow = "1.0.73"
 async-stream = "0.3.3"
 derive_more = "0.99.17"
 serde = { version = "1", features = ["derive"] }

--- a/examples/store.rs
+++ b/examples/store.rs
@@ -5,7 +5,7 @@ use futures::{SinkExt, Stream, StreamExt};
 use quic_rpc::{
     server::RpcServerError,
     transport::{flume, Connection, ServerEndpoint},
-    Service, ServiceEndpoint, *,
+    *,
 };
 use serde::{Deserialize, Serialize};
 use std::{fmt::Debug, result};


### PR DESCRIPTION
Fixes `non_local_definitions` in nightly.
Note that this is not a clippy error but a compiler error.

I don't actually understand the complain from the compiler. Minimal examples creating an enumeration and adding a simple Display impl inside a test do not trigger the error. I wouldn't look _too much_ into it while false positives are being reported and fixed. That being said, moving the definitions and implementations outside the test fixes the issues

Also upgrade the minimal versions of anyhow and serde, as both fail in nightly