### PR TITLE
Add boxed transport

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ quinn-udp = { package = "iroh-quinn-udp", version = "0.4.0", optional = true }
 interprocess = { version = "2.1", features = ["tokio"], optional = true }
 hex = "0.4.3"
 futures = { version = "0.3.30", optional = true }
+anyhow = "1.0.73"
 
 [dependencies.educe]
 # This is an unused dependency, it is needed to make the minimal

--- a/src/transport/boxed.rs
+++ b/src/transport/boxed.rs
@@ -1,0 +1,402 @@
+//! Boxed transport with concrete types
+
+use std::{
+    fmt::Debug,
+    pin::Pin,
+    task::{Context, Poll},
+};
+
+use futures_lite::FutureExt;
+use futures_sink::Sink;
+#[cfg(feature = "quinn-transport")]
+use futures_util::TryStreamExt;
+use futures_util::{future::BoxFuture, SinkExt, Stream, StreamExt};
+use pin_project::pin_project;
+use std::future::Future;
+
+use crate::{RpcMessage, Service};
+
+use super::{ConnectionCommon, ConnectionErrors};
+type BoxedFuture<'a, T> = Pin<Box<dyn Future<Output = T> + Send + Sync + 'a>>;
+
+enum SendSinkInner<T: RpcMessage> {
+    Direct(::flume::r#async::SendSink<'static, T>),
+    Boxed(Pin<Box<dyn Sink<T, Error = anyhow::Error> + Send + Sync + 'static>>),
+}
+
+/// A sink that can be used to send messages to the remote end of a channel.
+///
+/// For local channels, this is a thin wrapper around a flume send sink.
+/// For network channels, this contains a boxed sink, since it is reasonable
+/// to assume that in that case the additional overhead of boxing is negligible.
+#[pin_project]
+pub struct SendSink<T: RpcMessage>(SendSinkInner<T>);
+
+impl<T: RpcMessage> SendSink<T> {
+    /// Create a new send sink from a boxed sink
+    pub fn boxed(sink: impl Sink<T, Error = anyhow::Error> + Send + Sync + 'static) -> Self {
+        Self(SendSinkInner::Boxed(Box::pin(sink)))
+    }
+
+    /// Create a new send sink from a direct flume send sink
+    pub(crate) fn direct(sink: ::flume::r#async::SendSink<'static, T>) -> Self {
+        Self(SendSinkInner::Direct(sink))
+    }
+}
+
+impl<T: RpcMessage> Sink<T> for SendSink<T> {
+    type Error = anyhow::Error;
+
+    fn poll_ready(
+        self: std::pin::Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+    ) -> Poll<Result<(), Self::Error>> {
+        match self.project().0 {
+            SendSinkInner::Direct(sink) => sink.poll_ready_unpin(cx).map_err(anyhow::Error::from),
+            SendSinkInner::Boxed(sink) => sink.poll_ready_unpin(cx).map_err(anyhow::Error::from),
+        }
+    }
+
+    fn start_send(self: std::pin::Pin<&mut Self>, item: T) -> Result<(), Self::Error> {
+        match self.project().0 {
+            SendSinkInner::Direct(sink) => sink.start_send_unpin(item).map_err(anyhow::Error::from),
+            SendSinkInner::Boxed(sink) => sink.start_send_unpin(item).map_err(anyhow::Error::from),
+        }
+    }
+
+    fn poll_flush(
+        self: std::pin::Pin<&mut Self>,
+        cx: &mut Context<'_>,
+    ) -> Poll<Result<(), Self::Error>> {
+        match self.project().0 {
+            SendSinkInner::Direct(sink) => sink.poll_flush_unpin(cx).map_err(anyhow::Error::from),
+            SendSinkInner::Boxed(sink) => sink.poll_flush_unpin(cx).map_err(anyhow::Error::from),
+        }
+    }
+
+    fn poll_close(
+        self: std::pin::Pin<&mut Self>,
+        cx: &mut Context<'_>,
+    ) -> Poll<Result<(), Self::Error>> {
+        match self.project().0 {
+            SendSinkInner::Direct(sink) => sink.poll_close_unpin(cx).map_err(anyhow::Error::from),
+            SendSinkInner::Boxed(sink) => sink.poll_close_unpin(cx).map_err(anyhow::Error::from),
+        }
+    }
+}
+
+enum RecvStreamInner<T: RpcMessage> {
+    Direct(::flume::r#async::RecvStream<'static, T>),
+    Boxed(Pin<Box<dyn Stream<Item = Result<T, anyhow::Error>> + Send + Sync + 'static>>),
+}
+
+/// A stream that can be used to receive messages from the remote end of a channel.
+///
+/// For local channels, this is a thin wrapper around a flume receive stream.
+/// For network channels, this contains a boxed stream, since it is reasonable
+#[pin_project]
+pub struct RecvStream<T: RpcMessage>(RecvStreamInner<T>);
+
+impl<T: RpcMessage> RecvStream<T> {
+    /// Create a new receive stream from a boxed stream
+    pub fn boxed(
+        stream: impl Stream<Item = Result<T, anyhow::Error>> + Send + Sync + 'static,
+    ) -> Self {
+        Self(RecvStreamInner::Boxed(Box::pin(stream)))
+    }
+
+    /// Create a new receive stream from a direct flume receive stream
+    pub(crate) fn direct(stream: ::flume::r#async::RecvStream<'static, T>) -> Self {
+        Self(RecvStreamInner::Direct(stream))
+    }
+}
+
+impl<T: RpcMessage> Stream for RecvStream<T> {
+    type Item = Result<T, anyhow::Error>;
+
+    fn poll_next(self: std::pin::Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        match self.project().0 {
+            RecvStreamInner::Direct(stream) => match stream.poll_next_unpin(cx) {
+                Poll::Ready(Some(item)) => Poll::Ready(Some(Ok(item))),
+                Poll::Ready(None) => Poll::Ready(None),
+                Poll::Pending => Poll::Pending,
+            },
+            RecvStreamInner::Boxed(stream) => stream.poll_next_unpin(cx),
+        }
+    }
+}
+
+enum OpenFutureInner<'a, In: RpcMessage, Out: RpcMessage> {
+    /// A direct future (todo)
+    // Direct(...),
+    /// A boxed future
+    Boxed(BoxFuture<'a, anyhow::Result<(SendSink<Out>, RecvStream<In>)>>),
+}
+
+/// A concrete future for opening a channel
+#[pin_project]
+pub struct OpenFuture<'a, In: RpcMessage, Out: RpcMessage>(OpenFutureInner<'a, In, Out>);
+
+impl<'a, In: RpcMessage, Out: RpcMessage> OpenFuture<'a, In, Out> {
+    fn boxed(
+        f: impl Future<Output = anyhow::Result<(SendSink<Out>, RecvStream<In>)>> + Send + Sync + 'a,
+    ) -> Self {
+        Self(OpenFutureInner::Boxed(Box::pin(f)))
+    }
+}
+
+impl<'a, In: RpcMessage, Out: RpcMessage> Future for OpenFuture<'a, In, Out> {
+    type Output = anyhow::Result<(SendSink<Out>, RecvStream<In>)>;
+
+    fn poll(self: Pin<&mut Self>, cx: &mut std::task::Context<'_>) -> Poll<Self::Output> {
+        match self.project().0 {
+            OpenFutureInner::Boxed(f) => f.poll(cx),
+        }
+    }
+}
+
+enum AcceptFutureInner<'a, In: RpcMessage, Out: RpcMessage> {
+    /// A direct future (todo)
+    // Direct(...),
+    /// A boxed future
+    Boxed(BoxedFuture<'a, anyhow::Result<(SendSink<Out>, RecvStream<In>)>>),
+}
+
+/// Concrete accept future
+#[pin_project]
+pub struct AcceptFuture<'a, In: RpcMessage, Out: RpcMessage>(AcceptFutureInner<'a, In, Out>);
+
+impl<'a, In: RpcMessage, Out: RpcMessage> AcceptFuture<'a, In, Out> {
+    fn boxed(
+        f: impl Future<Output = anyhow::Result<(SendSink<Out>, RecvStream<In>)>> + Send + Sync + 'a,
+    ) -> Self {
+        Self(AcceptFutureInner::Boxed(Box::pin(f)))
+    }
+}
+
+impl<'a, In: RpcMessage, Out: RpcMessage> Future for AcceptFuture<'a, In, Out> {
+    type Output = anyhow::Result<(SendSink<Out>, RecvStream<In>)>;
+
+    fn poll(self: Pin<&mut Self>, cx: &mut std::task::Context<'_>) -> Poll<Self::Output> {
+        match self.project().0 {
+            AcceptFutureInner::Boxed(f) => f.poll(cx),
+        }
+    }
+}
+
+/// A boxable connection
+pub trait BoxableConnection<In: RpcMessage, Out: RpcMessage>:
+    Debug + Send + Sync + 'static
+{
+    /// Clone the connection and box it
+    fn clone_box(&self) -> Box<dyn BoxableConnection<In, Out>>;
+
+    /// Open a channel to the remote che
+    fn open_bi_boxed(&self) -> OpenFuture<In, Out>;
+}
+
+/// A boxed connection
+#[derive(Debug)]
+pub struct Connection<In: RpcMessage, Out: RpcMessage>(Box<dyn BoxableConnection<In, Out>>);
+
+impl<In: RpcMessage, Out: RpcMessage> Connection<In, Out> {
+    /// Wrap a boxable server endpoint into a box, transforming all the types to concrete types
+    pub fn new(x: impl BoxableConnection<In, Out>) -> Self {
+        Self(Box::new(x))
+    }
+}
+
+impl<In: RpcMessage, Out: RpcMessage> Clone for Connection<In, Out> {
+    fn clone(&self) -> Self {
+        Self(self.0.clone_box())
+    }
+}
+
+impl<In: RpcMessage, Out: RpcMessage> ConnectionCommon<In, Out> for Connection<In, Out> {
+    type RecvStream = RecvStream<In>;
+    type SendSink = SendSink<Out>;
+}
+
+impl<In: RpcMessage, Out: RpcMessage> ConnectionErrors for Connection<In, Out> {
+    type OpenError = anyhow::Error;
+    type SendError = anyhow::Error;
+    type RecvError = anyhow::Error;
+}
+
+impl<In: RpcMessage, Out: RpcMessage> super::Connection<In, Out> for Connection<In, Out> {
+    async fn open_bi(&self) -> Result<(Self::SendSink, Self::RecvStream), Self::OpenError> {
+        self.0.open_bi_boxed().await
+    }
+}
+
+/// A boxable server endpoint
+pub trait BoxableServerEndpoint<In: RpcMessage, Out: RpcMessage>:
+    Debug + Send + Sync + 'static
+{
+    /// Clone the server endpoint and box it
+    fn clone_box(&self) -> Box<dyn BoxableServerEndpoint<In, Out>>;
+
+    /// Accept a channel from a remote client
+    fn accept_bi_boxed(&self) -> AcceptFuture<In, Out>;
+
+    /// Get the local address
+    fn local_addr(&self) -> &[super::LocalAddr];
+}
+
+/// A boxed server endpoint
+#[derive(Debug)]
+pub struct ServerEndpoint<In: RpcMessage, Out: RpcMessage>(Box<dyn BoxableServerEndpoint<In, Out>>);
+
+impl<In: RpcMessage, Out: RpcMessage> ServerEndpoint<In, Out> {
+    /// Wrap a boxable server endpoint into a box, transforming all the types to concrete types
+    pub fn new(x: impl BoxableServerEndpoint<In, Out>) -> Self {
+        Self(Box::new(x))
+    }
+}
+
+impl<In: RpcMessage, Out: RpcMessage> Clone for ServerEndpoint<In, Out> {
+    fn clone(&self) -> Self {
+        Self(self.0.clone_box())
+    }
+}
+
+impl<In: RpcMessage, Out: RpcMessage> ConnectionCommon<In, Out> for ServerEndpoint<In, Out> {
+    type RecvStream = RecvStream<In>;
+    type SendSink = SendSink<Out>;
+}
+
+impl<In: RpcMessage, Out: RpcMessage> ConnectionErrors for ServerEndpoint<In, Out> {
+    type OpenError = anyhow::Error;
+    type SendError = anyhow::Error;
+    type RecvError = anyhow::Error;
+}
+
+impl<In: RpcMessage, Out: RpcMessage> super::ServerEndpoint<In, Out> for ServerEndpoint<In, Out> {
+    fn accept_bi(
+        &self,
+    ) -> impl Future<Output = Result<(Self::SendSink, Self::RecvStream), Self::OpenError>> + Send
+    {
+        self.0.accept_bi_boxed()
+    }
+
+    fn local_addr(&self) -> &[super::LocalAddr] {
+        self.0.local_addr()
+    }
+}
+
+#[cfg(feature = "quinn-transport")]
+impl<S: Service> BoxableConnection<S::Res, S::Req> for super::quinn::QuinnConnection<S> {
+    fn clone_box(&self) -> Box<dyn BoxableConnection<S::Res, S::Req>> {
+        Box::new(self.clone())
+    }
+
+    fn open_bi_boxed(&self) -> OpenFuture<S::Res, S::Req> {
+        let f = Box::pin(async move {
+            let (send, recv) = super::Connection::open_bi(self).await?;
+            // map the error types to anyhow
+            let send = send.sink_map_err(anyhow::Error::from);
+            let recv = recv.map_err(anyhow::Error::from);
+            // return the boxed streams
+            anyhow::Ok((SendSink::boxed(send), RecvStream::boxed(recv)))
+        });
+        OpenFuture::boxed(f)
+    }
+}
+
+#[cfg(feature = "quinn-transport")]
+impl<S: Service> BoxableServerEndpoint<S::Req, S::Res> for super::quinn::QuinnServerEndpoint<S> {
+    fn clone_box(&self) -> Box<dyn BoxableServerEndpoint<S::Req, S::Res>> {
+        Box::new(self.clone())
+    }
+
+    fn accept_bi_boxed(&self) -> AcceptFuture<S::Req, S::Res> {
+        let f = async move {
+            let (send, recv) = super::ServerEndpoint::accept_bi(self).await?;
+            let send = send.sink_map_err(anyhow::Error::from);
+            let recv = recv.map_err(anyhow::Error::from);
+            anyhow::Ok((SendSink::boxed(send), RecvStream::boxed(recv)))
+        };
+        AcceptFuture::boxed(f)
+    }
+
+    fn local_addr(&self) -> &[super::LocalAddr] {
+        super::ServerEndpoint::local_addr(self)
+    }
+}
+
+#[cfg(feature = "flume-transport")]
+impl<S: Service> BoxableConnection<S::Res, S::Req> for super::flume::FlumeConnection<S> {
+    fn clone_box(&self) -> Box<dyn BoxableConnection<S::Res, S::Req>> {
+        Box::new(self.clone())
+    }
+
+    fn open_bi_boxed(&self) -> OpenFuture<S::Res, S::Req> {
+        let f = Box::pin(async move {
+            let (send, recv) = super::Connection::open_bi(self).await?;
+            // return the boxed streams
+            anyhow::Ok((SendSink::direct(send.0), RecvStream::direct(recv.0)))
+        });
+        OpenFuture::boxed(f)
+    }
+}
+
+#[cfg(feature = "flume-transport")]
+impl<S: Service> BoxableServerEndpoint<S::Req, S::Res> for super::flume::FlumeServerEndpoint<S> {
+    fn clone_box(&self) -> Box<dyn BoxableServerEndpoint<S::Req, S::Res>> {
+        Box::new(self.clone())
+    }
+
+    fn accept_bi_boxed(&self) -> AcceptFuture<S::Req, S::Res> {
+        let f = Box::pin(async move {
+            let (send, recv) = super::ServerEndpoint::accept_bi(self)
+                .await
+                .map_err(anyhow::Error::from)?;
+            Ok((SendSink::direct(send.0), RecvStream::direct(recv.0)))
+        });
+        AcceptFuture::boxed(f)
+    }
+
+    fn local_addr(&self) -> &[super::LocalAddr] {
+        super::ServerEndpoint::local_addr(self)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::Service;
+
+    #[derive(Debug, Clone)]
+    struct FooService;
+
+    impl Service for FooService {
+        type Req = u64;
+        type Res = u64;
+    }
+
+    #[cfg(feature = "flume-transport")]
+    #[tokio::test]
+    async fn box_smoke() {
+        use futures_lite::StreamExt;
+        use futures_util::SinkExt;
+
+        use crate::transport::{Connection, ServerEndpoint};
+
+        let (server, client) = crate::transport::flume::connection::<FooService>(1);
+        let server = super::ServerEndpoint::new(server);
+        let client = super::Connection::new(client);
+        // spawn echo server
+        tokio::spawn(async move {
+            while let Ok((mut send, mut recv)) = server.accept_bi().await {
+                if let Some(Ok(msg)) = recv.next().await {
+                    send.send(msg).await.ok();
+                }
+            }
+            anyhow::Ok(())
+        });
+        if let Ok((mut send, mut recv)) = client.open_bi().await {
+            send.send(1).await.ok();
+            let res = recv.next().await;
+            println!("{:?}", res);
+        }
+    }
+}

--- a/src/transport/flume.rs
+++ b/src/transport/flume.rs
@@ -1,7 +1,7 @@
 //! Memory transport implementation using [flume]
 //!
 //! [flume]: https://docs.rs/flume/
-use futures_lite::Stream;
+use futures_lite::{Future, Stream};
 use futures_sink::Sink;
 
 use crate::{
@@ -9,7 +9,7 @@ use crate::{
     RpcMessage, Service,
 };
 use core::fmt;
-use std::{error, fmt::Display, pin::Pin, result, task::Poll};
+use std::{error, fmt::Display, marker::PhantomData, pin::Pin, result, task::Poll};
 
 use super::ConnectionCommon;
 
@@ -129,17 +129,84 @@ impl<S: Service> ConnectionErrors for FlumeServerEndpoint<S> {
     type OpenError = self::AcceptBiError;
 }
 
+type Socket<In, Out> = (self::SendSink<Out>, self::RecvStream<In>);
+
+/// Future returned by [FlumeConnection::open_bi]
+pub struct OpenBiFuture<In: RpcMessage, Out: RpcMessage> {
+    inner: flume::r#async::SendFut<'static, Socket<Out, In>>,
+    res: Option<Socket<In, Out>>,
+}
+
+impl<In: RpcMessage, Out: RpcMessage> fmt::Debug for OpenBiFuture<In, Out> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("OpenBiFuture").finish()
+    }
+}
+
+impl<In: RpcMessage, Out: RpcMessage> OpenBiFuture<In, Out> {
+    fn new(inner: flume::r#async::SendFut<'static, Socket<Out, In>>, res: Socket<In, Out>) -> Self {
+        Self {
+            inner,
+            res: Some(res),
+        }
+    }
+}
+
+impl<In: RpcMessage, Out: RpcMessage> Future for OpenBiFuture<In, Out> {
+    type Output = result::Result<Socket<In, Out>, self::OpenBiError>;
+
+    fn poll(
+        mut self: Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<Self::Output> {
+        match Pin::new(&mut self.inner).poll(cx) {
+            Poll::Ready(Ok(())) => self
+                .res
+                .take()
+                .map(|x| Poll::Ready(Ok(x)))
+                .unwrap_or(Poll::Pending),
+            Poll::Ready(Err(_)) => Poll::Ready(Err(self::OpenBiError::RemoteDropped)),
+            Poll::Pending => Poll::Pending,
+        }
+    }
+}
+
+/// Future returned by [FlumeServerEndpoint::accept_bi]
+pub struct AcceptBiFuture<In: RpcMessage, Out: RpcMessage> {
+    wrapped: flume::r#async::RecvFut<'static, (SendSink<Out>, RecvStream<In>)>,
+    _p: PhantomData<(In, Out)>,
+}
+
+impl<In: RpcMessage, Out: RpcMessage> fmt::Debug for AcceptBiFuture<In, Out> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("AcceptBiFuture").finish()
+    }
+}
+
+impl<In: RpcMessage, Out: RpcMessage> Future for AcceptBiFuture<In, Out> {
+    type Output = result::Result<(SendSink<Out>, RecvStream<In>), AcceptBiError>;
+
+    fn poll(mut self: Pin<&mut Self>, cx: &mut std::task::Context<'_>) -> Poll<Self::Output> {
+        match Pin::new(&mut self.wrapped).poll(cx) {
+            Poll::Ready(Ok((send, recv))) => Poll::Ready(Ok((send, recv))),
+            Poll::Ready(Err(_)) => Poll::Ready(Err(AcceptBiError::RemoteDropped)),
+            Poll::Pending => Poll::Pending,
+        }
+    }
+}
+
 impl<S: Service> ConnectionCommon<S::Req, S::Res> for FlumeServerEndpoint<S> {
     type SendSink = SendSink<S::Res>;
     type RecvStream = RecvStream<S::Req>;
 }
 
 impl<S: Service> ServerEndpoint<S::Req, S::Res> for FlumeServerEndpoint<S> {
-    async fn accept_bi(&self) -> Result<(Self::SendSink, Self::RecvStream), AcceptBiError> {
-        self.stream
-            .recv_async()
-            .await
-            .map_err(|_| AcceptBiError::RemoteDropped)
+    #[allow(refining_impl_trait)]
+    fn accept_bi(&self) -> AcceptBiFuture<S::Req, S::Res> {
+        AcceptBiFuture {
+            wrapped: self.stream.clone().into_recv_async(),
+            _p: PhantomData,
+        }
     }
 
     fn local_addr(&self) -> &[LocalAddr] {
@@ -161,7 +228,8 @@ impl<S: Service> ConnectionCommon<S::Res, S::Req> for FlumeConnection<S> {
 }
 
 impl<S: Service> Connection<S::Res, S::Req> for FlumeConnection<S> {
-    async fn open_bi(&self) -> Result<(Self::SendSink, Self::RecvStream), Self::OpenError> {
+    #[allow(refining_impl_trait)]
+    fn open_bi(&self) -> OpenBiFuture<S::Res, S::Req> {
         let (local_send, remote_recv) = flume::bounded::<S::Req>(128);
         let (remote_send, local_recv) = flume::bounded::<S::Res>(128);
         let remote_chan = (
@@ -172,11 +240,7 @@ impl<S: Service> Connection<S::Res, S::Req> for FlumeConnection<S> {
             SendSink(local_send.into_sink()),
             RecvStream(local_recv.into_stream()),
         );
-        self.sink
-            .send_async(remote_chan)
-            .await
-            .map_err(|_| OpenBiError::RemoteDropped)?;
-        Ok(local_chan)
+        OpenBiFuture::new(self.sink.clone().into_send_async(remote_chan), local_chan)
     }
 }
 

--- a/src/transport/flume.rs
+++ b/src/transport/flume.rs
@@ -26,7 +26,7 @@ impl fmt::Display for RecvError {
 }
 
 /// Sink for memory channels
-pub struct SendSink<T: RpcMessage>(flume::r#async::SendSink<'static, T>);
+pub struct SendSink<T: RpcMessage>(pub(crate) flume::r#async::SendSink<'static, T>);
 
 impl<T: RpcMessage> fmt::Debug for SendSink<T> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -72,7 +72,7 @@ impl<T: RpcMessage> Sink<T> for SendSink<T> {
 }
 
 /// Stream for memory channels
-pub struct RecvStream<T: RpcMessage>(flume::r#async::RecvStream<'static, T>);
+pub struct RecvStream<T: RpcMessage>(pub(crate) flume::r#async::RecvStream<'static, T>);
 
 impl<T: RpcMessage> fmt::Debug for RecvStream<T> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {

--- a/src/transport/mod.rs
+++ b/src/transport/mod.rs
@@ -7,6 +7,8 @@ use std::{
     fmt::{self, Debug, Display},
     net::SocketAddr,
 };
+#[cfg(feature = "flume-transport")]
+pub mod boxed;
 #[cfg(feature = "combined-transport")]
 pub mod combined;
 #[cfg(feature = "flume-transport")]


### PR DESCRIPTION
Boxed transform that allows to unify different transports without having to have a type parameter.

It has a special case for the memory transport so that one is not boxing.