### PR TITLE
increase version number

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -743,7 +743,7 @@ dependencies = [
 
 [[package]]
 name = "quic-rpc"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "async-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "quic-rpc"
-version = "0.7.0"
+version = "0.8.0"
 edition = "2021"
 authors = ["Rüdiger Klaehn <rklaehn@protonmail.com>"]
 keywords = ["api", "protocol", "network", "rpc"]


### PR DESCRIPTION
We need a new version number according to semver-checks:

```
❯ cargo semver-checks
     Parsing quic-rpc v0.7.0 (current)
      Parsed [  22.468s] (current)
     Parsing quic-rpc v0.7.0 (baseline)
      Parsed [  22.495s] (baseline)
    Checking quic-rpc v0.7.0 -> v0.7.0 (no change)
     Checked [   0.023s] 67 checks; 66 passed, 1 failed, 0 unnecessary

--- failure enum_missing: pub enum removed or renamed ---

Description:
A publicly-visible enum cannot be imported by its prior path. A `pub use` may have been removed, or the enum itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.30.0/src/lints/enum_missing.ron

Failed in:
  enum quic_rpc::client::ClientStreamingItemError, previously in file /Users/rklaehn/.cargo/registry/src/index.crates.io-6f17d22bba15001f/quic-rpc-0.7.0/src/client.rs:355
  enum quic_rpc::client::ClientStreamingError, previously in file /Users/rklaehn/.cargo/registry/src/index.crates.io-6f17d22bba15001f/quic-rpc-0.7.0/src/client.rs:338
  enum quic_rpc::client::StreamingResponseItemError, previously in file /Users/rklaehn/.cargo/registry/src/index.crates.io-6f17d22bba15001f/quic-rpc-0.7.0/src/client.rs:391
  enum quic_rpc::client::RpcClientError, previously in file /Users/rklaehn/.cargo/registry/src/index.crates.io-6f17d22bba15001f/quic-rpc-0.7.0/src/client.rs:281
  enum quic_rpc::client::BidiError, previously in file /Users/rklaehn/.cargo/registry/src/index.crates.io-6f17d22bba15001f/quic-rpc-0.7.0/src/client.rs:304
  enum quic_rpc::client::StreamingResponseError, previously in file /Users/rklaehn/.cargo/registry/src/index.crates.io-6f17d22bba15001f/quic-rpc-0.7.0/src/client.rs:374
  enum quic_rpc::client::BidiItemError, previously in file /Users/rklaehn/.cargo/registry/src/index.crates.io-6f17d22bba15001f/quic-rpc-0.7.0/src/client.rs:321
     Summary semver requires new major version: 1 major and 0 minor checks failed
    Finished [  45.004s] quic-rpc
```