### PR TITLE
feat: Allow to compose RPC services

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,7 +54,7 @@ quinn-transport = ["flume", "quinn", "bincode", "tokio-serde", "tokio-util"]
 flume-transport = ["flume"]
 combined-transport = []
 macros = []
-default = []
+default = ["flume-transport"]
 
 [[example]]
 name = "errors"
@@ -66,6 +66,10 @@ required-features = ["flume-transport", "macros"]
 
 [[example]]
 name = "store"
+required-features = ["flume-transport"]
+
+[[example]]
+name = "modularize"
 required-features = ["flume-transport"]
 
 [workspace]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,7 +54,7 @@ quinn-transport = ["flume", "quinn", "bincode", "tokio-serde", "tokio-util"]
 flume-transport = ["flume"]
 combined-transport = []
 macros = []
-default = ["flume-transport"]
+default = []
 
 [[example]]
 name = "errors"

--- a/examples/modularize.rs
+++ b/examples/modularize.rs
@@ -1,3 +1,14 @@
+//! This example shows how an RPC service can be modularized, even between different crates.
+//!
+//! The [`calc`] and [`clock`] modules both expose a [`quic_rpc::Service`] in a regular fashion.
+//! They do not `use` anything from `super` or `app` so they could live in their own crates
+//! unchanged. The only difference to other examples is that their handlers take a generic 
+//! `S: IntoService<clock:ClockService>`, which allows to pass in any service that can be mapped to
+//! the module's service.
+//!
+//! The [`app`] module depends on both `calc` and `clock` and composes both their servers and
+//! clients into a single app handler / client.
+
 use quic_rpc::{transport::flume, RpcServer};
 use tracing::warn;
 

--- a/examples/modularize.rs
+++ b/examples/modularize.rs
@@ -1,0 +1,304 @@
+use quic_rpc::{client::RpcClient, transport::flume, RpcServer, ServiceEndpoint};
+use tracing::warn;
+
+async fn run_server(
+    server_ep: impl ServiceEndpoint<app::Service>,
+    handler: app::Handler,
+) -> anyhow::Result<()> {
+    let server = RpcServer::new(server_ep);
+    loop {
+        let (req, chan) = server.accept().await?;
+        let handler = handler.clone();
+        tokio::task::spawn(async move {
+            handler.handle(req, chan).await;
+        });
+    }
+}
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    let (server_conn, client_conn) = flume::connection::<app::Request, app::Response>(1);
+    let server_handle = tokio::task::spawn(async move {
+        let handler = app::Handler::default();
+        if let Err(err) = run_server(server_conn, handler).await {
+            warn!(?err, "RPC server failed");
+        };
+    });
+
+    app::client_demo(client_conn).await;
+    server_handle.await?;
+    Ok(())
+}
+
+mod app {
+    use super::{calc, clock};
+    use derive_more::{From, TryInto};
+    use quic_rpc::{server::RpcChannel, ServiceConnection, ServiceEndpoint};
+    use serde::{Deserialize, Serialize};
+
+    #[derive(Debug, Serialize, Deserialize, From, TryInto)]
+    pub enum Request {
+        Calc(calc::Request),
+        Clock(clock::Request),
+    }
+
+    #[derive(Debug, Serialize, Deserialize, From, TryInto)]
+    pub enum Response {
+        Calc(calc::Response),
+        Clock(clock::Response),
+    }
+
+    #[derive(Copy, Clone, Debug)]
+    pub struct Service;
+    impl quic_rpc::Service for Service {
+        type Req = Request;
+        type Res = Response;
+    }
+
+    #[derive(Clone, Default)]
+    pub struct Handler {
+        calc: calc::Handler,
+        clock: clock::Handler,
+    }
+
+    impl Handler {
+        pub async fn handle<E: ServiceEndpoint<Service>>(
+            &self,
+            req: Request,
+            chan: RpcChannel<Service, E>,
+        ) {
+            let handler = self.clone();
+            // let _res = match req {
+            //     Request::Calc(req) => self.calc.handle(req, chan).await,
+            //     Request::Clock(req) => self.clock.handle(req, chan).await,
+            // };
+        }
+    }
+
+    pub async fn client_demo<C: ServiceConnection<Service>>(conn: C) {
+        // clock::client_demo(conn).await;
+        // calc::client_demo(conn).await;
+
+        // let client = quic_rpc::RpcClient::<Service, _>::new(conn);
+        // let res = client.rpc(calc::AddRequest(2, 7)).await;
+        // println!("rpc res: {res:?}");
+    }
+
+    impl From<calc::AddRequest> for Request {
+        fn from(value: calc::AddRequest) -> Self {
+            Request::Calc(calc::Request::Add(value))
+        }
+    }
+}
+
+mod calc {
+    use derive_more::{From, TryInto};
+    use quic_rpc::{message::RpcMsg, server::RpcChannel, ServiceConnection, ServiceEndpoint};
+    use serde::{Deserialize, Serialize};
+    use std::fmt::Debug;
+
+    #[derive(Debug, Serialize, Deserialize)]
+    pub struct AddRequest(pub i64, pub i64);
+
+    impl RpcMsg<Service> for AddRequest {
+        type Response = AddResponse;
+    }
+
+    #[derive(Debug, Serialize, Deserialize)]
+    pub struct AddResponse(pub i64);
+
+    #[derive(Debug, Serialize, Deserialize, From, TryInto)]
+    pub enum Request {
+        Add(AddRequest),
+    }
+
+    #[derive(Debug, Serialize, Deserialize, From, TryInto)]
+    pub enum Response {
+        Add(AddResponse),
+    }
+
+    #[derive(Copy, Clone, Debug)]
+    pub struct Service;
+    impl quic_rpc::Service for Service {
+        type Req = Request;
+        type Res = Response;
+    }
+
+    #[derive(Clone, Default)]
+    pub struct Handler;
+
+    impl Handler {
+        pub async fn handle<E: ServiceEndpoint<Service>>(
+            &self,
+            req: Request,
+            chan: RpcChannel<Service, E>,
+        ) {
+            let handler = self.clone();
+            let _res = match req {
+                Request::Add(req) => chan.rpc(req, handler, Self::on_add).await,
+            };
+        }
+
+        pub async fn on_add(self, req: AddRequest) -> AddResponse {
+            AddResponse(req.0 + req.1)
+        }
+    }
+
+    pub async fn client_demo<C: ServiceConnection<Service>>(conn: C) {
+        let client = quic_rpc::RpcClient::<Service, _>::new(conn);
+
+        // a rpc call
+        for i in 0..3 {
+            println!("a rpc call [{i}]");
+            let client = client.clone();
+            tokio::task::spawn(async move {
+                let res = client.rpc(AddRequest(2, i)).await;
+                println!("rpc res [{i}]: {res:?}");
+            });
+        }
+    }
+}
+
+mod clock {
+    use anyhow::Result;
+    use derive_more::{From, TryInto};
+    use futures::{Stream, StreamExt};
+    use quic_rpc::{
+        message::{Msg, ServerStreaming, ServerStreamingMsg},
+        server::RpcChannel,
+        RpcClient, ServiceConnection, ServiceEndpoint,
+    };
+    use serde::{Deserialize, Serialize};
+    use std::{
+        fmt::Debug,
+        sync::{Arc, RwLock},
+        time::Duration,
+    };
+    use tokio::sync::Notify;
+
+    #[derive(Debug, Serialize, Deserialize)]
+    pub struct TickRequest;
+
+    impl Msg<Service> for TickRequest {
+        type Pattern = ServerStreaming;
+    }
+
+    impl ServerStreamingMsg<Service> for TickRequest {
+        type Response = TickResponse;
+    }
+
+    #[derive(Debug, Serialize, Deserialize)]
+    pub struct TickResponse {
+        tick: usize,
+    }
+
+    #[derive(Debug, Serialize, Deserialize, From, TryInto)]
+    pub enum Request {
+        Tick(TickRequest),
+    }
+
+    #[derive(Debug, Serialize, Deserialize, From, TryInto)]
+    pub enum Response {
+        Tick(TickResponse),
+    }
+
+    #[derive(Copy, Clone, Debug)]
+    pub struct Service;
+    impl quic_rpc::Service for Service {
+        type Req = Request;
+        type Res = Response;
+    }
+
+    #[derive(Clone)]
+    pub struct Handler {
+        tick: Arc<RwLock<usize>>,
+        ontick: Arc<Notify>,
+    }
+
+    impl Default for Handler {
+        fn default() -> Self {
+            Self::new(Duration::from_secs(1))
+        }
+    }
+
+    impl Handler {
+        pub fn new(tick_duration: Duration) -> Self {
+            let h = Handler {
+                tick: Default::default(),
+                ontick: Default::default(),
+            };
+            let h2 = h.clone();
+            tokio::task::spawn(async move {
+                loop {
+                    tokio::time::sleep(tick_duration).await;
+                    *h2.tick.write().unwrap() += 1;
+                    h2.ontick.notify_waiters();
+                }
+            });
+            h
+        }
+
+        pub async fn handle<E: ServiceEndpoint<Service>>(
+            &self,
+            req: Request,
+            chan: RpcChannel<Service, E>,
+        ) {
+            let handler = self.clone();
+            let _res = match req {
+                Request::Tick(req) => chan.server_streaming(req, handler, Self::on_tick).await,
+            };
+        }
+
+        pub fn on_tick(
+            self,
+            req: TickRequest,
+        ) -> impl Stream<Item = TickResponse> + Send + 'static {
+            let (tx, rx) = flume::bounded(2);
+            tokio::task::spawn(async move {
+                if let Err(err) = self.on_tick0(req, tx).await {
+                    tracing::warn!(?err, "on_tick RPC handler failed");
+                }
+            });
+            rx.into_stream()
+        }
+
+        pub async fn on_tick0(
+            self,
+            _req: TickRequest,
+            tx: flume::Sender<TickResponse>,
+        ) -> Result<()> {
+            loop {
+                let tick = *self.tick.read().unwrap();
+                tx.send_async(TickResponse { tick }).await?;
+                self.ontick.notified().await;
+            }
+        }
+    }
+
+    pub async fn client_demo<C: ServiceConnection<Service>>(conn: C) {
+        let client = RpcClient::<Service, _>::new(conn);
+
+        // a rpc call
+        for i in 0..3 {
+            println!("a rpc call [{i}]");
+            let client = client.clone();
+            tokio::task::spawn(async move {
+                if let Err(err) = run_tick(client, i).await {
+                    tracing::warn!(?err, "client: run_tick failed");
+                }
+            });
+        }
+    }
+
+    async fn run_tick<C: ServiceConnection<Service>>(
+        client: RpcClient<Service, C>,
+        id: usize,
+    ) -> anyhow::Result<()> {
+        let mut res = client.server_streaming(TickRequest).await?;
+        while let Some(res) = res.next().await {
+            println!("stream [{id}]: {res:?}");
+        }
+        println!("stream [{id}]: done");
+        Ok(())
+    }
+}

--- a/examples/modularize.rs
+++ b/examples/modularize.rs
@@ -1,13 +1,11 @@
 //! This example shows how an RPC service can be modularized, even between different crates.
 //!
+//! * `app` module is the top level. it composes `iroh` plus one handler of the app itself
+//! * `iroh` module composes two other services, `calc` and `clock`
+//!
 //! The [`calc`] and [`clock`] modules both expose a [`quic_rpc::Service`] in a regular fashion.
 //! They do not `use` anything from `super` or `app` so they could live in their own crates
-//! unchanged. The only difference to other examples is that their handlers take a generic
-//! `S: IntoService<clock:ClockService>`, which allows to pass in any service that can be mapped to
-//! the module's service.
-//!
-//! The [`app`] module depends on both `calc` and `clock` and composes both their servers and
-//! clients into a single app handler / client.
+//! unchanged. 
 
 use quic_rpc::{transport::flume, RpcServer};
 use tracing::warn;

--- a/src/client.rs
+++ b/src/client.rs
@@ -97,7 +97,7 @@ impl<S: Service + IntoService<S2>, C: ServiceConnection<S>, S2: Service> RpcClie
     }
 
     /// Map this channel into a derivable service channel.
-    pub fn service<SN: Service>(self) -> RpcClient<S, C, SN>
+    pub fn map<SN: Service>(self) -> RpcClient<S, C, SN>
     where
         S: IntoService<SN>,
     {

--- a/src/client.rs
+++ b/src/client.rs
@@ -139,9 +139,7 @@ where
     {
         let msg = self.map.req_up(msg.into());
         let (mut send, mut recv) = self.source.open_bi().await.map_err(RpcClientError::Open)?;
-        send.send(msg.into())
-            .await
-            .map_err(RpcClientError::<C>::Send)?;
+        send.send(msg).await.map_err(RpcClientError::<C>::Send)?;
         let res = recv
             .next()
             .await
@@ -149,7 +147,7 @@ where
             .map_err(RpcClientError::<C>::RecvError)?;
         // keep send alive until we have the answer
         drop(send);
-        let res: S2::Res = self
+        let res = self
             .map
             .try_res_down(res)
             .map_err(|_| RpcClientError::DowncastError)?;

--- a/src/client.rs
+++ b/src/client.rs
@@ -96,7 +96,10 @@ impl<S: Service + IntoService<S2>, C: ServiceConnection<S>, S2: Service> RpcClie
         self.source
     }
 
-    /// Map this channel into a derivable service channel.
+    /// Map this channel's service into an inner service.
+    ///
+    /// This method is available as long as the outer service implements [`IntoService`] for the
+    /// inner service.
     pub fn map<SN: Service>(self) -> RpcClient<S, C, SN>
     where
         S: IntoService<SN>,

--- a/src/client.rs
+++ b/src/client.rs
@@ -252,16 +252,15 @@ where
         send.send(msg).await.map_err(BidiError::<C>::Send)?;
         let send = UpdateSink(send, PhantomData, Arc::clone(&self.map));
         let map = Arc::clone(&self.map);
-        let recv = Box::pin(recv
-            .map(move |x| match x {
-                Ok(x) => {
-                    let x = map
-                        .res_try_into_inner(x)
-                        .map_err(|_| BidiItemError::DowncastError)?;
-                    M::Response::try_from(x).map_err(|_| BidiItemError::DowncastError)
-                }
-                Err(e) => Err(BidiItemError::RecvError(e)),
-            }));
+        let recv = Box::pin(recv.map(move |x| match x {
+            Ok(x) => {
+                let x = map
+                    .res_try_into_inner(x)
+                    .map_err(|_| BidiItemError::DowncastError)?;
+                M::Response::try_from(x).map_err(|_| BidiItemError::DowncastError)
+            }
+            Err(e) => Err(BidiItemError::RecvError(e)),
+        }));
         Ok((send, recv))
     }
 }

--- a/src/client.rs
+++ b/src/client.rs
@@ -65,8 +65,7 @@ where
     }
 
     fn start_send(self: Pin<&mut Self>, item: T) -> Result<(), Self::Error> {
-        let req: S2::Req = item.into();
-        let req = S::outer_req_from(req);
+        let req = S::outer_req_from(item);
         self.project().0.start_send_unpin(req)
     }
 
@@ -98,7 +97,7 @@ impl<S: Service + IntoService<S2>, C: ServiceConnection<S>, S2: Service> RpcClie
     }
 
     /// Map this channel into a derivable service channel.
-    pub fn into_service<SN: Service>(self) -> RpcClient<S, C, SN>
+    pub fn service<SN: Service>(self) -> RpcClient<S, C, SN>
     where
         S: IntoService<SN>,
     {
@@ -110,9 +109,7 @@ impl<S: Service + IntoService<S2>, C: ServiceConnection<S>, S2: Service> RpcClie
     where
         M: RpcMsg<S2>,
     {
-        let msg: S2::Req = msg.into();
         let msg = S::outer_req_from(msg);
-        let msg: <S as Service>::Req = msg.into();
         let (mut send, mut recv) = self.source.open_bi().await.map_err(RpcClientError::Open)?;
         send.send(msg).await.map_err(RpcClientError::<C>::Send)?;
         let res = recv
@@ -137,7 +134,6 @@ impl<S: Service + IntoService<S2>, C: ServiceConnection<S>, S2: Service> RpcClie
     where
         M: ServerStreamingMsg<S2>,
     {
-        let msg: S2::Req = msg.into();
         let msg = S::outer_req_from(msg);
         let (mut send, recv) = self
             .source
@@ -174,7 +170,6 @@ impl<S: Service + IntoService<S2>, C: ServiceConnection<S>, S2: Service> RpcClie
     where
         M: ClientStreamingMsg<S2>,
     {
-        let msg: S2::Req = msg.into();
         let msg = S::outer_req_from(msg);
         let (mut send, mut recv) = self
             .source
@@ -216,7 +211,6 @@ impl<S: Service + IntoService<S2>, C: ServiceConnection<S>, S2: Service> RpcClie
     where
         M: BidiStreamingMsg<S2>,
     {
-        let msg: S2::Req = msg.into();
         let msg = S::outer_req_from(msg);
         let (mut send, recv) = self.source.open_bi().await.map_err(BidiError::Open)?;
         send.send(msg).await.map_err(BidiError::<C>::Send)?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -154,6 +154,140 @@ pub trait Service: Send + Sync + Debug + Clone + 'static {
     type Res: RpcMessage;
 }
 
+// pub trait MappedService2<S, Req, Res>: Service<Req, Res> {
+//     type Req
+//
+// }
+///
+// pub trait ServiceWrapperFor<S>: Service {}
+//
+// impl<S0, S2> ServiceWrapperFor<S2> for S0
+// where
+//     S0: Service,
+//     S2: Service,
+//     S0::Req: From<S2::Req>,
+//     S0::Res: From<S0::Res>,
+// {
+// }
+// //
+// ///
+// pub trait FromService<S: Service>: Service {
+//     ///
+//     fn req_from(req: <Self as Service>::Req) -> S::Req;
+//     ///
+//     fn res_from(res: <Self as Service>::Res) -> S::Res;
+// }
+//
+// impl<S0, S2> FromService<S0> for S2
+// where
+//     S0: Service,
+//     S2: Service,
+//     S2::Req: Into<S0::Req> + Send + 'static,
+//     S2::Res: Into<S0::Res> + Send + 'static,
+// {
+//     fn req_from(req: <Self as Service>::Req) -> S0::Req {
+//         req.into()
+//     }
+//     fn res_from(res: <Self as Service>::Res) -> S0::Res {
+//         res.into()
+//     }
+// }
+
+///
+pub trait IntoService<S: Service>: Service {
+    ///
+    fn outer_req_from(req: S::Req) -> Self::Req;
+    ///
+    fn outer_res_from(res: S::Res) -> Self::Res;
+    ///
+    fn try_inner_req_from(req: Self::Req) -> Result<S::Req, ()>;
+    ///
+    fn try_inner_res_from(res: Self::Res) -> Result<S::Res, ()>;
+}
+
+impl<S0, S2> IntoService<S2> for S0
+where
+    S0: Service,
+    S2: Service,
+    S2::Req: Into<S0::Req> + Send + 'static,
+    S2::Res: Into<S0::Res> + Send + 'static,
+
+    S2::Req: TryFrom<S0::Req> + Send + 'static,
+    S2::Res: TryFrom<S0::Res> + Send + 'static,
+{
+    fn outer_req_from(req: S2::Req) -> S0::Req {
+        req.into()
+    }
+    fn outer_res_from(res: S2::Res) -> S0::Res {
+        res.into()
+    }
+
+    ///
+    fn try_inner_req_from(req: S0::Req) -> Result<S2::Req, ()> {
+        req.try_into().map_err(|_| ())
+    }
+    ///
+    fn try_inner_res_from(res: Self::Res) -> Result<S2::Res, ()> {
+        res.try_into().map_err(|_| ())
+    }
+
+    // fn try_req_into(req: S2::Req) -> <Self as Service>::Req {
+    //     req.into()
+    // }
+    // fn try_res_from(res: S2::Res) -> <Self as Service>::Res {
+    //     res.into()
+    // }
+}
+
+// ///
+// pub trait IntoService<S: Service>: Service {
+//     fn req_into(req: <Self as Service>::Req) -> S::Req;
+//     fn res_into(res: <Self as Service>::Res) -> S::Res;
+// }
+//
+// impl<S0, S2> IntoService<S2> for S0
+// where
+//     S0: Service,
+//     S2: Service,
+//     S2::Req: Into<S0::Req> + Send + 'static,
+//     S2::Res: Into<S0::Res> + Send + 'static,
+// {
+//     fn req_into(req: S2::Req) -> S0::Req {
+//         req.into()
+//     }
+//     fn res_into(res: S2::Res) -> S0::Res {
+//         res.into()
+//     }
+// }
+
+// impl<S0, S2> IntoService<S2> for S0 where S0: Service, S2: FromService<S0> {
+//     fn req_into(req: <S2 as Service>::Req) -> <S0 as Service>::Req {
+//         <S0 as FromService<S2>>::req_from(req)
+//     }
+//
+//     fn res_into(res: <S2 as Service>::Res) -> <S0 as Service>::Res {
+//         <S0 as FromService<S2>>::res_from(res)
+//     }
+// }
+
+// impl<S2, S0> MappedService<S0> for S2
+// where
+//     S0: Service,
+//     S2: Service,
+//     // <T as Service>::Req: From<S::Req>,
+//     // <T as Service>::Res: From<S::Res>,
+//     // <S0 as Service>::Req: From<S2::Req>,
+//     // <S0 as Service>::Res: From<S2::Res>,
+//     // <S2 as Service>::Req: From<S0::Req>,
+//     // <S2 as Service>::Res: From<S0::Res>,
+//         S2::Req: Into<S0::Req> + Send + 'static,
+//         S2::Res: Into<S0::Res> + Send + 'static,
+// {
+// }
+// S0: quic_rpc::Service,
+// S0::Req: From<Request> + Send + 'static,
+// S0::Res: From<Response> + Send + 'static,
+
 /// A connection to a specific service on a specific remote machine
 ///
 /// This is just a trait alias for a [Connection] with the right types.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -173,10 +173,8 @@ impl<S0, S2> IntoService<S2> for S0
 where
     S0: Service,
     S2: Service,
-    S2::Req: Into<S0::Req> + Send + 'static,
-    S2::Res: Into<S0::Res> + Send + 'static,
-    S2::Req: TryFrom<S0::Req> + Send + 'static,
-    S2::Res: TryFrom<S0::Res> + Send + 'static,
+    S2::Req: Into<S0::Req> + TryFrom<S0::Req> + Send + 'static,
+    S2::Res: Into<S0::Res> + TryFrom<S0::Res> + Send + 'static,
 {
     fn outer_req_from(req: impl Into<S2::Req>) -> S0::Req {
         (req.into()).into()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -168,13 +168,13 @@ pub trait Service: Send + Sync + Debug + Clone + 'static {
 /// If an outer service impls [`IntoService`] for an inner service, the [`crate::RpcChannel`] and [`RpcClient`]
 pub trait IntoService<S: Service>: Service {
     /// Convert the inner request into the outer request.
-    fn outer_req_from(req: impl Into<S::Req>) -> Self::Req;
+    fn req_up(req: impl Into<S::Req>) -> Self::Req;
     /// Convert the inner response into the outer response.
-    fn outer_res_from(res: impl Into<S::Res>) -> Self::Res;
+    fn res_up(res: impl Into<S::Res>) -> Self::Res;
     /// Try to convert the outer request into the inner request.
-    fn try_inner_req_from(req: Self::Req) -> Result<S::Req, ()>;
+    fn try_req_down(req: Self::Req) -> Result<S::Req, ()>;
     /// Try to convert the outer response into the inner response.
-    fn try_inner_res_from(res: Self::Res) -> Result<S::Res, ()>;
+    fn try_res_down(res: Self::Res) -> Result<S::Res, ()>;
 }
 
 impl<S0, S2> IntoService<S2> for S0
@@ -184,19 +184,19 @@ where
     S2::Req: Into<S0::Req> + TryFrom<S0::Req> + Send + 'static,
     S2::Res: Into<S0::Res> + TryFrom<S0::Res> + Send + 'static,
 {
-    fn outer_req_from(req: impl Into<S2::Req>) -> S0::Req {
+    fn req_up(req: impl Into<S2::Req>) -> S0::Req {
         (req.into()).into()
     }
 
-    fn outer_res_from(res: impl Into<S2::Res>) -> S0::Res {
+    fn res_up(res: impl Into<S2::Res>) -> S0::Res {
         (res.into()).into()
     }
 
-    fn try_inner_req_from(req: Self::Req) -> Result<S2::Req, ()> {
+    fn try_req_down(req: Self::Req) -> Result<S2::Req, ()> {
         req.try_into().map_err(|_| ())
     }
 
-    fn try_inner_res_from(res: Self::Res) -> Result<S2::Res, ()> {
+    fn try_res_down(res: Self::Res) -> Result<S2::Res, ()> {
         res.try_into().map_err(|_| ())
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -92,11 +92,7 @@
 #![deny(missing_docs)]
 #![deny(rustdoc::broken_intra_doc_links)]
 use serde::{de::DeserializeOwned, Serialize};
-use std::{
-    fmt::{Debug, Display},
-    marker::PhantomData,
-    sync::Arc,
-};
+use std::fmt::{Debug, Display};
 use transport::{Connection, ServerEndpoint};
 pub mod client;
 pub mod message;
@@ -106,6 +102,7 @@ pub use client::RpcClient;
 pub use server::RpcServer;
 #[cfg(feature = "macros")]
 mod macros;
+mod map;
 
 /// Requirements for a RPC message
 ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -156,8 +156,16 @@ pub trait Service: Send + Sync + Debug + Clone + 'static {
 
 /// Marker trait for services that can be mapped into another service.
 ///
+/// This can be used in place of the usual `S: Service` generic to accept any service that can be
+/// mapped to the service in question.
+///
 /// There is usually no need to impl this trait manually, because it is auto-implemented as long as
-/// the inner service's Req and Res types implement Into and TryFrom to the outer service's types.
+/// the inner service's Req and Res types implement [`Into`] and [`TryFrom`] to the outer service's types.
+///
+/// See `examples/modularize.rs` for an example of how to use this trait to decouple RPC services
+/// between different, independent modules or crates.
+///
+/// If an outer service impls [`IntoService`] for an inner service, the [`crate::RpcChannel`] and [`RpcClient`]
 pub trait IntoService<S: Service>: Service {
     /// Convert the inner request into the outer request.
     fn outer_req_from(req: impl Into<S::Req>) -> Self::Req;

--- a/src/map.rs
+++ b/src/map.rs
@@ -13,7 +13,7 @@ pub trait MapService<SOuter: Service, SInner: Service>:
     /// Convert an inner request into the outer request.
     fn req_into_outer(&self, req: SInner::Req) -> SOuter::Req;
 
-    /// Convert an inner response into the outer response. 
+    /// Convert an inner response into the outer response.
     fn res_into_outer(&self, res: SInner::Res) -> SOuter::Res;
 
     /// Try to convert the outer request into the inner request.

--- a/src/map.rs
+++ b/src/map.rs
@@ -127,23 +127,19 @@ where
 {
     fn req_into_outer(&self, req: SInner::Req) -> SOuter::Req {
         let req = self.map2.req_into_outer(req);
-        let req = self.map1.req_into_outer(req);
-        req
+        self.map1.req_into_outer(req)
     }
     fn res_into_outer(&self, res: SInner::Res) -> SOuter::Res {
         let res = self.map2.res_into_outer(res);
-        let res = self.map1.res_into_outer(res);
-        res
+        self.map1.res_into_outer(res)
     }
     fn req_try_into_inner(&self, req: SOuter::Req) -> Result<SInner::Req, ()> {
         let req = self.map1.req_try_into_inner(req)?;
-        let req = self.map2.req_try_into_inner(req);
-        req
+        self.map2.req_try_into_inner(req)
     }
 
     fn res_try_into_inner(&self, res: SOuter::Res) -> Result<SInner::Res, ()> {
         let res = self.map1.res_try_into_inner(res)?;
-        let res = self.map2.res_try_into_inner(res);
-        res
+        self.map2.res_try_into_inner(res)
     }
 }

--- a/src/map.rs
+++ b/src/map.rs
@@ -2,11 +2,11 @@ use std::{marker::PhantomData, sync::Arc};
 
 use crate::Service;
 
-pub trait IntoService<S1: Service, S2: Service>: std::fmt::Debug + Send + Sync + 'static {
-    fn req_up(&self, req: <S2 as Service>::Req) -> <S1 as Service>::Req;
-    fn res_up(&self, res: <S2 as Service>::Res) -> <S1 as Service>::Res;
-    fn try_req_down(&self, req: <S1 as Service>::Req) -> Result<<S2 as Service>::Req, ()>;
-    fn try_res_down(&self, res: <S1 as Service>::Res) -> Result<<S2 as Service>::Res, ()>;
+pub trait MapService<S1: Service, S2: Service>: std::fmt::Debug + Send + Sync + 'static {
+    fn req_up(&self, req: S2::Req) -> S1::Req;
+    fn res_up(&self, res: S2::Res) -> S1::Res;
+    fn try_req_down(&self, req: S1::Req) -> Result<S2::Req, ()>;
+    fn try_res_down(&self, res: S1::Res) -> Result<S2::Res, ()>;
 }
 
 #[derive(Debug)]
@@ -30,26 +30,26 @@ where
     }
 }
 
-impl<S1, S2> IntoService<S1, S2> for Mapper<S1, S2>
+impl<S1, S2> MapService<S1, S2> for Mapper<S1, S2>
 where
     S1: Service,
     S2: Service,
     S2::Req: Into<S1::Req> + TryFrom<S1::Req>,
     S2::Res: Into<S1::Res> + TryFrom<S1::Res>,
 {
-    fn req_up(&self, req: <S2 as Service>::Req) -> <S1 as Service>::Req {
+    fn req_up(&self, req: S2::Req) -> S1::Req {
         (req.into()).into()
     }
 
-    fn res_up(&self, res: <S2 as Service>::Res) -> <S1 as Service>::Res {
+    fn res_up(&self, res: S2::Res) -> S1::Res {
         (res.into()).into()
     }
 
-    fn try_req_down(&self, req: <S1 as Service>::Req) -> Result<<S2 as Service>::Req, ()> {
+    fn try_req_down(&self, req: S1::Req) -> Result<S2::Req, ()> {
         req.try_into().map_err(|_| ())
     }
 
-    fn try_res_down(&self, res: <S1 as Service>::Res) -> Result<<S2 as Service>::Res, ()> {
+    fn try_res_down(&self, res: S1::Res) -> Result<S2::Res, ()> {
         res.try_into().map_err(|_| ())
     }
 }
@@ -62,7 +62,7 @@ where
     S3: Service,
     S3::Req: Into<S2::Req> + TryFrom<S2::Req>,
 {
-    m1: Arc<dyn IntoService<S1, S2>>,
+    m1: Arc<dyn MapService<S1, S2>>,
     m2: Mapper<S2, S3>,
 }
 
@@ -74,7 +74,7 @@ where
     S3::Req: Into<S2::Req> + TryFrom<S2::Req>,
     S3::Res: Into<S2::Res> + TryFrom<S2::Res>,
 {
-    pub fn new(m1: Arc<dyn IntoService<S1, S2>>) -> Self {
+    pub fn new(m1: Arc<dyn MapService<S1, S2>>) -> Self {
         Self {
             m1,
             m2: Mapper::new(),
@@ -82,7 +82,7 @@ where
     }
 }
 
-impl<S1, S2, S3> IntoService<S1, S3> for ChainedMapper<S1, S2, S3>
+impl<S1, S2, S3> MapService<S1, S3> for ChainedMapper<S1, S2, S3>
 where
     S1: Service,
     S2: Service,

--- a/src/map.rs
+++ b/src/map.rs
@@ -1,0 +1,114 @@
+use std::{marker::PhantomData, sync::Arc};
+
+use crate::Service;
+
+pub trait IntoService<S1: Service, S2: Service>: std::fmt::Debug + Send + Sync + 'static {
+    fn req_up(&self, req: <S2 as Service>::Req) -> <S1 as Service>::Req;
+    fn res_up(&self, res: <S2 as Service>::Res) -> <S1 as Service>::Res;
+    fn try_req_down(&self, req: <S1 as Service>::Req) -> Result<<S2 as Service>::Req, ()>;
+    fn try_res_down(&self, res: <S1 as Service>::Res) -> Result<<S2 as Service>::Res, ()>;
+}
+
+#[derive(Debug)]
+pub struct Mapper<S1, S2> {
+    s1: PhantomData<S1>,
+    s2: PhantomData<S2>,
+}
+
+impl<S1, S2> Mapper<S1, S2>
+where
+    S1: Service,
+    S2: Service,
+    S2::Req: Into<S1::Req> + TryFrom<S1::Req>,
+    S2::Res: Into<S1::Res> + TryFrom<S1::Res>,
+{
+    pub fn new() -> Self {
+        Self {
+            s1: PhantomData,
+            s2: PhantomData,
+        }
+    }
+}
+
+impl<S1, S2> IntoService<S1, S2> for Mapper<S1, S2>
+where
+    S1: Service,
+    S2: Service,
+    S2::Req: Into<S1::Req> + TryFrom<S1::Req>,
+    S2::Res: Into<S1::Res> + TryFrom<S1::Res>,
+{
+    fn req_up(&self, req: <S2 as Service>::Req) -> <S1 as Service>::Req {
+        (req.into()).into()
+    }
+
+    fn res_up(&self, res: <S2 as Service>::Res) -> <S1 as Service>::Res {
+        (res.into()).into()
+    }
+
+    fn try_req_down(&self, req: <S1 as Service>::Req) -> Result<<S2 as Service>::Req, ()> {
+        req.try_into().map_err(|_| ())
+    }
+
+    fn try_res_down(&self, res: <S1 as Service>::Res) -> Result<<S2 as Service>::Res, ()> {
+        res.try_into().map_err(|_| ())
+    }
+}
+
+#[derive(Debug)]
+pub struct ChainedMapper<S1, S2, S3>
+where
+    S1: Service,
+    S2: Service,
+    S3: Service,
+    S3::Req: Into<S2::Req> + TryFrom<S2::Req>,
+{
+    m1: Arc<dyn IntoService<S1, S2>>,
+    m2: Mapper<S2, S3>,
+}
+
+impl<S1, S2, S3> ChainedMapper<S1, S2, S3>
+where
+    S1: Service,
+    S2: Service,
+    S3: Service,
+    S3::Req: Into<S2::Req> + TryFrom<S2::Req>,
+    S3::Res: Into<S2::Res> + TryFrom<S2::Res>,
+{
+    pub fn new(m1: Arc<dyn IntoService<S1, S2>>) -> Self {
+        Self {
+            m1,
+            m2: Mapper::new(),
+        }
+    }
+}
+
+impl<S1, S2, S3> IntoService<S1, S3> for ChainedMapper<S1, S2, S3>
+where
+    S1: Service,
+    S2: Service,
+    S3: Service,
+    S3::Req: Into<S2::Req> + TryFrom<S2::Req>,
+    S3::Res: Into<S2::Res> + TryFrom<S2::Res>,
+{
+    fn req_up(&self, req: S3::Req) -> S1::Req {
+        let req = self.m2.req_up(req);
+        let req = self.m1.req_up(req.into());
+        req
+    }
+    fn res_up(&self, res: S3::Res) -> S1::Res {
+        let res = self.m2.res_up(res);
+        let res = self.m1.res_up(res.into());
+        res
+    }
+    fn try_req_down(&self, req: S1::Req) -> Result<S3::Req, ()> {
+        let req = self.m1.try_req_down(req)?;
+        let req = self.m2.try_req_down(req.try_into().map_err(|_| ())?);
+        req
+    }
+
+    fn try_res_down(&self, res: <S1 as Service>::Res) -> Result<<S3 as Service>::Res, ()> {
+        let res = self.m1.try_res_down(res)?;
+        let res = self.m2.try_res_down(res.try_into().map_err(|_| ())?);
+        res
+    }
+}

--- a/src/server.rs
+++ b/src/server.rs
@@ -75,7 +75,10 @@ impl<S: IntoService<S2>, C: ServiceEndpoint<S>, S2: Service> RpcChannel<S, C, S2
         }
     }
 
-    /// Map this channel into a derivable service channel.
+    /// Map this channel's service into an inner service.
+    ///
+    /// This method is available as long as the outer service implements [`IntoService`] for the
+    /// inner service.
     pub fn map<SN: Service>(self) -> RpcChannel<S, C, SN>
     where
         S: IntoService<SN>,

--- a/src/server.rs
+++ b/src/server.rs
@@ -113,7 +113,7 @@ impl<S: IntoService<S2>, C: ServiceEndpoint<S>, S2: Service> RpcChannel<S, C, S2
             // get the response
             let res = f(target, req).await;
             // turn into a S::Res so we can send it
-            let res = S::outer_res_from(res);
+            let res = S::res_up(res);
             // send it and return the error if any
             send.send(res).await.map_err(RpcServerError::SendError)
         })
@@ -141,7 +141,7 @@ impl<S: IntoService<S2>, C: ServiceEndpoint<S>, S2: Service> RpcChannel<S, C, S2
             // get the response
             let res = f(target, req, updates).await;
             // turn into a S::Res so we can send it
-            let res = S::outer_res_from(res);
+            let res = S::res_up(res);
             // send it and return the error if any
             send.send(res).await.map_err(RpcServerError::SendError)
         })
@@ -172,7 +172,7 @@ impl<S: IntoService<S2>, C: ServiceEndpoint<S>, S2: Service> RpcChannel<S, C, S2
             tokio::pin!(responses);
             while let Some(response) = responses.next().await {
                 // turn into a S::Res so we can send it
-                let response = S::outer_res_from(response);
+                let response = S::res_up(response);
                 // send it and return the error if any
                 send.send(response).await.map_err(RpcServerError::SendError)?;
             }
@@ -210,7 +210,7 @@ impl<S: IntoService<S2>, C: ServiceEndpoint<S>, S2: Service> RpcChannel<S, C, S2
             tokio::pin!(responses);
             while let Some(response) = responses.next().await {
                 // turn into a S::Res so we can send it
-                let response = S::outer_res_from(response);
+                let response = S::res_up(response);
                 // send it and return the error if any
                 send.send(response)
                     .await

--- a/tests/flume.rs
+++ b/tests/flume.rs
@@ -1,7 +1,11 @@
 #![cfg(feature = "flume-transport")]
 mod math;
 use math::*;
-use quic_rpc::{server::RpcServerError, transport::flume, RpcClient, RpcServer};
+use quic_rpc::{
+    server::{RpcChannel, RpcServerError},
+    transport::flume,
+    RpcClient, RpcServer, Service,
+};
 
 #[tokio::test]
 async fn flume_channel_bench() -> anyhow::Result<()> {
@@ -11,6 +15,77 @@ async fn flume_channel_bench() -> anyhow::Result<()> {
     let server = RpcServer::<ComputeService, _>::new(server);
     let server_handle = tokio::task::spawn(ComputeService::server(server));
     let client = RpcClient::<ComputeService, _>::new(client);
+    bench(client, 1000000).await?;
+    // dropping the client will cause the server to terminate
+    match server_handle.await? {
+        Err(RpcServerError::Accept(_)) => {}
+        e => panic!("unexpected termination result {e:?}"),
+    }
+    Ok(())
+}
+
+#[tokio::test]
+async fn flume_channel_mapped_bench() -> anyhow::Result<()> {
+    use derive_more::{From, TryInto};
+    use serde::{Deserialize, Serialize};
+
+    tracing_subscriber::fmt::try_init().ok();
+
+    #[derive(Debug, Serialize, Deserialize, From, TryInto)]
+    enum OuterRequest {
+        Inner(InnerRequest),
+    }
+    #[derive(Debug, Serialize, Deserialize, From, TryInto)]
+    enum InnerRequest {
+        Compute(ComputeRequest),
+    }
+    #[derive(Debug, Serialize, Deserialize, From, TryInto)]
+    enum OuterResponse {
+        Inner(InnerResponse),
+    }
+    #[derive(Debug, Serialize, Deserialize, From, TryInto)]
+    enum InnerResponse {
+        Compute(ComputeResponse),
+    }
+    #[derive(Debug, Clone)]
+    struct OuterService;
+    impl Service for OuterService {
+        type Req = OuterRequest;
+        type Res = OuterResponse;
+    }
+    #[derive(Debug, Clone)]
+    struct InnerService;
+    impl Service for InnerService {
+        type Req = InnerRequest;
+        type Res = InnerResponse;
+    }
+    let (server, client) = flume::connection::<OuterRequest, OuterResponse>(1);
+
+    let server = RpcServer::<OuterService, _>::new(server);
+    // let server: RpcServer<OuterService, _, InnerService> = server.map();
+    // let server: RpcServer<OuterService, _, ComputeService> = server.map();
+    let server_handle: tokio::task::JoinHandle<Result<(), RpcServerError<_>>> =
+        tokio::task::spawn(async move {
+            let service = ComputeService;
+            loop {
+                let (req, chan) = server.accept().await?;
+                let service = service.clone();
+                tokio::spawn(async move {
+                    let req: OuterRequest = req;
+                    match req {
+                        OuterRequest::Inner(InnerRequest::Compute(req)) => {
+                            let chan: RpcChannel<OuterService, _, InnerService> = chan.map();
+                            let chan: RpcChannel<OuterService, _, ComputeService> = chan.map();
+                            ComputeService::handle_rpc_request(service, req, chan).await
+                        }
+                    }
+                });
+            }
+        });
+
+    let client = RpcClient::<OuterService, _>::new(client);
+    let client: RpcClient<OuterService, _, InnerService> = client.map();
+    let client: RpcClient<OuterService, _, ComputeService> = client.map();
     bench(client, 1000000).await?;
     // dropping the client will cause the server to terminate
     match server_handle.await? {

--- a/tests/math.rs
+++ b/tests/math.rs
@@ -9,7 +9,8 @@ use derive_more::{From, TryInto};
 use futures::{SinkExt, Stream, StreamExt, TryStreamExt};
 use quic_rpc::{
     declare_bidi_streaming, declare_client_streaming, declare_rpc, declare_server_streaming,
-    server::RpcServerError, RpcClient, RpcServer, Service, ServiceConnection, ServiceEndpoint,
+    server::{RpcChannel, RpcServerError},
+    RpcClient, RpcServer, Service, ServiceConnection, ServiceEndpoint,
 };
 use serde::{Deserialize, Serialize};
 use std::{
@@ -137,20 +138,30 @@ impl ComputeService {
         loop {
             let (req, chan) = s.accept().await?;
             let service = service.clone();
-            tokio::spawn(async move {
-                use ComputeRequest::*;
-                #[rustfmt::skip]
-                match req {
-                    Sqr(msg) => chan.rpc(msg, service, ComputeService::sqr).await,
-                    Sum(msg) => chan.client_streaming(msg, service, ComputeService::sum).await,
-                    Fibonacci(msg) => chan.server_streaming(msg, service, ComputeService::fibonacci).await,
-                    Multiply(msg) => chan.bidi_streaming(msg, service, ComputeService::multiply).await,
-                    SumUpdate(_) => Err(RpcServerError::UnexpectedStartMessage)?,
-                    MultiplyUpdate(_) => Err(RpcServerError::UnexpectedStartMessage)?,
-                }?;
-                Ok::<_, RpcServerError<C>>(())
-            });
+            tokio::spawn(async move { Self::handle_rpc_request(service, req, chan).await });
         }
+    }
+
+    pub async fn handle_rpc_request<S, E>(
+        service: ComputeService,
+        req: ComputeRequest,
+        chan: RpcChannel<S, E, ComputeService>,
+    ) -> Result<(), RpcServerError<E>>
+    where
+        S: Service,
+        E: ServiceEndpoint<S>,
+    {
+        use ComputeRequest::*;
+        #[rustfmt::skip]
+        match req {
+            Sqr(msg) => chan.rpc(msg, service, ComputeService::sqr).await,
+            Sum(msg) => chan.client_streaming(msg, service, ComputeService::sum).await,
+            Fibonacci(msg) => chan.server_streaming(msg, service, ComputeService::fibonacci).await,
+            Multiply(msg) => chan.bidi_streaming(msg, service, ComputeService::multiply).await,
+            MultiplyUpdate(_) => Err(RpcServerError::UnexpectedStartMessage)?,
+            SumUpdate(_) => Err(RpcServerError::UnexpectedStartMessage)?,
+        }?;
+        Ok(())
     }
 
     /// Runs the service until `count` requests have been received.
@@ -275,12 +286,12 @@ fn clear_line() {
     print!("\r{}\r", " ".repeat(80));
 }
 
-pub async fn bench<C: ServiceConnection<ComputeService>>(
-    client: RpcClient<ComputeService, C>,
+pub async fn bench<S, C>(
+    client: RpcClient<S, C, ComputeService>,
     n: u64,
 ) -> anyhow::Result<()>
 where
-    C::SendError: std::error::Error,
+    C::SendError: std::error::Error, S: Service, C: ServiceConnection<S>
 {
     // individual RPCs
     {

--- a/tests/math.rs
+++ b/tests/math.rs
@@ -286,12 +286,11 @@ fn clear_line() {
     print!("\r{}\r", " ".repeat(80));
 }
 
-pub async fn bench<S, C>(
-    client: RpcClient<S, C, ComputeService>,
-    n: u64,
-) -> anyhow::Result<()>
+pub async fn bench<S, C>(client: RpcClient<S, C, ComputeService>, n: u64) -> anyhow::Result<()>
 where
-    C::SendError: std::error::Error, S: Service, C: ServiceConnection<S>
+    C::SendError: std::error::Error,
+    S: Service,
+    C: ServiceConnection<S>,
 {
     // individual RPCs
     {

--- a/tests/quinn.rs
+++ b/tests/quinn.rs
@@ -150,7 +150,7 @@ async fn server_away_and_back() -> anyhow::Result<()> {
     let client = make_client_endpoint("0.0.0.0:0".parse()?, &[&server_cert])?;
     let client_connection =
         transport::quinn::QuinnConnection::new(client, server_addr, "localhost".into());
-    let client = RpcClient::new(client_connection);
+    let client = RpcClient::<ComputeService, _>::new(client_connection);
 
     // send a request. No server available so it should fail
     client.rpc(Sqr(4)).await.unwrap_err();


### PR DESCRIPTION
It was quite a ride through the generics in this crate, but I finally found a solution for how to nicely decouple RPC services between modules or crates.

Importantly, it allows for an outer, app-level RPC service to delegate to inner services which are defined in other modules or crates. The inner services are regular quic-rpc services, and can even run on their own without the outer service. They take a single additional generic, so the code does not become horribly more generic.

See the [`modularize` example](https://github.com/n0-computer/quic-rpc/pull/67/files#diff-1e2caabb88ad7edadc4021df91911d45d413d0fbb10c8bd16684a4c88d55f82e) for a full, end-to-end example that composes RPC services from two different modules (which could be crates as well).

*Edit* I found a new approach that allows to compose services not only for two layers but infinitely. I updated the modularize example to have an additonal layer:
* App composes `iroh` and some app-owned RPC
* `iroh` composes two other services, `calc`  and `clock`

Note that the composition works equally for the server handler and a client wrapper. See the example.