### PR TITLE
deps: Depend on iroh-quinn and bump version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -132,8 +132,8 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "futures",
+ "iroh-quinn",
  "quic-rpc",
- "quinn",
  "rustls",
  "serde",
  "tokio",
@@ -496,6 +496,54 @@ dependencies = [
 ]
 
 [[package]]
+name = "iroh-quinn"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5f3a9d551023df808c2407d7e5db069e8a994b53c9dcd35b858b4e4c220a2c4"
+dependencies = [
+ "bytes",
+ "iroh-quinn-proto",
+ "iroh-quinn-udp",
+ "pin-project-lite",
+ "rustc-hash",
+ "rustls",
+ "thiserror",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "iroh-quinn-proto"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16f2656b322c7f6cf3eb95e632d1c0f2fa546841915b0270da581f918c70c4be"
+dependencies = [
+ "bytes",
+ "rand",
+ "ring",
+ "rustc-hash",
+ "rustls",
+ "rustls-native-certs",
+ "slab",
+ "thiserror",
+ "tinyvec",
+ "tracing",
+]
+
+[[package]]
+name = "iroh-quinn-udp"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6679979a7271c24f9dae9622c0b4a543881508aa3a7396f55dfbaaa56f01c063"
+dependencies = [
+ "bytes",
+ "libc",
+ "socket2 0.5.3",
+ "tracing",
+ "windows-sys",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -743,7 +791,7 @@ dependencies = [
 
 [[package]]
 name = "quic-rpc"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -757,9 +805,9 @@ dependencies = [
  "futures-sink",
  "futures-util",
  "hyper",
+ "iroh-quinn",
  "pin-project",
  "proc-macro2",
- "quinn",
  "rcgen",
  "rustls",
  "serde",
@@ -770,54 +818,6 @@ dependencies = [
  "tokio-util",
  "tracing",
  "tracing-subscriber",
-]
-
-[[package]]
-name = "quinn"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8cc2c5017e4b43d5995dcea317bc46c1e09404c0a9664d2908f7f02dfe943d75"
-dependencies = [
- "bytes",
- "pin-project-lite",
- "quinn-proto",
- "quinn-udp",
- "rustc-hash",
- "rustls",
- "thiserror",
- "tokio",
- "tracing",
-]
-
-[[package]]
-name = "quinn-proto"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8c8bb234e70c863204303507d841e7fa2295e95c822b2bb4ca8ebf57f17b1cb"
-dependencies = [
- "bytes",
- "rand",
- "ring",
- "rustc-hash",
- "rustls",
- "rustls-native-certs",
- "slab",
- "thiserror",
- "tinyvec",
- "tracing",
-]
-
-[[package]]
-name = "quinn-udp"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6df19e284d93757a9fb91d63672f7741b129246a669db09d1c0063071debc0c0"
-dependencies = [
- "bytes",
- "libc",
- "socket2 0.5.3",
- "tracing",
- "windows-sys",
 ]
 
 [[package]]
@@ -1038,8 +1038,8 @@ dependencies = [
  "anyhow",
  "async-stream",
  "futures",
+ "iroh-quinn",
  "quic-rpc",
- "quinn",
  "rcgen",
  "rustls",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "quic-rpc"
-version = "0.8.0"
+version = "0.9.0"
 edition = "2021"
 authors = ["Rüdiger Klaehn <rklaehn@protonmail.com>"]
 keywords = ["api", "protocol", "network", "rpc"]
@@ -23,7 +23,7 @@ futures-sink = "0.3.30"
 futures-util = { version = "0.3.30", features = ["sink"] }
 hyper = { version = "0.14.16", features = ["full"], optional = true }
 pin-project = "1"
-quinn = { version = "0.10", optional = true }
+quinn = { package = "iroh-quinn", version = "0.10", optional = true }
 serde = { version = "1.0.183", features = ["derive"] }
 tokio = { version = "1", default-features = false, features = ["macros", "sync"] }
 tokio-serde = { version = "0.8", features = ["bincode"], optional = true }
@@ -42,7 +42,7 @@ async-stream = "0.3.3"
 derive_more = { version = "1.0.0-beta.1", features = ["full"] }
 serde = { version = "1", features = ["derive"] }
 tokio = { version = "1", features = ["full"] }
-quinn = "0.10"
+quinn = { package = "iroh-quinn", version = "0.10" }
 rcgen = "0.10.0"
 rustls = "0.21"
 thousands = "0.2.0"

--- a/examples/split/client/Cargo.toml
+++ b/examples/split/client/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2021"
 anyhow = "1.0.14"
 futures = "0.3.26"
 quic-rpc = { path = "../../..", features = ["quinn-transport", "macros"] }
-quinn = "0.10"
+quinn = { package = "iroh-quinn", version = "0.10" }
 rustls = { version = "0.21", features = ["dangerous_configuration"] }
 tracing-subscriber = "0.3.16"
 serde = { version = "1", features = ["derive"] }

--- a/examples/split/server/Cargo.toml
+++ b/examples/split/server/Cargo.toml
@@ -11,7 +11,7 @@ async-stream = "0.3.3"
 futures = "0.3.26"
 tracing-subscriber = "0.3.16"
 quic-rpc = { path = "../../..", features = ["quinn-transport", "macros"] }
-quinn = "0.10"
+quinn = { package = "iroh-quinn", version = "0.10" }
 rcgen = "0.10.0"
 rustls = "0.21"
 serde = { version = "1", features = ["derive"] }

--- a/src/pattern/bidi_streaming.rs
+++ b/src/pattern/bidi_streaming.rs
@@ -1,4 +1,4 @@
-//!
+//! Bidirectional stream interaction pattern.
 
 use futures_lite::{Stream, StreamExt};
 use futures_util::{FutureExt, SinkExt};

--- a/src/pattern/client_streaming.rs
+++ b/src/pattern/client_streaming.rs
@@ -1,4 +1,5 @@
-//!
+//! Client streaming interaction pattern.
+
 use futures_lite::{future::Boxed, Future, StreamExt};
 use futures_util::{FutureExt, SinkExt, TryFutureExt};
 

--- a/src/pattern/rpc.rs
+++ b/src/pattern/rpc.rs
@@ -1,4 +1,4 @@
-//!
+//! RPC interaction pattern.
 
 use futures_lite::{Future, StreamExt};
 use futures_util::{FutureExt, SinkExt};

--- a/src/pattern/server_streaming.rs
+++ b/src/pattern/server_streaming.rs
@@ -1,4 +1,4 @@
-//!
+//! Server streaming interaction pattern.
 
 use futures_lite::{Stream, StreamExt};
 use futures_util::{FutureExt, SinkExt, TryFutureExt};

--- a/src/pattern/try_server_streaming.rs
+++ b/src/pattern/try_server_streaming.rs
@@ -1,4 +1,5 @@
-//!
+//! Fallible server streaming interaction pattern.
+
 use futures_lite::{Future, Stream, StreamExt};
 use futures_util::{FutureExt, SinkExt, TryFutureExt};
 use serde::{Deserialize, Serialize};
@@ -25,7 +26,7 @@ use std::{
 #[derive(Debug, Clone, Copy, Serialize, Deserialize)]
 pub struct StreamCreated;
 
-///
+/// Fallible server streaming interaction pattern.
 #[derive(Debug, Clone, Copy)]
 pub struct TryServerStreaming;
 


### PR DESCRIPTION
Iroh itself is changing it's dependency to iroh-quinn, change it here as well.

This prepares the release as well by bumping the version number.