### PR TITLE
Add TryServerStreaming interaction pattern

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,8 +51,6 @@ jobs:
             name: "Windows GNU"
         channel:
           - "stable"
-          - "beta"
-          - "nightly"
     steps:
       - uses: actions/checkout@v2
       - uses: dtolnay/rust-toolchain@master
@@ -84,7 +82,6 @@ jobs:
         channel:
           - "stable"
           - "beta"
-          - "nightly"
     steps:
       - uses: actions/checkout@v2
       - uses: dtolnay/rust-toolchain@master

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -143,9 +143,12 @@ dependencies = [
 
 [[package]]
 name = "convert_case"
-version = "0.4.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e"
+checksum = "ec182b0ca2f35d8fc196cf3404988fd8b8c739a4d270ff118a398feb0cbec1ca"
+dependencies = [
+ "unicode-segmentation",
+]
 
 [[package]]
 name = "core-foundation"
@@ -171,15 +174,24 @@ checksum = "7684a49fb1af197853ef7b2ee694bc1f5b4179556f1e5710e1760c5db6f5e929"
 
 [[package]]
 name = "derive_more"
-version = "0.99.17"
+version = "1.0.0-beta.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fb810d30a7c1953f91334de7244731fc3f3c10d7fe163338a35b9f640960321"
+checksum = "f7abbfc297053be59290e3152f8cbcd52c8642e0728b69ee187d991d4c1af08d"
+dependencies = [
+ "derive_more-impl",
+]
+
+[[package]]
+name = "derive_more-impl"
+version = "1.0.0-beta.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bba3e9872d7c58ce7ef0fcf1844fcc3e23ef2a58377b50df35dd98e42a5726e"
 dependencies = [
  "convert_case",
  "proc-macro2",
  "quote",
- "rustc_version",
- "syn 1.0.109",
+ "syn 2.0.28",
+ "unicode-xid",
 ]
 
 [[package]]
@@ -863,15 +875,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
-name = "rustc_version"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
-dependencies = [
- "semver",
-]
-
-[[package]]
 name = "rustix"
 version = "0.38.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -974,12 +977,6 @@ dependencies = [
  "core-foundation-sys",
  "libc",
 ]
-
-[[package]]
-name = "semver"
-version = "1.0.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0293b4b29daaf487284529cc2f5675b8e57c61f70167ba415a463651fd6a918"
 
 [[package]]
 name = "serde"
@@ -1334,6 +1331,18 @@ name = "unicode-ident"
 version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "301abaae475aa91687eb82514b328ab47a211a533026cb25fc3e519b86adfc3c"
+
+[[package]]
+name = "unicode-segmentation"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4c87d22b6e3f4a18d4d40ef354e97c90fcb14dd91d7dc0aa9d8a1172ebf7202"
+
+[[package]]
+name = "unicode-xid"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f962df74c8c05a667b5ee8bcf162993134c104e96440b663c8daa176dc772d8c"
 
 [[package]]
 name = "untrusted"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ futures = "0.3"
 hyper = { version = "0.14.16", features = ["full"], optional = true }
 pin-project = "1"
 quinn = { version = "0.10", optional = true }
-serde = { version = "1.0.183" }
+serde = { version = "1.0.183", features = ["derive"] }
 tokio = { version = "1", default-features = false, features = ["macros"] }
 tokio-serde = { version = "0.8", features = ["bincode"], optional = true }
 tokio-util = { version = "0.7", features = ["codec"], optional = true }
@@ -37,7 +37,7 @@ version = "0.4.20"
 [dev-dependencies]
 anyhow = "1.0.73"
 async-stream = "0.3.3"
-derive_more = "0.99.17"
+derive_more = { version = "1.0.0-beta.1", features = ["full"] }
 serde = { version = "1", features = ["derive"] }
 tokio = { version = "1", features = ["full"] }
 quinn = "0.10"

--- a/examples/split/types/Cargo.toml
+++ b/examples/split/types/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-derive_more = "0.99.17"
+derive_more = { version = "1.0.0-beta.1", features = ["from", "display", "try_into"] }
 futures = "0.3.26"
 quic-rpc = { path = "../../..", features = ["macros"] }
 serde = { version = "1", features = ["derive"] }

--- a/src/client.rs
+++ b/src/client.rs
@@ -3,18 +3,14 @@
 //! The main entry point is [RpcClient].
 use crate::{
     map::{ChainedMapper, MapService, Mapper},
-    message::{BidiStreamingMsg, ClientStreamingMsg, RpcMsg, ServerStreamingMsg},
-    transport::ConnectionErrors,
     Service, ServiceConnection,
 };
-use futures::{future::BoxFuture, FutureExt, Sink, SinkExt, Stream, StreamExt, TryFutureExt};
+use futures::{Sink, SinkExt, Stream};
 use pin_project::pin_project;
 use std::{
-    error,
-    fmt::{self, Debug},
+    fmt::Debug,
     marker::PhantomData,
     pin::Pin,
-    result,
     sync::Arc,
     task::{Context, Poll},
 };
@@ -46,9 +42,9 @@ impl<S, C: Clone, SInner> Clone for RpcClient<S, C, SInner> {
 #[pin_project]
 #[derive(Debug)]
 pub struct UpdateSink<S, C, T, SInner = S>(
-    #[pin] C::SendSink,
-    PhantomData<T>,
-    Arc<dyn MapService<S, SInner>>,
+    #[pin] pub C::SendSink,
+    pub PhantomData<T>,
+    pub Arc<dyn MapService<S, SInner>>,
 )
 where
     S: Service,
@@ -132,137 +128,6 @@ where
             map: Arc::new(map),
         }
     }
-
-    /// RPC call to the server, single request, single response
-    pub async fn rpc<M>(&self, msg: M) -> result::Result<M::Response, RpcClientError<C>>
-    where
-        M: RpcMsg<SInner>,
-    {
-        let msg = self.map.req_into_outer(msg.into());
-        let (mut send, mut recv) = self.source.open_bi().await.map_err(RpcClientError::Open)?;
-        send.send(msg).await.map_err(RpcClientError::<C>::Send)?;
-        let res = recv
-            .next()
-            .await
-            .ok_or(RpcClientError::<C>::EarlyClose)?
-            .map_err(RpcClientError::<C>::RecvError)?;
-        // keep send alive until we have the answer
-        drop(send);
-        let res = self
-            .map
-            .res_try_into_inner(res)
-            .map_err(|_| RpcClientError::DowncastError)?;
-        M::Response::try_from(res).map_err(|_| RpcClientError::DowncastError)
-    }
-
-    /// Bidi call to the server, request opens a stream, response is a stream
-    pub async fn server_streaming<M>(
-        &self,
-        msg: M,
-    ) -> result::Result<
-        BoxStreamSync<'static, result::Result<M::Response, StreamingResponseItemError<C>>>,
-        StreamingResponseError<C>,
-    >
-    where
-        M: ServerStreamingMsg<SInner>,
-    {
-        let msg = self.map.req_into_outer(msg.into());
-        let (mut send, recv) = self
-            .source
-            .open_bi()
-            .await
-            .map_err(StreamingResponseError::Open)?;
-        send.send(msg)
-            .map_err(StreamingResponseError::<C>::Send)
-            .await?;
-        let map = Arc::clone(&self.map);
-        let recv = recv.map(move |x| match x {
-            Ok(x) => {
-                let x = map
-                    .res_try_into_inner(x)
-                    .map_err(|_| StreamingResponseItemError::DowncastError)?;
-                M::Response::try_from(x).map_err(|_| StreamingResponseItemError::DowncastError)
-            }
-            Err(e) => Err(StreamingResponseItemError::RecvError(e)),
-        });
-        // keep send alive so the request on the server side does not get cancelled
-        let recv = Box::pin(DeferDrop(recv, send));
-        Ok(recv)
-    }
-
-    /// Call to the server that allows the client to stream, single response
-    pub async fn client_streaming<M>(
-        &self,
-        msg: M,
-    ) -> result::Result<
-        (
-            UpdateSink<S, C, M::Update, SInner>,
-            BoxFuture<'static, result::Result<M::Response, ClientStreamingItemError<C>>>,
-        ),
-        ClientStreamingError<C>,
-    >
-    where
-        M: ClientStreamingMsg<SInner>,
-    {
-        let msg = self.map.req_into_outer(msg.into());
-        let (mut send, mut recv) = self
-            .source
-            .open_bi()
-            .await
-            .map_err(ClientStreamingError::Open)?;
-        send.send(msg).map_err(ClientStreamingError::Send).await?;
-        let send = UpdateSink::<S, C, M::Update, SInner>(send, PhantomData, Arc::clone(&self.map));
-        let map = Arc::clone(&self.map);
-        let recv = async move {
-            let item = recv
-                .next()
-                .await
-                .ok_or(ClientStreamingItemError::EarlyClose)?;
-
-            match item {
-                Ok(x) => {
-                    let x = map
-                        .res_try_into_inner(x)
-                        .map_err(|_| ClientStreamingItemError::DowncastError)?;
-                    M::Response::try_from(x).map_err(|_| ClientStreamingItemError::DowncastError)
-                }
-                Err(e) => Err(ClientStreamingItemError::RecvError(e)),
-            }
-        }
-        .boxed();
-        Ok((send, recv))
-    }
-
-    /// Bidi call to the server, request opens a stream, response is a stream
-    pub async fn bidi<M>(
-        &self,
-        msg: M,
-    ) -> result::Result<
-        (
-            UpdateSink<S, C, M::Update, SInner>,
-            BoxStreamSync<'static, result::Result<M::Response, BidiItemError<C>>>,
-        ),
-        BidiError<C>,
-    >
-    where
-        M: BidiStreamingMsg<SInner>,
-    {
-        let msg = self.map.req_into_outer(msg.into());
-        let (mut send, recv) = self.source.open_bi().await.map_err(BidiError::Open)?;
-        send.send(msg).await.map_err(BidiError::<C>::Send)?;
-        let send = UpdateSink(send, PhantomData, Arc::clone(&self.map));
-        let map = Arc::clone(&self.map);
-        let recv = Box::pin(recv.map(move |x| match x {
-            Ok(x) => {
-                let x = map
-                    .res_try_into_inner(x)
-                    .map_err(|_| BidiItemError::DowncastError)?;
-                M::Response::try_from(x).map_err(|_| BidiItemError::DowncastError)
-            }
-            Err(e) => Err(BidiItemError::RecvError(e)),
-        }));
-        Ok((send, recv))
-    }
 }
 
 impl<S, C, SInner> AsRef<C> for RpcClient<S, C, SInner>
@@ -275,133 +140,6 @@ where
         &self.source
     }
 }
-
-/// Client error. All client DSL methods return a `Result` with this error type.
-#[derive(Debug)]
-pub enum RpcClientError<C: ConnectionErrors> {
-    /// Unable to open a substream at all
-    Open(C::OpenError),
-    /// Unable to send the request to the server
-    Send(C::SendError),
-    /// Server closed the stream before sending a response
-    EarlyClose,
-    /// Unable to receive the response from the server
-    RecvError(C::RecvError),
-    /// Unexpected response from the server
-    DowncastError,
-}
-
-impl<C: ConnectionErrors> fmt::Display for RpcClientError<C> {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        fmt::Debug::fmt(self, f)
-    }
-}
-
-impl<C: ConnectionErrors> error::Error for RpcClientError<C> {}
-
-/// Server error when accepting a bidi request
-#[derive(Debug)]
-pub enum BidiError<C: ConnectionErrors> {
-    /// Unable to open a substream at all
-    Open(C::OpenError),
-    /// Unable to send the request to the server
-    Send(C::SendError),
-}
-
-impl<C: ConnectionErrors> fmt::Display for BidiError<C> {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        fmt::Debug::fmt(self, f)
-    }
-}
-
-impl<C: ConnectionErrors> error::Error for BidiError<C> {}
-
-/// Server error when receiving an item for a bidi request
-#[derive(Debug)]
-pub enum BidiItemError<C: ConnectionErrors> {
-    /// Unable to receive the response from the server
-    RecvError(C::RecvError),
-    /// Unexpected response from the server
-    DowncastError,
-}
-
-impl<C: ConnectionErrors> fmt::Display for BidiItemError<C> {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        fmt::Debug::fmt(self, f)
-    }
-}
-
-impl<C: ConnectionErrors> error::Error for BidiItemError<C> {}
-
-/// Server error when accepting a client streaming request
-#[derive(Debug)]
-pub enum ClientStreamingError<C: ConnectionErrors> {
-    /// Unable to open a substream at all
-    Open(C::OpenError),
-    /// Unable to send the request to the server
-    Send(C::SendError),
-}
-
-impl<C: ConnectionErrors> fmt::Display for ClientStreamingError<C> {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        fmt::Debug::fmt(self, f)
-    }
-}
-
-impl<C: ConnectionErrors> error::Error for ClientStreamingError<C> {}
-
-/// Server error when receiving an item for a client streaming request
-#[derive(Debug)]
-pub enum ClientStreamingItemError<C: ConnectionErrors> {
-    /// Connection was closed before receiving the first message
-    EarlyClose,
-    /// Unable to receive the response from the server
-    RecvError(C::RecvError),
-    /// Unexpected response from the server
-    DowncastError,
-}
-
-impl<C: ConnectionErrors> fmt::Display for ClientStreamingItemError<C> {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        fmt::Debug::fmt(self, f)
-    }
-}
-
-impl<C: ConnectionErrors> error::Error for ClientStreamingItemError<C> {}
-
-/// Server error when accepting a server streaming request
-#[derive(Debug)]
-pub enum StreamingResponseError<C: ConnectionErrors> {
-    /// Unable to open a substream at all
-    Open(C::OpenError),
-    /// Unable to send the request to the server
-    Send(C::SendError),
-}
-
-impl<S: ConnectionErrors> fmt::Display for StreamingResponseError<S> {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        fmt::Debug::fmt(self, f)
-    }
-}
-
-impl<S: ConnectionErrors> error::Error for StreamingResponseError<S> {}
-
-/// Client error when handling responses from a server streaming request
-#[derive(Debug)]
-pub enum StreamingResponseItemError<S: ConnectionErrors> {
-    /// Unable to receive the response from the server
-    RecvError(S::RecvError),
-    /// Unexpected response from the server
-    DowncastError,
-}
-
-impl<S: ConnectionErrors> fmt::Display for StreamingResponseItemError<S> {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        fmt::Debug::fmt(self, f)
-    }
-}
-
-impl<S: ConnectionErrors> error::Error for StreamingResponseItemError<S> {}
 
 /// Wrap a stream with an additional item that is kept alive until the stream is dropped
 #[pin_project]

--- a/src/client.rs
+++ b/src/client.rs
@@ -28,8 +28,8 @@ pub type BoxStreamSync<'a, T> = Pin<Box<dyn Stream<Item = T> + Send + Sync + 'a>
 /// for the client DSL. `S` is the service type, `C` is the substream source.
 #[derive(Debug)]
 pub struct RpcClient<S, C, SInner = S> {
-    source: C,
-    map: Arc<dyn MapService<S, SInner>>,
+    pub(crate) source: C,
+    pub(crate) map: Arc<dyn MapService<S, SInner>>,
 }
 
 impl<S, C: Clone, SInner> Clone for RpcClient<S, C, SInner> {
@@ -405,7 +405,7 @@ impl<S: ConnectionErrors> error::Error for StreamingResponseItemError<S> {}
 
 /// Wrap a stream with an additional item that is kept alive until the stream is dropped
 #[pin_project]
-struct DeferDrop<S: Stream, X>(#[pin] S, X);
+pub(crate) struct DeferDrop<S: Stream, X>(#[pin] pub S, pub X);
 
 impl<S: Stream, X> Stream for DeferDrop<S, X> {
     type Item = S::Item;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -104,6 +104,8 @@ pub use server::RpcServer;
 mod macros;
 mod map;
 
+pub mod pattern;
+
 /// Requirements for a RPC message
 ///
 /// Even when just using the mem transport, we require messages to be Serializable and Deserializable.

--- a/src/message.rs
+++ b/src/message.rs
@@ -4,65 +4,17 @@
 use crate::Service;
 use std::fmt::Debug;
 
+pub use crate::pattern::bidi_streaming::{BidiStreaming, BidiStreamingMsg};
+pub use crate::pattern::client_streaming::{ClientStreaming, ClientStreamingMsg};
+pub use crate::pattern::rpc::{Rpc, RpcMsg};
+pub use crate::pattern::server_streaming::{ServerStreaming, ServerStreamingMsg};
+
 /// Declares the interaction pattern for a message and a service.
 ///
 /// For each server and each message, only one interaction pattern can be defined.
 pub trait Msg<S: Service>: Into<S::Req> + TryFrom<S::Req> + Send + 'static {
     /// The interaction pattern for this message with this service.
     type Pattern: InteractionPattern;
-}
-
-/// Defines the response type for a rpc message.
-///
-/// Since this is the most common interaction pattern, this also implements [Msg] for you
-/// automatically, with the interaction pattern set to [Rpc]. This is to reduce boilerplate
-/// when defining rpc messages.
-pub trait RpcMsg<S: Service>: Msg<S, Pattern = Rpc> {
-    /// The type for the response
-    ///
-    /// For requests that can produce errors, this can be set to [Result<T, E>](std::result::Result).
-    type Response: Into<S::Res> + TryFrom<S::Res> + Send + 'static;
-}
-
-/// We can only do this for one trait, so we do it for RpcMsg since it is the most common
-impl<T: RpcMsg<S>, S: Service> Msg<S> for T {
-    type Pattern = Rpc;
-}
-
-/// Defines update type and response type for a client streaming message.
-pub trait ClientStreamingMsg<S: Service>: Msg<S, Pattern = ClientStreaming> {
-    /// The type for request updates
-    ///
-    /// For a request that does not support updates, this can be safely set to any type, including
-    /// the message type itself. Any update for such a request will result in an error.
-    type Update: Into<S::Req> + TryFrom<S::Req> + Send + 'static;
-
-    /// The type for the response
-    ///
-    /// For requests that can produce errors, this can be set to [Result<T, E>](std::result::Result).
-    type Response: Into<S::Res> + TryFrom<S::Res> + Send + 'static;
-}
-
-/// Defines response type for a server streaming message.
-pub trait ServerStreamingMsg<S: Service>: Msg<S, Pattern = ServerStreaming> {
-    /// The type for the response
-    ///
-    /// For requests that can produce errors, this can be set to [Result<T, E>](std::result::Result).
-    type Response: Into<S::Res> + TryFrom<S::Res> + Send + 'static;
-}
-
-/// Defines update type and response type for a bidi streaming message.
-pub trait BidiStreamingMsg<S: Service>: Msg<S, Pattern = BidiStreaming> {
-    /// The type for request updates
-    ///
-    /// For a request that does not support updates, this can be safely set to any type, including
-    /// the message type itself. Any update for such a request will result in an error.
-    type Update: Into<S::Req> + TryFrom<S::Req> + Send + 'static;
-
-    /// The type for the response
-    ///
-    /// For requests that can produce errors, this can be set to [Result<T, E>](std::result::Result).
-    type Response: Into<S::Res> + TryFrom<S::Res> + Send + 'static;
 }
 
 /// Trait defining interaction pattern.
@@ -75,33 +27,3 @@ pub trait BidiStreamingMsg<S: Service>: Msg<S, Pattern = BidiStreaming> {
 ///
 /// You could define your own interaction patterns such as OneWay.
 pub trait InteractionPattern: Debug + Clone + Send + Sync + 'static {}
-
-/// Rpc interaction pattern
-///
-/// There is only one request and one response.
-#[derive(Debug, Clone, Copy)]
-pub struct Rpc;
-impl InteractionPattern for Rpc {}
-
-/// Client streaming interaction pattern
-///
-/// After the initial request, the client can send updates, but there is only
-/// one response.
-#[derive(Debug, Clone, Copy)]
-pub struct ClientStreaming;
-impl InteractionPattern for ClientStreaming {}
-
-/// Server streaming interaction pattern
-///
-/// After the initial request, the server can send a stream of responses.
-#[derive(Debug, Clone, Copy)]
-pub struct ServerStreaming;
-impl InteractionPattern for ServerStreaming {}
-
-/// Bidirectional streaming interaction pattern
-///
-/// After the initial request, the client can send updates and the server can
-/// send responses.
-#[derive(Debug, Clone, Copy)]
-pub struct BidiStreaming;
-impl InteractionPattern for BidiStreaming {}

--- a/src/pattern/bidi_streaming.rs
+++ b/src/pattern/bidi_streaming.rs
@@ -1,0 +1,154 @@
+//!
+use futures::{FutureExt, SinkExt, Stream, StreamExt};
+
+use crate::{
+    client::{BoxStreamSync, UpdateSink},
+    message::{InteractionPattern, Msg},
+    server::{race2, RpcChannel, RpcServerError, UpdateStream},
+    transport::ConnectionErrors,
+    RpcClient, Service, ServiceConnection, ServiceEndpoint,
+};
+
+use std::{
+    error,
+    fmt::{self, Debug},
+    marker::PhantomData,
+    result,
+    sync::Arc,
+};
+
+/// Bidirectional streaming interaction pattern
+///
+/// After the initial request, the client can send updates and the server can
+/// send responses.
+#[derive(Debug, Clone, Copy)]
+pub struct BidiStreaming;
+impl InteractionPattern for BidiStreaming {}
+
+/// Defines update type and response type for a bidi streaming message.
+pub trait BidiStreamingMsg<S: Service>: Msg<S, Pattern = BidiStreaming> {
+    /// The type for request updates
+    ///
+    /// For a request that does not support updates, this can be safely set to any type, including
+    /// the message type itself. Any update for such a request will result in an error.
+    type Update: Into<S::Req> + TryFrom<S::Req> + Send + 'static;
+
+    /// The type for the response
+    ///
+    /// For requests that can produce errors, this can be set to [Result<T, E>](std::result::Result).
+    type Response: Into<S::Res> + TryFrom<S::Res> + Send + 'static;
+}
+
+/// Server error when accepting a bidi request
+#[derive(Debug)]
+pub enum Error<C: ConnectionErrors> {
+    /// Unable to open a substream at all
+    Open(C::OpenError),
+    /// Unable to send the request to the server
+    Send(C::SendError),
+}
+
+impl<C: ConnectionErrors> fmt::Display for Error<C> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Debug::fmt(self, f)
+    }
+}
+
+impl<C: ConnectionErrors> error::Error for Error<C> {}
+
+/// Server error when receiving an item for a bidi request
+#[derive(Debug)]
+pub enum ItemError<C: ConnectionErrors> {
+    /// Unable to receive the response from the server
+    RecvError(C::RecvError),
+    /// Unexpected response from the server
+    DowncastError,
+}
+
+impl<C: ConnectionErrors> fmt::Display for ItemError<C> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Debug::fmt(self, f)
+    }
+}
+
+impl<C: ConnectionErrors> error::Error for ItemError<C> {}
+
+impl<S, C, SInner> RpcClient<S, C, SInner>
+where
+    S: Service,
+    C: ServiceConnection<S>,
+    SInner: Service,
+{
+    /// Bidi call to the server, request opens a stream, response is a stream
+    pub async fn bidi<M>(
+        &self,
+        msg: M,
+    ) -> result::Result<
+        (
+            UpdateSink<S, C, M::Update, SInner>,
+            BoxStreamSync<'static, result::Result<M::Response, ItemError<C>>>,
+        ),
+        Error<C>,
+    >
+    where
+        M: BidiStreamingMsg<SInner>,
+    {
+        let msg = self.map.req_into_outer(msg.into());
+        let (mut send, recv) = self.source.open_bi().await.map_err(Error::Open)?;
+        send.send(msg).await.map_err(Error::<C>::Send)?;
+        let send = UpdateSink(send, PhantomData, Arc::clone(&self.map));
+        let map = Arc::clone(&self.map);
+        let recv = Box::pin(recv.map(move |x| match x {
+            Ok(x) => {
+                let x = map
+                    .res_try_into_inner(x)
+                    .map_err(|_| ItemError::DowncastError)?;
+                M::Response::try_from(x).map_err(|_| ItemError::DowncastError)
+            }
+            Err(e) => Err(ItemError::RecvError(e)),
+        }));
+        Ok((send, recv))
+    }
+}
+
+impl<S, C, SInner> RpcChannel<S, C, SInner>
+where
+    S: Service,
+    C: ServiceEndpoint<S>,
+    SInner: Service,
+{
+    /// handle the message M using the given function on the target object
+    ///
+    /// If you want to support concurrent requests, you need to spawn this on a tokio task yourself.
+    pub async fn bidi_streaming<M, F, Str, T>(
+        self,
+        req: M,
+        target: T,
+        f: F,
+    ) -> result::Result<(), RpcServerError<C>>
+    where
+        M: BidiStreamingMsg<SInner>,
+        F: FnOnce(T, M, UpdateStream<S, C, M::Update, SInner>) -> Str + Send + 'static,
+        Str: Stream<Item = M::Response> + Send + 'static,
+        T: Send + 'static,
+    {
+        let Self { mut send, recv, .. } = self;
+        // downcast the updates
+        let (updates, read_error) = UpdateStream::new(recv, Arc::clone(&self.map));
+        // get the response
+        let responses = f(target, req, updates);
+        race2(read_error.map(Err), async move {
+            tokio::pin!(responses);
+            while let Some(response) = responses.next().await {
+                // turn into a S::Res so we can send it
+                let response = self.map.res_into_outer(response.into());
+                // send it and return the error if any
+                send.send(response)
+                    .await
+                    .map_err(RpcServerError::SendError)?;
+            }
+            Ok(())
+        })
+        .await
+    }
+}

--- a/src/pattern/client_streaming.rs
+++ b/src/pattern/client_streaming.rs
@@ -1,0 +1,154 @@
+//!
+use futures::{future::BoxFuture, Future, FutureExt, SinkExt, StreamExt, TryFutureExt};
+
+use crate::{
+    client::UpdateSink,
+    message::{InteractionPattern, Msg},
+    server::{race2, RpcChannel, RpcServerError, UpdateStream},
+    transport::ConnectionErrors,
+    RpcClient, Service, ServiceConnection, ServiceEndpoint,
+};
+
+use std::{
+    error,
+    fmt::{self, Debug},
+    marker::PhantomData,
+    result,
+    sync::Arc,
+};
+
+/// Client streaming interaction pattern
+///
+/// After the initial request, the client can send updates, but there is only
+/// one response.
+#[derive(Debug, Clone, Copy)]
+pub struct ClientStreaming;
+impl InteractionPattern for ClientStreaming {}
+
+/// Defines update type and response type for a client streaming message.
+pub trait ClientStreamingMsg<S: Service>: Msg<S, Pattern = ClientStreaming> {
+    /// The type for request updates
+    ///
+    /// For a request that does not support updates, this can be safely set to any type, including
+    /// the message type itself. Any update for such a request will result in an error.
+    type Update: Into<S::Req> + TryFrom<S::Req> + Send + 'static;
+
+    /// The type for the response
+    ///
+    /// For requests that can produce errors, this can be set to [Result<T, E>](std::result::Result).
+    type Response: Into<S::Res> + TryFrom<S::Res> + Send + 'static;
+}
+
+/// Server error when accepting a client streaming request
+#[derive(Debug)]
+pub enum Error<C: ConnectionErrors> {
+    /// Unable to open a substream at all
+    Open(C::OpenError),
+    /// Unable to send the request to the server
+    Send(C::SendError),
+}
+
+impl<C: ConnectionErrors> fmt::Display for Error<C> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Debug::fmt(self, f)
+    }
+}
+
+impl<C: ConnectionErrors> error::Error for Error<C> {}
+
+/// Server error when receiving an item for a client streaming request
+#[derive(Debug)]
+pub enum ItemError<C: ConnectionErrors> {
+    /// Connection was closed before receiving the first message
+    EarlyClose,
+    /// Unable to receive the response from the server
+    RecvError(C::RecvError),
+    /// Unexpected response from the server
+    DowncastError,
+}
+
+impl<C: ConnectionErrors> fmt::Display for ItemError<C> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Debug::fmt(self, f)
+    }
+}
+
+impl<C: ConnectionErrors> error::Error for ItemError<C> {}
+
+impl<S, C, SInner> RpcClient<S, C, SInner>
+where
+    S: Service,
+    C: ServiceConnection<S>,
+    SInner: Service,
+{
+    /// Call to the server that allows the client to stream, single response
+    pub async fn client_streaming<M>(
+        &self,
+        msg: M,
+    ) -> result::Result<
+        (
+            UpdateSink<S, C, M::Update, SInner>,
+            BoxFuture<'static, result::Result<M::Response, ItemError<C>>>,
+        ),
+        Error<C>,
+    >
+    where
+        M: ClientStreamingMsg<SInner>,
+    {
+        let msg = self.map.req_into_outer(msg.into());
+        let (mut send, mut recv) = self.source.open_bi().await.map_err(Error::Open)?;
+        send.send(msg).map_err(Error::Send).await?;
+        let send = UpdateSink::<S, C, M::Update, SInner>(send, PhantomData, Arc::clone(&self.map));
+        let map = Arc::clone(&self.map);
+        let recv = async move {
+            let item = recv.next().await.ok_or(ItemError::EarlyClose)?;
+
+            match item {
+                Ok(x) => {
+                    let x = map
+                        .res_try_into_inner(x)
+                        .map_err(|_| ItemError::DowncastError)?;
+                    M::Response::try_from(x).map_err(|_| ItemError::DowncastError)
+                }
+                Err(e) => Err(ItemError::RecvError(e)),
+            }
+        }
+        .boxed();
+        Ok((send, recv))
+    }
+}
+
+impl<S, C, SInner> RpcChannel<S, C, SInner>
+where
+    S: Service,
+    C: ServiceEndpoint<S>,
+    SInner: Service,
+{
+    /// handle the message M using the given function on the target object
+    ///
+    /// If you want to support concurrent requests, you need to spawn this on a tokio task yourself.
+    pub async fn client_streaming<M, F, Fut, T>(
+        self,
+        req: M,
+        target: T,
+        f: F,
+    ) -> result::Result<(), RpcServerError<C>>
+    where
+        M: ClientStreamingMsg<SInner>,
+        F: FnOnce(T, M, UpdateStream<S, C, M::Update, SInner>) -> Fut + Send + 'static,
+        Fut: Future<Output = M::Response> + Send + 'static,
+        T: Send + 'static,
+    {
+        let Self { mut send, recv, .. } = self;
+        let (updates, read_error) = UpdateStream::new(recv, Arc::clone(&self.map));
+        race2(read_error.map(Err), async move {
+            // get the response
+            let res = f(target, req, updates).await;
+            // turn into a S::Res so we can send it
+            let res = self.map.res_into_outer(res.into());
+            // send it and return the error if any
+            send.send(res).await.map_err(RpcServerError::SendError)
+        })
+        .await
+    }
+}

--- a/src/pattern/mod.rs
+++ b/src/pattern/mod.rs
@@ -1,0 +1,2 @@
+//!
+pub mod try_server_streaming;

--- a/src/pattern/mod.rs
+++ b/src/pattern/mod.rs
@@ -1,4 +1,9 @@
+//! Predefined interaction patterns.
 //!
+//! An interaction pattern can be as simple as an rpc call or something more
+//! complex such as bidirectional streaming.
+//!
+//! Each pattern defines different associated message types for the interaction.
 pub mod bidi_streaming;
 pub mod client_streaming;
 pub mod rpc;

--- a/src/pattern/mod.rs
+++ b/src/pattern/mod.rs
@@ -1,2 +1,6 @@
 //!
+pub mod bidi_streaming;
+pub mod client_streaming;
+pub mod rpc;
+pub mod server_streaming;
 pub mod try_server_streaming;

--- a/src/pattern/rpc.rs
+++ b/src/pattern/rpc.rs
@@ -1,0 +1,158 @@
+//!
+use futures::{Future, FutureExt, SinkExt, StreamExt};
+
+use crate::{
+    message::{InteractionPattern, Msg},
+    server::{race2, RpcChannel, RpcServerError},
+    transport::ConnectionErrors,
+    RpcClient, Service, ServiceConnection, ServiceEndpoint,
+};
+
+use std::{
+    error,
+    fmt::{self, Debug},
+    result,
+};
+
+/// Rpc interaction pattern
+///
+/// There is only one request and one response.
+#[derive(Debug, Clone, Copy)]
+pub struct Rpc;
+impl InteractionPattern for Rpc {}
+
+/// Defines the response type for a rpc message.
+///
+/// Since this is the most common interaction pattern, this also implements [Msg] for you
+/// automatically, with the interaction pattern set to [Rpc]. This is to reduce boilerplate
+/// when defining rpc messages.
+pub trait RpcMsg<S: Service>: Msg<S, Pattern = Rpc> {
+    /// The type for the response
+    ///
+    /// For requests that can produce errors, this can be set to [Result<T, E>](std::result::Result).
+    type Response: Into<S::Res> + TryFrom<S::Res> + Send + 'static;
+}
+
+/// We can only do this for one trait, so we do it for RpcMsg since it is the most common
+impl<T: RpcMsg<S>, S: Service> Msg<S> for T {
+    type Pattern = Rpc;
+}
+/// Client error. All client DSL methods return a `Result` with this error type.
+#[derive(Debug)]
+pub enum Error<C: ConnectionErrors> {
+    /// Unable to open a substream at all
+    Open(C::OpenError),
+    /// Unable to send the request to the server
+    Send(C::SendError),
+    /// Server closed the stream before sending a response
+    EarlyClose,
+    /// Unable to receive the response from the server
+    RecvError(C::RecvError),
+    /// Unexpected response from the server
+    DowncastError,
+}
+
+impl<C: ConnectionErrors> fmt::Display for Error<C> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Debug::fmt(self, f)
+    }
+}
+
+impl<C: ConnectionErrors> error::Error for Error<C> {}
+
+impl<S, C, SInner> RpcClient<S, C, SInner>
+where
+    S: Service,
+    C: ServiceConnection<S>,
+    SInner: Service,
+{
+    /// RPC call to the server, single request, single response
+    pub async fn rpc<M>(&self, msg: M) -> result::Result<M::Response, Error<C>>
+    where
+        M: RpcMsg<SInner>,
+    {
+        let msg = self.map.req_into_outer(msg.into());
+        let (mut send, mut recv) = self.source.open_bi().await.map_err(Error::Open)?;
+        send.send(msg).await.map_err(Error::<C>::Send)?;
+        let res = recv
+            .next()
+            .await
+            .ok_or(Error::<C>::EarlyClose)?
+            .map_err(Error::<C>::RecvError)?;
+        // keep send alive until we have the answer
+        drop(send);
+        let res = self
+            .map
+            .res_try_into_inner(res)
+            .map_err(|_| Error::DowncastError)?;
+        M::Response::try_from(res).map_err(|_| Error::DowncastError)
+    }
+}
+
+impl<S, C, SInner> RpcChannel<S, C, SInner>
+where
+    S: Service,
+    C: ServiceEndpoint<S>,
+    SInner: Service,
+{
+    /// handle the message of type `M` using the given function on the target object
+    ///
+    /// If you want to support concurrent requests, you need to spawn this on a tokio task yourself.
+    pub async fn rpc<M, F, Fut, T>(
+        self,
+        req: M,
+        target: T,
+        f: F,
+    ) -> result::Result<(), RpcServerError<C>>
+    where
+        M: RpcMsg<SInner>,
+        F: FnOnce(T, M) -> Fut,
+        Fut: Future<Output = M::Response>,
+        T: Send + 'static,
+    {
+        let Self {
+            mut send, mut recv, ..
+        } = self;
+        // cancel if we get an update, no matter what it is
+        let cancel = recv
+            .next()
+            .map(|_| RpcServerError::UnexpectedUpdateMessage::<C>);
+        // race the computation and the cancellation
+        race2(cancel.map(Err), async move {
+            // get the response
+            let res = f(target, req).await;
+            // turn into a S::Res so we can send it
+            let res = self.map.res_into_outer(res.into());
+            // send it and return the error if any
+            send.send(res).await.map_err(RpcServerError::SendError)
+        })
+        .await
+    }
+
+    /// A rpc call that also maps the error from the user type to the wire type
+    ///
+    /// This is useful if you want to write your function with a convenient error type like anyhow::Error,
+    /// yet still use a serializable error type on the wire.
+    pub async fn rpc_map_err<M, F, Fut, T, R, E1, E2>(
+        self,
+        req: M,
+        target: T,
+        f: F,
+    ) -> result::Result<(), RpcServerError<C>>
+    where
+        M: RpcMsg<SInner, Response = result::Result<R, E2>>,
+        F: FnOnce(T, M) -> Fut,
+        Fut: Future<Output = result::Result<R, E1>>,
+        E2: From<E1>,
+        T: Send + 'static,
+    {
+        let fut = |target: T, msg: M| async move {
+            // call the inner fn
+            let res: Result<R, E1> = f(target, msg).await;
+            // convert the error type
+            let res: Result<R, E2> = res.map_err(E2::from);
+            res
+        };
+        self.rpc(req, target, fut).await
+    }
+}

--- a/src/pattern/server_streaming.rs
+++ b/src/pattern/server_streaming.rs
@@ -1,0 +1,146 @@
+//!
+use futures::{FutureExt, SinkExt, Stream, StreamExt, TryFutureExt};
+
+use crate::{
+    client::{BoxStreamSync, DeferDrop},
+    message::{InteractionPattern, Msg},
+    server::{race2, RpcChannel, RpcServerError},
+    transport::ConnectionErrors,
+    RpcClient, Service, ServiceConnection, ServiceEndpoint,
+};
+
+use std::{
+    error,
+    fmt::{self, Debug},
+    result,
+    sync::Arc,
+};
+
+/// Server streaming interaction pattern
+///
+/// After the initial request, the server can send a stream of responses.
+#[derive(Debug, Clone, Copy)]
+pub struct ServerStreaming;
+impl InteractionPattern for ServerStreaming {}
+
+/// Defines response type for a server streaming message.
+pub trait ServerStreamingMsg<S: Service>: Msg<S, Pattern = ServerStreaming> {
+    /// The type for the response
+    ///
+    /// For requests that can produce errors, this can be set to [Result<T, E>](std::result::Result).
+    type Response: Into<S::Res> + TryFrom<S::Res> + Send + 'static;
+}
+
+/// Server error when accepting a server streaming request
+#[derive(Debug)]
+pub enum Error<C: ConnectionErrors> {
+    /// Unable to open a substream at all
+    Open(C::OpenError),
+    /// Unable to send the request to the server
+    Send(C::SendError),
+}
+
+impl<S: ConnectionErrors> fmt::Display for Error<S> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Debug::fmt(self, f)
+    }
+}
+
+impl<S: ConnectionErrors> error::Error for Error<S> {}
+
+/// Client error when handling responses from a server streaming request
+#[derive(Debug)]
+pub enum ItemError<S: ConnectionErrors> {
+    /// Unable to receive the response from the server
+    RecvError(S::RecvError),
+    /// Unexpected response from the server
+    DowncastError,
+}
+
+impl<S: ConnectionErrors> fmt::Display for ItemError<S> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Debug::fmt(self, f)
+    }
+}
+
+impl<S: ConnectionErrors> error::Error for ItemError<S> {}
+
+impl<S, C, SInner> RpcClient<S, C, SInner>
+where
+    S: Service,
+    C: ServiceConnection<S>,
+    SInner: Service,
+{
+    /// Bidi call to the server, request opens a stream, response is a stream
+    pub async fn server_streaming<M>(
+        &self,
+        msg: M,
+    ) -> result::Result<BoxStreamSync<'static, result::Result<M::Response, ItemError<C>>>, Error<C>>
+    where
+        M: ServerStreamingMsg<SInner>,
+    {
+        let msg = self.map.req_into_outer(msg.into());
+        let (mut send, recv) = self.source.open_bi().await.map_err(Error::Open)?;
+        send.send(msg).map_err(Error::<C>::Send).await?;
+        let map = Arc::clone(&self.map);
+        let recv = recv.map(move |x| match x {
+            Ok(x) => {
+                let x = map
+                    .res_try_into_inner(x)
+                    .map_err(|_| ItemError::DowncastError)?;
+                M::Response::try_from(x).map_err(|_| ItemError::DowncastError)
+            }
+            Err(e) => Err(ItemError::RecvError(e)),
+        });
+        // keep send alive so the request on the server side does not get cancelled
+        let recv = Box::pin(DeferDrop(recv, send));
+        Ok(recv)
+    }
+}
+
+impl<S, C, SInner> RpcChannel<S, C, SInner>
+where
+    S: Service,
+    C: ServiceEndpoint<S>,
+    SInner: Service,
+{
+    /// handle the message M using the given function on the target object
+    ///
+    /// If you want to support concurrent requests, you need to spawn this on a tokio task yourself.
+    pub async fn server_streaming<M, F, Str, T>(
+        self,
+        req: M,
+        target: T,
+        f: F,
+    ) -> result::Result<(), RpcServerError<C>>
+    where
+        M: ServerStreamingMsg<SInner>,
+        F: FnOnce(T, M) -> Str + Send + 'static,
+        Str: Stream<Item = M::Response> + Send + 'static,
+        T: Send + 'static,
+    {
+        let Self {
+            mut send, mut recv, ..
+        } = self;
+        // cancel if we get an update, no matter what it is
+        let cancel = recv
+            .next()
+            .map(|_| RpcServerError::UnexpectedUpdateMessage::<C>);
+        // race the computation and the cancellation
+        race2(cancel.map(Err), async move {
+            // get the response
+            let responses = f(target, req);
+            tokio::pin!(responses);
+            while let Some(response) = responses.next().await {
+                // turn into a S::Res so we can send it
+                let response = self.map.res_into_outer(response.into());
+                // send it and return the error if any
+                send.send(response)
+                    .await
+                    .map_err(RpcServerError::SendError)?;
+            }
+            Ok(())
+        })
+        .await
+    }
+}

--- a/src/pattern/try_server_streaming.rs
+++ b/src/pattern/try_server_streaming.rs
@@ -1,0 +1,214 @@
+//!
+use futures::{FutureExt, SinkExt, Stream, StreamExt, TryFutureExt};
+use serde::{Deserialize, Serialize};
+
+use crate::{
+    client::{BoxStreamSync, DeferDrop},
+    message::{InteractionPattern, Msg},
+    server::{race2, RpcChannel, RpcServerError},
+    transport::ConnectionErrors,
+    RpcClient, Service, ServiceConnection, ServiceEndpoint,
+};
+
+use std::{
+    error,
+    fmt::{self, Debug},
+    result,
+    sync::Arc,
+};
+
+///
+#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
+pub struct StreamCreated;
+
+///
+#[derive(Debug, Clone, Copy)]
+pub struct TryServerStreaming;
+
+impl InteractionPattern for TryServerStreaming {}
+
+/// Same as [ServerStreamingMsg], but with lazy stream creation and the error type explicitly defined.
+pub trait TryServerStreamingMsg<S: Service>: Msg<S, Pattern = TryServerStreaming>
+where
+    std::result::Result<Self::Item, Self::ItemError>: Into<S::Res> + TryFrom<S::Res>,
+    std::result::Result<StreamCreated, Self::CreateError>: Into<S::Res> + TryFrom<S::Res>,
+{
+    /// Error when creating the stream
+    type CreateError: Debug + Send + 'static;
+
+    /// Error for stream items
+    type ItemError: Debug + Send + 'static;
+
+    /// The type for the response
+    ///
+    /// For requests that can produce errors, this can be set to [Result<T, E>](std::result::Result).
+    type Item: Send + 'static;
+}
+
+/// Server error when accepting a server streaming request
+///
+/// This combines network errors with application errors. Usually you don't
+/// care about the exact nature of the error, but if you want to handle
+/// application errors differently, you can match on this enum.
+#[derive(Debug)]
+pub enum Error<C: ConnectionErrors, E: Debug> {
+    /// Unable to open a substream at all
+    Open(C::OpenError),
+    /// Unable to send the request to the server
+    Send(C::SendError),
+    /// Error received when creating the stream
+    Recv(C::RecvError),
+    /// Connection was closed before receiving the first message
+    EarlyClose,
+    /// Unexpected response from the server
+    Downcast,
+    /// Application error
+    Application(E),
+}
+
+impl<S: ConnectionErrors, E: Debug> fmt::Display for Error<S, E> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Debug::fmt(self, f)
+    }
+}
+
+impl<S: ConnectionErrors, E: Debug> error::Error for Error<S, E> {}
+
+/// Client error when handling responses from a server streaming request
+#[derive(Debug)]
+pub enum ItemError<S: ConnectionErrors, E: Debug> {
+    /// Unable to receive the response from the server
+    Recv(S::RecvError),
+    /// Unexpected response from the server
+    Downcast,
+    /// Application error
+    Application(E),
+}
+
+impl<S: ConnectionErrors, E: Debug> fmt::Display for ItemError<S, E> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Debug::fmt(self, f)
+    }
+}
+
+impl<S: ConnectionErrors, E: Debug> error::Error for ItemError<S, E> {}
+
+impl<S, C, SInner> RpcChannel<S, C, SInner>
+where
+    S: Service,
+    C: ServiceEndpoint<S>,
+    SInner: Service,
+{
+    /// handle the message M using the given function on the target object
+    ///
+    /// If you want to support concurrent requests, you need to spawn this on a tokio task yourself.
+    ///
+    /// Compared to [RpcChannel::server_streaming], with this method the stream creation is via
+    /// a function that returns a future that resolves to a stream.
+    pub async fn try_server_streaming<M, F, Fut, Str, T>(
+        self,
+        req: M,
+        target: T,
+        f: F,
+    ) -> result::Result<(), RpcServerError<C>>
+    where
+        M: TryServerStreamingMsg<SInner>,
+        std::result::Result<M::Item, M::ItemError>: Into<SInner::Res> + TryFrom<SInner::Res>,
+        std::result::Result<StreamCreated, M::CreateError>:
+            Into<SInner::Res> + TryFrom<SInner::Res>,
+        F: FnOnce(T, M) -> Fut + Send + 'static,
+        Fut: futures::Future<Output = std::result::Result<Str, M::CreateError>> + Send + 'static,
+        Str: Stream<Item = std::result::Result<M::Item, M::ItemError>> + Send + 'static,
+        T: Send + 'static,
+    {
+        let Self {
+            mut send, mut recv, ..
+        } = self;
+        // cancel if we get an update, no matter what it is
+        let cancel = recv
+            .next()
+            .map(|_| RpcServerError::UnexpectedUpdateMessage::<C>);
+        // race the computation and the cancellation
+        race2(cancel.map(Err), async move {
+            // get the response
+            let responses = match f(target, req).await {
+                Ok(responses) => {
+                    // turn into a S::Res so we can send it
+                    let response = self.map.res_into_outer(Ok(StreamCreated).into());
+                    // send it and return the error if any
+                    send.send(response)
+                        .await
+                        .map_err(RpcServerError::SendError)?;
+                    responses
+                }
+                Err(cause) => {
+                    // turn into a S::Res so we can send it
+                    let response = self.map.res_into_outer(Err(cause).into());
+                    // send it and return the error if any
+                    send.send(response)
+                        .await
+                        .map_err(RpcServerError::SendError)?;
+                    return Ok(());
+                }
+            };
+            tokio::pin!(responses);
+            while let Some(response) = responses.next().await {
+                // turn into a S::Res so we can send it
+                let response = self.map.res_into_outer(response.into());
+                // send it and return the error if any
+                send.send(response)
+                    .await
+                    .map_err(RpcServerError::SendError)?;
+            }
+            Ok(())
+        })
+        .await
+    }
+}
+
+impl<S, C, SInner> RpcClient<S, C, SInner>
+where
+    S: Service,
+    C: ServiceConnection<S>,
+    SInner: Service,
+{
+    /// Bidi call to the server, request opens a stream, response is a stream
+    pub async fn try_server_streaming<M>(
+        &self,
+        msg: M,
+    ) -> result::Result<
+        BoxStreamSync<'static, Result<M::Item, ItemError<C, M::ItemError>>>,
+        Error<C, M::CreateError>,
+    >
+    where
+        M: TryServerStreamingMsg<SInner>,
+        Result<M::Item, M::ItemError>: Into<SInner::Res> + TryFrom<SInner::Res>,
+        Result<StreamCreated, M::CreateError>: Into<SInner::Res> + TryFrom<SInner::Res>,
+    {
+        let msg = self.map.req_into_outer(msg.into());
+        let (mut send, mut recv) = self.source.open_bi().await.map_err(Error::Open)?;
+        send.send(msg).map_err(Error::Send).await?;
+        let map = Arc::clone(&self.map);
+        let Some(initial) = recv.next().await else {
+            return Err(Error::EarlyClose);
+        };
+        let initial = initial.map_err(Error::Recv)?; // initial response
+        let initial = map
+            .res_try_into_inner(initial)
+            .map_err(|_| Error::Downcast)?;
+        let initial = <std::result::Result<StreamCreated, M::CreateError>>::try_from(initial)
+            .map_err(|_| Error::Downcast)?;
+        let _ = initial.map_err(Error::Application)?;
+        let recv = recv.map(move |x| {
+            let x = x.map_err(ItemError::Recv)?;
+            let x = map.res_try_into_inner(x).map_err(|_| ItemError::Downcast)?;
+            let x = <std::result::Result<M::Item, M::ItemError>>::try_from(x)
+                .map_err(|_| ItemError::Downcast)?;
+            let x = x.map_err(ItemError::Application)?;
+            Ok(x)
+        });
+        // keep send alive so the request on the server side does not get cancelled
+        let recv = Box::pin(DeferDrop(recv, send));
+        Ok(recv)
+    }
+}

--- a/src/server.rs
+++ b/src/server.rs
@@ -3,11 +3,10 @@
 //! The main entry point is [RpcServer]
 use crate::{
     map::{ChainedMapper, MapService, Mapper},
-    message::{BidiStreamingMsg, ClientStreamingMsg, RpcMsg, ServerStreamingMsg},
     transport::ConnectionErrors,
     Service, ServiceEndpoint,
 };
-use futures::{channel::oneshot, task, task::Poll, Future, FutureExt, SinkExt, Stream, StreamExt};
+use futures::{channel::oneshot, task, task::Poll, Future, FutureExt, Stream, StreamExt};
 use pin_project::pin_project;
 use std::{
     error,
@@ -114,170 +113,6 @@ where
             map: Arc::new(map),
         }
     }
-
-    /// handle the message of type `M` using the given function on the target object
-    ///
-    /// If you want to support concurrent requests, you need to spawn this on a tokio task yourself.
-    pub async fn rpc<M, F, Fut, T>(
-        self,
-        req: M,
-        target: T,
-        f: F,
-    ) -> result::Result<(), RpcServerError<C>>
-    where
-        M: RpcMsg<SInner>,
-        F: FnOnce(T, M) -> Fut,
-        Fut: Future<Output = M::Response>,
-        T: Send + 'static,
-    {
-        let Self {
-            mut send, mut recv, ..
-        } = self;
-        // cancel if we get an update, no matter what it is
-        let cancel = recv
-            .next()
-            .map(|_| RpcServerError::UnexpectedUpdateMessage::<C>);
-        // race the computation and the cancellation
-        race2(cancel.map(Err), async move {
-            // get the response
-            let res = f(target, req).await;
-            // turn into a S::Res so we can send it
-            let res = self.map.res_into_outer(res.into());
-            // send it and return the error if any
-            send.send(res).await.map_err(RpcServerError::SendError)
-        })
-        .await
-    }
-
-    /// handle the message M using the given function on the target object
-    ///
-    /// If you want to support concurrent requests, you need to spawn this on a tokio task yourself.
-    pub async fn client_streaming<M, F, Fut, T>(
-        self,
-        req: M,
-        target: T,
-        f: F,
-    ) -> result::Result<(), RpcServerError<C>>
-    where
-        M: ClientStreamingMsg<SInner>,
-        F: FnOnce(T, M, UpdateStream<S, C, M::Update, SInner>) -> Fut + Send + 'static,
-        Fut: Future<Output = M::Response> + Send + 'static,
-        T: Send + 'static,
-    {
-        let Self { mut send, recv, .. } = self;
-        let (updates, read_error) = UpdateStream::new(recv, Arc::clone(&self.map));
-        race2(read_error.map(Err), async move {
-            // get the response
-            let res = f(target, req, updates).await;
-            // turn into a S::Res so we can send it
-            let res = self.map.res_into_outer(res.into());
-            // send it and return the error if any
-            send.send(res).await.map_err(RpcServerError::SendError)
-        })
-        .await
-    }
-
-    /// handle the message M using the given function on the target object
-    ///
-    /// If you want to support concurrent requests, you need to spawn this on a tokio task yourself.
-    pub async fn bidi_streaming<M, F, Str, T>(
-        self,
-        req: M,
-        target: T,
-        f: F,
-    ) -> result::Result<(), RpcServerError<C>>
-    where
-        M: BidiStreamingMsg<SInner>,
-        F: FnOnce(T, M, UpdateStream<S, C, M::Update, SInner>) -> Str + Send + 'static,
-        Str: Stream<Item = M::Response> + Send + 'static,
-        T: Send + 'static,
-    {
-        let Self { mut send, recv, .. } = self;
-        // downcast the updates
-        let (updates, read_error) = UpdateStream::new(recv, Arc::clone(&self.map));
-        // get the response
-        let responses = f(target, req, updates);
-        race2(read_error.map(Err), async move {
-            tokio::pin!(responses);
-            while let Some(response) = responses.next().await {
-                // turn into a S::Res so we can send it
-                let response = self.map.res_into_outer(response.into());
-                // send it and return the error if any
-                send.send(response)
-                    .await
-                    .map_err(RpcServerError::SendError)?;
-            }
-            Ok(())
-        })
-        .await
-    }
-
-    /// handle the message M using the given function on the target object
-    ///
-    /// If you want to support concurrent requests, you need to spawn this on a tokio task yourself.
-    pub async fn server_streaming<M, F, Str, T>(
-        self,
-        req: M,
-        target: T,
-        f: F,
-    ) -> result::Result<(), RpcServerError<C>>
-    where
-        M: ServerStreamingMsg<SInner>,
-        F: FnOnce(T, M) -> Str + Send + 'static,
-        Str: Stream<Item = M::Response> + Send + 'static,
-        T: Send + 'static,
-    {
-        let Self {
-            mut send, mut recv, ..
-        } = self;
-        // cancel if we get an update, no matter what it is
-        let cancel = recv
-            .next()
-            .map(|_| RpcServerError::UnexpectedUpdateMessage::<C>);
-        // race the computation and the cancellation
-        race2(cancel.map(Err), async move {
-            // get the response
-            let responses = f(target, req);
-            tokio::pin!(responses);
-            while let Some(response) = responses.next().await {
-                // turn into a S::Res so we can send it
-                let response = self.map.res_into_outer(response.into());
-                // send it and return the error if any
-                send.send(response)
-                    .await
-                    .map_err(RpcServerError::SendError)?;
-            }
-            Ok(())
-        })
-        .await
-    }
-
-    /// A rpc call that also maps the error from the user type to the wire type
-    ///
-    /// This is useful if you want to write your function with a convenient error type like anyhow::Error,
-    /// yet still use a serializable error type on the wire.
-    pub async fn rpc_map_err<M, F, Fut, T, R, E1, E2>(
-        self,
-        req: M,
-        target: T,
-        f: F,
-    ) -> result::Result<(), RpcServerError<C>>
-    where
-        M: RpcMsg<SInner, Response = result::Result<R, E2>>,
-        F: FnOnce(T, M) -> Fut,
-        Fut: Future<Output = result::Result<R, E1>>,
-        E2: From<E1>,
-        T: Send + 'static,
-    {
-        let fut = |target: T, msg: M| async move {
-            // call the inner fn
-            let res: Result<R, E1> = f(target, msg).await;
-            // convert the error type
-            let res: Result<R, E2> = res.map_err(E2::from);
-            res
-        };
-        self.rpc(req, target, fut).await
-    }
 }
 
 impl<S: Service, C: ServiceEndpoint<S>> RpcServer<S, C> {
@@ -344,7 +179,7 @@ where
     C: ServiceEndpoint<S>,
     T: TryFrom<SInner::Req>,
 {
-    fn new(
+    pub(crate) fn new(
         recv: C::RecvStream,
         map: Arc<dyn MapService<S, SInner>>,
     ) -> (Self, UnwrapToPending<RpcServerError<C>>) {
@@ -433,7 +268,7 @@ impl<C: ConnectionErrors> fmt::Display for RpcServerError<C> {
 impl<C: ConnectionErrors> error::Error for RpcServerError<C> {}
 
 /// Take an oneshot receiver and just return Pending the underlying future returns `Err(oneshot::Canceled)`
-struct UnwrapToPending<T>(oneshot::Receiver<T>);
+pub(crate) struct UnwrapToPending<T>(oneshot::Receiver<T>);
 
 impl<T> Future for UnwrapToPending<T> {
     type Output = T;

--- a/src/server.rs
+++ b/src/server.rs
@@ -68,7 +68,7 @@ pub struct RpcChannel<S: Service, C: ServiceEndpoint<S>, SInner: Service = S> {
     /// Stream to receive requests from the client.
     pub recv: C::RecvStream,
     /// Mapper to map between S and S2
-    map: Arc<dyn MapService<S, SInner>>,
+    pub map: Arc<dyn MapService<S, SInner>>,
 }
 
 impl<S, C> RpcChannel<S, C, S>
@@ -447,7 +447,7 @@ impl<T> Future for UnwrapToPending<T> {
     }
 }
 
-async fn race2<T, A: Future<Output = T>, B: Future<Output = T>>(f1: A, f2: B) -> T {
+pub(crate) async fn race2<T, A: Future<Output = T>, B: Future<Output = T>>(f1: A, f2: B) -> T {
     tokio::select! {
         x = f1 => x,
         x = f2 => x,

--- a/tests/try.rs
+++ b/tests/try.rs
@@ -1,0 +1,103 @@
+#![cfg(feature = "flume-transport")]
+use derive_more::{From, TryInto};
+use futures::{Stream, StreamExt};
+use quic_rpc::{
+    message::Msg,
+    pattern::try_server_streaming::{StreamCreated, TryServerStreaming, TryServerStreamingMsg},
+    server::RpcServerError,
+    transport::flume,
+    RpcClient, RpcServer, Service,
+};
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone)]
+struct TryService;
+
+impl Service for TryService {
+    type Req = TryRequest;
+    type Res = TryResponse;
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct StreamN {
+    n: u64,
+}
+
+impl Msg<TryService> for StreamN {
+    type Pattern = TryServerStreaming;
+}
+
+impl TryServerStreamingMsg<TryService> for StreamN {
+    type Item = u64;
+    type ItemError = String;
+    type CreateError = String;
+}
+
+/// request enum
+#[derive(Debug, Serialize, Deserialize, From, TryInto)]
+pub enum TryRequest {
+    StreamN(StreamN),
+}
+
+#[derive(Debug, Serialize, Deserialize, From, TryInto, Clone)]
+pub enum TryResponse {
+    StreamN(std::result::Result<u64, String>),
+    StreamNError(std::result::Result<StreamCreated, String>),
+}
+
+#[derive(Clone)]
+struct Handler;
+
+impl Handler {
+    async fn try_stream_n(
+        self,
+        req: StreamN,
+    ) -> std::result::Result<impl Stream<Item = std::result::Result<u64, String>>, String> {
+        if req.n % 2 != 0 {
+            return Err("odd n not allowed".to_string());
+        }
+        let stream = async_stream::stream! {
+            for i in 0..req.n {
+                if i > 5 {
+                    yield Err("n too large".to_string());
+                    return;
+                }
+                yield Ok(i);
+            }
+        };
+        Ok(stream)
+    }
+}
+
+#[tokio::test]
+async fn try_server_streaming() -> anyhow::Result<()> {
+    tracing_subscriber::fmt::try_init().ok();
+    let (server, client) = flume::connection::<TryRequest, TryResponse>(1);
+
+    let server = RpcServer::<TryService, _>::new(server);
+    let server_handle = tokio::task::spawn(async move {
+        loop {
+            let (req, chan) = server.accept().await?;
+            let handler = Handler;
+            match req {
+                TryRequest::StreamN(req) => {
+                    chan.try_server_streaming(req, handler, Handler::try_stream_n)
+                        .await?;
+                }
+            }
+        }
+        #[allow(unreachable_code)]
+        Ok(())
+    });
+    let client = RpcClient::<TryService, _>::new(client);
+    let stream_n = client.try_server_streaming(StreamN { n: 10 }).await?;
+    let items: Vec<_> = stream_n.collect().await;
+    println!("{:?}", items);
+    drop(client);
+    // dropping the client will cause the server to terminate
+    match server_handle.await? {
+        Err(RpcServerError::Accept(_)) => {}
+        e => panic!("unexpected termination result {e:?}"),
+    }
+    Ok(())
+}


### PR DESCRIPTION
also reorganize this into a separate pattern dir.

I think we need to separate out the patterns more. E.g. in some cases it would be useful if you don't have a fn that returns a stream but get a fn that gets a sink.

In any case, this is the attempt to do an interaction pattern that is more friendly to the case where the stream creation itself is async and fallible, and the stream contains results.

For usage, see the example in the try.rs test.