### PR TITLE
refactor!: use `Service` generic in transport connections

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,7 +52,7 @@ proc-macro2 = "1.0.66"
 futures-buffered = "0.2.4"
 
 [features]
-hyper-transport = ["flume", "hyper", "bincode", "bytes"]
+hyper-transport = ["flume", "hyper", "bincode", "bytes", "tokio-serde", "tokio-util"]
 quinn-transport = ["flume", "quinn", "bincode", "tokio-serde", "tokio-util"]
 flume-transport = ["flume"]
 combined-transport = []

--- a/examples/errors.rs
+++ b/examples/errors.rs
@@ -55,9 +55,9 @@ impl Fs {
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     let fs = Fs;
-    let (server, client) = quic_rpc::transport::flume::connection(1);
-    let client = RpcClient::<IoService, _>::new(client);
-    let server = RpcServer::<IoService, _>::new(server);
+    let (server, client) = quic_rpc::transport::flume::connection::<IoService>(1);
+    let client = RpcClient::new(client);
+    let server = RpcServer::new(server);
     let handle = tokio::task::spawn(async move {
         for _ in 0..1 {
             let (req, chan) = server.accept().await?;

--- a/examples/macro.rs
+++ b/examples/macro.rs
@@ -105,7 +105,7 @@ create_store_dispatch!(Store, dispatch_store_request);
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
-    let (server, client) = flume::connection::<StoreRequest, StoreResponse>(1);
+    let (server, client) = flume::connection::<StoreService>(1);
     let server_handle = tokio::task::spawn(async move {
         let target = Store;
         run_server_loop(StoreService, server, target, dispatch_store_request).await

--- a/examples/modularize.rs
+++ b/examples/modularize.rs
@@ -19,7 +19,7 @@ use app::AppService;
 async fn main() -> Result<()> {
     // Spawn an inmemory connection.
     // Could use quic equally (all code in this example is generic over the transport)
-    let (server_conn, client_conn) = flume::connection::<app::Request, app::Response>(1);
+    let (server_conn, client_conn) = flume::connection::<AppService>(1);
 
     // spawn the server
     let handler = app::Handler::default();

--- a/examples/split/client/src/main.rs
+++ b/examples/split/client/src/main.rs
@@ -1,5 +1,6 @@
 use futures::sink::SinkExt;
 use futures::stream::StreamExt;
+use quic_rpc::transport::quinn::QuinnConnection;
 use quic_rpc::RpcClient;
 use quinn::{ClientConfig, Endpoint};
 use std::io;
@@ -14,12 +15,9 @@ async fn main() -> anyhow::Result<()> {
     tracing_subscriber::fmt::init();
     let server_addr: SocketAddr = "127.0.0.1:12345".parse()?;
     let endpoint = make_insecure_client_endpoint("0.0.0.0:0".parse()?)?;
-    let client = quic_rpc::transport::quinn::QuinnConnection::new(
-        endpoint,
-        server_addr,
-        "localhost".to_string(),
-    );
-    let client = RpcClient::<ComputeService, _>::new(client);
+    let client =
+        QuinnConnection::<ComputeService>::new(endpoint, server_addr, "localhost".to_string());
+    let client = RpcClient::new(client);
     // let mut client = ComputeClient(client);
 
     // a rpc call

--- a/examples/split/server/src/main.rs
+++ b/examples/split/server/src/main.rs
@@ -1,6 +1,7 @@
 use async_stream::stream;
 use futures::stream::{Stream, StreamExt};
 use quic_rpc::server::run_server_loop;
+use quic_rpc::transport::quinn::QuinnServerEndpoint;
 use quinn::{Endpoint, ServerConfig};
 use std::net::SocketAddr;
 use std::sync::Arc;
@@ -61,7 +62,7 @@ async fn main() -> anyhow::Result<()> {
     tracing_subscriber::fmt::init();
     let server_addr: SocketAddr = "127.0.0.1:12345".parse()?;
     let (server, _server_certs) = make_server_endpoint(server_addr)?;
-    let channel = quic_rpc::transport::quinn::QuinnServerEndpoint::new(server)?;
+    let channel = QuinnServerEndpoint::<ComputeService>::new(server)?;
     let target = Compute;
     run_server_loop(
         ComputeService,

--- a/examples/store.rs
+++ b/examples/store.rs
@@ -184,7 +184,7 @@ async fn main() -> anyhow::Result<()> {
         }
     }
 
-    let (server, client) = flume::connection::<StoreRequest, StoreResponse>(1);
+    let (server, client) = flume::connection::<StoreService>(1);
     let client = RpcClient::<StoreService, _>::new(client);
     let server = RpcServer::<StoreService, _>::new(server);
     let server_handle = tokio::task::spawn(server_future(server));
@@ -231,7 +231,13 @@ async fn main() -> anyhow::Result<()> {
 }
 
 async fn _main_unsugared() -> anyhow::Result<()> {
-    let (server, client) = flume::connection::<u64, String>(1);
+    #[derive(Clone, Debug)]
+    struct Service;
+    impl crate::Service for Service {
+        type Req = u64;
+        type Res = String;
+    }
+    let (server, client) = flume::connection::<Service>(1);
     let to_string_service = tokio::spawn(async move {
         let (mut send, mut recv) = server.accept_bi().await?;
         while let Some(item) = recv.next().await {

--- a/src/transport/flume.rs
+++ b/src/transport/flume.rs
@@ -6,7 +6,7 @@ use futures_sink::Sink;
 
 use crate::{
     transport::{Connection, ConnectionErrors, LocalAddr, ServerEndpoint},
-    RpcMessage,
+    RpcMessage, Service,
 };
 use core::fmt;
 use std::{error, fmt::Display, marker::PhantomData, pin::Pin, result, task::Poll};
@@ -100,11 +100,11 @@ impl error::Error for RecvError {}
 /// A flume based server endpoint.
 ///
 /// Created using [connection].
-pub struct FlumeServerEndpoint<In: RpcMessage, Out: RpcMessage> {
-    stream: flume::Receiver<(SendSink<Out>, RecvStream<In>)>,
+pub struct FlumeServerEndpoint<S: Service> {
+    stream: flume::Receiver<(SendSink<S::Res>, RecvStream<S::Req>)>,
 }
 
-impl<In: RpcMessage, Out: RpcMessage> Clone for FlumeServerEndpoint<In, Out> {
+impl<S: Service> Clone for FlumeServerEndpoint<S> {
     fn clone(&self) -> Self {
         Self {
             stream: self.stream.clone(),
@@ -112,7 +112,7 @@ impl<In: RpcMessage, Out: RpcMessage> Clone for FlumeServerEndpoint<In, Out> {
     }
 }
 
-impl<In: RpcMessage, Out: RpcMessage> fmt::Debug for FlumeServerEndpoint<In, Out> {
+impl<S: Service> fmt::Debug for FlumeServerEndpoint<S> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("FlumeServerEndpoint")
             .field("stream", &self.stream)
@@ -120,7 +120,7 @@ impl<In: RpcMessage, Out: RpcMessage> fmt::Debug for FlumeServerEndpoint<In, Out
     }
 }
 
-impl<In: RpcMessage, Out: RpcMessage> ConnectionErrors for FlumeServerEndpoint<In, Out> {
+impl<S: Service> ConnectionErrors for FlumeServerEndpoint<S> {
     type SendError = self::SendError;
 
     type RecvError = self::RecvError;
@@ -194,13 +194,13 @@ impl<In: RpcMessage, Out: RpcMessage> Future for AcceptBiFuture<In, Out> {
     }
 }
 
-impl<In: RpcMessage, Out: RpcMessage> ConnectionCommon<In, Out> for FlumeServerEndpoint<In, Out> {
-    type SendSink = SendSink<Out>;
-    type RecvStream = RecvStream<In>;
+impl<S: Service> ConnectionCommon<S::Req, S::Res> for FlumeServerEndpoint<S> {
+    type SendSink = SendSink<S::Res>;
+    type RecvStream = RecvStream<S::Req>;
 }
 
-impl<In: RpcMessage, Out: RpcMessage> ServerEndpoint<In, Out> for FlumeServerEndpoint<In, Out> {
-    type AcceptBiFut = AcceptBiFuture<In, Out>;
+impl<S: Service> ServerEndpoint<S::Req, S::Res> for FlumeServerEndpoint<S> {
+    type AcceptBiFut = AcceptBiFuture<S::Req, S::Res>;
 
     fn accept_bi(&self) -> Self::AcceptBiFut {
         AcceptBiFuture {
@@ -214,7 +214,7 @@ impl<In: RpcMessage, Out: RpcMessage> ServerEndpoint<In, Out> for FlumeServerEnd
     }
 }
 
-impl<In: RpcMessage, Out: RpcMessage> ConnectionErrors for FlumeConnection<In, Out> {
+impl<S: Service> ConnectionErrors for FlumeConnection<S> {
     type SendError = self::SendError;
 
     type RecvError = self::RecvError;
@@ -222,17 +222,17 @@ impl<In: RpcMessage, Out: RpcMessage> ConnectionErrors for FlumeConnection<In, O
     type OpenError = self::OpenBiError;
 }
 
-impl<In: RpcMessage, Out: RpcMessage> ConnectionCommon<In, Out> for FlumeConnection<In, Out> {
-    type SendSink = SendSink<Out>;
-    type RecvStream = RecvStream<In>;
+impl<S: Service> ConnectionCommon<S::Res, S::Req> for FlumeConnection<S> {
+    type SendSink = SendSink<S::Req>;
+    type RecvStream = RecvStream<S::Res>;
 }
 
-impl<In: RpcMessage, Out: RpcMessage> Connection<In, Out> for FlumeConnection<In, Out> {
-    type OpenBiFut = OpenBiFuture<In, Out>;
+impl<S: Service> Connection<S::Res, S::Req> for FlumeConnection<S> {
+    type OpenBiFut = OpenBiFuture<S::Res, S::Req>;
 
     fn open_bi(&self) -> Self::OpenBiFut {
-        let (local_send, remote_recv) = flume::bounded::<Out>(128);
-        let (remote_send, local_recv) = flume::bounded::<In>(128);
+        let (local_send, remote_recv) = flume::bounded::<S::Req>(128);
+        let (remote_send, local_recv) = flume::bounded::<S::Res>(128);
         let remote_chan = (
             SendSink(remote_send.into_sink()),
             RecvStream(remote_recv.into_stream()),
@@ -248,11 +248,11 @@ impl<In: RpcMessage, Out: RpcMessage> Connection<In, Out> for FlumeConnection<In
 /// A flume based connection to a server endpoint.
 ///
 /// Created using [connection].
-pub struct FlumeConnection<In: RpcMessage, Out: RpcMessage> {
-    sink: flume::Sender<(SendSink<In>, RecvStream<Out>)>,
+pub struct FlumeConnection<S: Service> {
+    sink: flume::Sender<(SendSink<S::Res>, RecvStream<S::Req>)>,
 }
 
-impl<In: RpcMessage, Out: RpcMessage> Clone for FlumeConnection<In, Out> {
+impl<S: Service> Clone for FlumeConnection<S> {
     fn clone(&self) -> Self {
         Self {
             sink: self.sink.clone(),
@@ -260,7 +260,7 @@ impl<In: RpcMessage, Out: RpcMessage> Clone for FlumeConnection<In, Out> {
     }
 }
 
-impl<In: RpcMessage, Out: RpcMessage> fmt::Debug for FlumeConnection<In, Out> {
+impl<S: Service> fmt::Debug for FlumeConnection<S> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("FlumeClientChannel")
             .field("sink", &self.sink)
@@ -335,9 +335,7 @@ impl std::error::Error for CreateChannelError {}
 /// Create a flume server endpoint and a connected flume client channel.
 ///
 /// `buffer` the size of the buffer for each channel. Keep this at a low value to get backpressure
-pub fn connection<Req: RpcMessage, Res: RpcMessage>(
-    buffer: usize,
-) -> (FlumeServerEndpoint<Req, Res>, FlumeConnection<Res, Req>) {
+pub fn connection<S: Service>(buffer: usize) -> (FlumeServerEndpoint<S>, FlumeConnection<S>) {
     let (sink, stream) = flume::bounded(buffer);
     (FlumeServerEndpoint { stream }, FlumeConnection { sink })
 }

--- a/src/transport/hyper.rs
+++ b/src/transport/hyper.rs
@@ -7,7 +7,7 @@ use std::{
 };
 
 use crate::transport::{Connection, ConnectionErrors, LocalAddr, ServerEndpoint};
-use crate::RpcMessage;
+use crate::{RpcMessage, Service};
 use bytes::Bytes;
 use flume::{r#async::RecvFut, Receiver, Sender};
 use futures_lite::{Stream, StreamExt};
@@ -33,9 +33,10 @@ struct HyperConnectionInner {
 }
 
 /// Hyper based connection to a server
-pub struct HyperConnection<In: RpcMessage, Out: RpcMessage> {
+#[derive(Clone)]
+pub struct HyperConnection<S: Service> {
     inner: Arc<HyperConnectionInner>,
-    _p: PhantomData<(In, Out)>,
+    _p: PhantomData<S>,
 }
 
 /// Trait so we don't have to drag around the hyper internals
@@ -49,7 +50,7 @@ impl<C: Connect + Clone + Send + Sync + 'static> Requester for Client<C, Body> {
     }
 }
 
-impl<In: RpcMessage, Out: RpcMessage> HyperConnection<In, Out> {
+impl<S: Service> HyperConnection<S> {
     /// create a client given an uri and the default configuration
     pub fn new(uri: Uri) -> Self {
         Self::with_config(uri, ChannelConfig::default())
@@ -86,21 +87,12 @@ impl<In: RpcMessage, Out: RpcMessage> HyperConnection<In, Out> {
     }
 }
 
-impl<In: RpcMessage, Out: RpcMessage> fmt::Debug for HyperConnection<In, Out> {
+impl<S: Service> fmt::Debug for HyperConnection<S> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("ClientChannel")
             .field("uri", &self.inner.uri)
             .field("config", &self.inner.config)
             .finish()
-    }
-}
-
-impl<In: RpcMessage, Out: RpcMessage> Clone for HyperConnection<In, Out> {
-    fn clone(&self) -> Self {
-        Self {
-            inner: self.inner.clone(),
-            _p: PhantomData,
-        }
     }
 }
 
@@ -181,9 +173,9 @@ impl Default for ChannelConfig {
 /// Creating this spawns a tokio task which runs the server, once dropped this task is shut
 /// down: no new connections will be accepted and existing channels will stop.
 #[derive(Debug)]
-pub struct HyperServerEndpoint<In: RpcMessage, Out: RpcMessage> {
+pub struct HyperServerEndpoint<S: Service> {
     /// The channel.
-    channel: Receiver<InternalChannel<In>>,
+    channel: Receiver<InternalChannel<S::Req>>,
     /// The configuration.
     config: Arc<ChannelConfig>,
     /// The sender to stop the server.
@@ -196,11 +188,11 @@ pub struct HyperServerEndpoint<In: RpcMessage, Out: RpcMessage> {
     /// This is useful when the listen address uses a random port, `:0`, to find out which
     /// port was bound by the kernel.
     local_addr: [LocalAddr; 1],
-    /// Phantom data for in and out
-    _p: PhantomData<(In, Out)>,
+    /// Phantom data for service
+    _p: PhantomData<S>,
 }
 
-impl<In: RpcMessage, Out: RpcMessage> HyperServerEndpoint<In, Out> {
+impl<S: Service> HyperServerEndpoint<S> {
     /// Creates a server listening on the [`SocketAddr`], with the default configuration.
     pub fn serve(addr: &SocketAddr) -> hyper::Result<Self> {
         Self::serve_with_config(addr, Default::default())
@@ -260,9 +252,9 @@ impl<In: RpcMessage, Out: RpcMessage> HyperServerEndpoint<In, Out> {
     /// response and sends them to the [`ServerChannel`].
     async fn handle_one_http2_request(
         req: Request<Body>,
-        accept_tx: Sender<InternalChannel<In>>,
+        accept_tx: Sender<InternalChannel<S::Req>>,
     ) -> Result<Response<Body>, String> {
-        let (req_tx, req_rx) = flume::bounded::<result::Result<In, RecvError>>(32);
+        let (req_tx, req_rx) = flume::bounded::<result::Result<S::Req, RecvError>>(32);
         let (res_tx, res_rx) = flume::bounded::<io::Result<Bytes>>(32);
         accept_tx
             .send_async((req_rx, res_tx))
@@ -373,7 +365,7 @@ fn spawn_recv_forwarder<In: RpcMessage>(
 // This does not want or need RpcMessage to be clone but still want to clone the
 // ServerChannel and it's containing channels itself.  The derive macro can't cope with this
 // so this needs to be written by hand.
-impl<In: RpcMessage, Out: RpcMessage> Clone for HyperServerEndpoint<In, Out> {
+impl<S: Service> Clone for HyperServerEndpoint<S> {
     fn clone(&self) -> Self {
         Self {
             channel: self.channel.clone(),
@@ -740,8 +732,8 @@ where
     }
 }
 
-impl<In: RpcMessage, Out: RpcMessage> HyperConnection<In, Out> {
-    fn open_bi(&self) -> OpenBiFuture<In, Out> {
+impl<S: Service> HyperConnection<S> {
+    fn open_bi(&self) -> OpenBiFuture<S::Res, S::Req> {
         event!(Level::TRACE, "open_bi {}", self.inner.uri);
         let (out_tx, out_rx) = flume::bounded::<io::Result<Bytes>>(32);
         let req: Result<Request<Body>, OpenBiError> = Request::post(&self.inner.uri)
@@ -758,7 +750,7 @@ impl<In: RpcMessage, Out: RpcMessage> HyperConnection<In, Out> {
     }
 }
 
-impl<In: RpcMessage, Out: RpcMessage> ConnectionErrors for HyperConnection<In, Out> {
+impl<S: Service> ConnectionErrors for HyperConnection<S> {
     type SendError = self::SendError;
 
     type RecvError = self::RecvError;
@@ -766,21 +758,21 @@ impl<In: RpcMessage, Out: RpcMessage> ConnectionErrors for HyperConnection<In, O
     type OpenError = OpenBiError;
 }
 
-impl<In: RpcMessage, Out: RpcMessage> ConnectionCommon<In, Out> for HyperConnection<In, Out> {
-    type RecvStream = self::RecvStream<In>;
+impl<S: Service> ConnectionCommon<S::Res, S::Req> for HyperConnection<S> {
+    type RecvStream = self::RecvStream<S::Res>;
 
-    type SendSink = self::SendSink<Out>;
+    type SendSink = self::SendSink<S::Req>;
 }
 
-impl<In: RpcMessage, Out: RpcMessage> Connection<In, Out> for HyperConnection<In, Out> {
-    type OpenBiFut = OpenBiFuture<In, Out>;
+impl<S: Service> Connection<S::Res, S::Req> for HyperConnection<S> {
+    type OpenBiFut = OpenBiFuture<S::Res, S::Req>;
 
     fn open_bi(&self) -> Self::OpenBiFut {
         self.open_bi()
     }
 }
 
-impl<In: RpcMessage, Out: RpcMessage> ConnectionErrors for HyperServerEndpoint<In, Out> {
+impl<S: Service> ConnectionErrors for HyperServerEndpoint<S> {
     type SendError = self::SendError;
 
     type RecvError = self::RecvError;
@@ -788,13 +780,13 @@ impl<In: RpcMessage, Out: RpcMessage> ConnectionErrors for HyperServerEndpoint<I
     type OpenError = AcceptBiError;
 }
 
-impl<In: RpcMessage, Out: RpcMessage> ConnectionCommon<In, Out> for HyperServerEndpoint<In, Out> {
-    type RecvStream = self::RecvStream<In>;
-    type SendSink = self::SendSink<Out>;
+impl<S: Service> ConnectionCommon<S::Req, S::Res> for HyperServerEndpoint<S> {
+    type RecvStream = self::RecvStream<S::Req>;
+    type SendSink = self::SendSink<S::Res>;
 }
 
-impl<In: RpcMessage, Out: RpcMessage> ServerEndpoint<In, Out> for HyperServerEndpoint<In, Out> {
-    type AcceptBiFut = AcceptBiFuture<In, Out>;
+impl<S: Service> ServerEndpoint<S::Req, S::Res> for HyperServerEndpoint<S> {
+    type AcceptBiFut = AcceptBiFuture<S::Req, S::Res>;
 
     fn local_addr(&self) -> &[LocalAddr] {
         &self.local_addr

--- a/tests/flume.rs
+++ b/tests/flume.rs
@@ -10,7 +10,7 @@ use quic_rpc::{
 #[tokio::test]
 async fn flume_channel_bench() -> anyhow::Result<()> {
     tracing_subscriber::fmt::try_init().ok();
-    let (server, client) = flume::connection::<ComputeRequest, ComputeResponse>(1);
+    let (server, client) = flume::connection::<ComputeService>(1);
 
     let server = RpcServer::<ComputeService, _>::new(server);
     let server_handle = tokio::task::spawn(ComputeService::server(server));
@@ -59,11 +59,9 @@ async fn flume_channel_mapped_bench() -> anyhow::Result<()> {
         type Req = InnerRequest;
         type Res = InnerResponse;
     }
-    let (server, client) = flume::connection::<OuterRequest, OuterResponse>(1);
+    let (server, client) = flume::connection::<OuterService>(1);
 
-    let server = RpcServer::<OuterService, _>::new(server);
-    // let server: RpcServer<OuterService, _, InnerService> = server.map();
-    // let server: RpcServer<OuterService, _, ComputeService> = server.map();
+    let server = RpcServer::new(server);
     let server_handle: tokio::task::JoinHandle<Result<(), RpcServerError<_>>> =
         tokio::task::spawn(async move {
             let service = ComputeService;
@@ -99,7 +97,7 @@ async fn flume_channel_mapped_bench() -> anyhow::Result<()> {
 #[tokio::test]
 async fn flume_channel_smoke() -> anyhow::Result<()> {
     tracing_subscriber::fmt::try_init().ok();
-    let (server, client) = flume::connection::<ComputeRequest, ComputeResponse>(1);
+    let (server, client) = flume::connection::<ComputeService>(1);
 
     let server = RpcServer::<ComputeService, _>::new(server);
     let server_handle = tokio::task::spawn(ComputeService::server(server));

--- a/tests/hyper.rs
+++ b/tests/hyper.rs
@@ -18,8 +18,8 @@ use math::*;
 mod util;
 
 fn run_server(addr: &SocketAddr) -> JoinHandle<anyhow::Result<()>> {
-    let channel = HyperServerEndpoint::<ComputeRequest, ComputeResponse>::serve(addr).unwrap();
-    let server = RpcServer::<ComputeService, _>::new(channel);
+    let channel = HyperServerEndpoint::<ComputeService>::serve(addr).unwrap();
+    let server = RpcServer::new(channel);
     tokio::spawn(async move {
         loop {
             let server = server.clone();
@@ -38,7 +38,7 @@ enum TestResponse {
     NoDeser(NoDeser),
 }
 
-type SC = HyperServerEndpoint<TestRequest, TestResponse>;
+type SC = HyperServerEndpoint<TestService>;
 
 /// request that can be too big
 #[derive(Debug, Serialize, Deserialize)]
@@ -134,8 +134,8 @@ async fn hyper_channel_bench() -> anyhow::Result<()> {
     let addr: SocketAddr = "127.0.0.1:3000".parse()?;
     let uri: Uri = "http://127.0.0.1:3000".parse()?;
     let server_handle = run_server(&addr);
-    let client = HyperConnection::new(uri);
-    let client = RpcClient::<ComputeService, _>::new(client);
+    let client = HyperConnection::<ComputeService>::new(uri);
+    let client = RpcClient::new(client);
     bench(client, 50000).await?;
     println!("terminating server");
     server_handle.abort();
@@ -148,7 +148,7 @@ async fn hyper_channel_smoke() -> anyhow::Result<()> {
     let addr: SocketAddr = "127.0.0.1:3001".parse()?;
     let uri: Uri = "http://127.0.0.1:3001".parse()?;
     let server_handle = run_server(&addr);
-    let client = HyperConnection::new(uri);
+    let client = HyperConnection::<ComputeService>::new(uri);
     smoke_test(client).await?;
     server_handle.abort();
     let _ = server_handle.await;
@@ -171,8 +171,8 @@ async fn hyper_channel_errors() -> anyhow::Result<()> {
         JoinHandle<anyhow::Result<()>>,
         Receiver<result::Result<(), RpcServerError<SC>>>,
     ) {
-        let channel = HyperServerEndpoint::serve(addr).unwrap();
-        let server = RpcServer::<TestService, _>::new(channel);
+        let channel = HyperServerEndpoint::<TestService>::serve(addr).unwrap();
+        let server = RpcServer::new(channel);
         let (res_tx, res_rx) = flume::unbounded();
         let handle = tokio::spawn(async move {
             loop {
@@ -212,8 +212,8 @@ async fn hyper_channel_errors() -> anyhow::Result<()> {
     let addr: SocketAddr = "127.0.0.1:3002".parse()?;
     let uri: Uri = "http://127.0.0.1:3002".parse()?;
     let (server_handle, server_results) = run_test_server(&addr);
-    let client = HyperConnection::new(uri);
-    let client = RpcClient::<TestService, _>::new(client);
+    let client = HyperConnection::<TestService>::new(uri);
+    let client = RpcClient::new(client);
 
     macro_rules! assert_matches {
         ($e:expr, $p:pat) => {

--- a/tests/try.rs
+++ b/tests/try.rs
@@ -72,7 +72,7 @@ impl Handler {
 #[tokio::test]
 async fn try_server_streaming() -> anyhow::Result<()> {
     tracing_subscriber::fmt::try_init().ok();
-    let (server, client) = flume::connection::<TryRequest, TryResponse>(1);
+    let (server, client) = flume::connection::<TryService>(1);
 
     let server = RpcServer::<TryService, _>::new(server);
     let server_handle = tokio::task::spawn(async move {


### PR DESCRIPTION
This changes the transport connection and endpoint struct to be generic over `S: Service` instead of `In: RpcMessage, Out: RpcMessage`. With this change, the public API surface of a crate using quic-rpc can be reduced to only make the service struct public and hide the RPC message types.

E.g. in Iroh, a quic client would now be
`Client<QuinnConnection<RpcService>>`
instead of
`Client<QuinnConnection<ProviderRequest, ProviderResponse>>`

## Breaking changes

The change breaks all transport types, they are now generic over  `S: Service` instead of `In: RpcMessage, Out: RpcMessage`.