### PR TITLE
deps: Upgrade to Quinn 0.11 and Rustls 0.23

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -68,12 +68,6 @@ dependencies = [
 
 [[package]]
 name = "base64"
-version = "0.21.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
-
-[[package]]
-name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
@@ -112,6 +106,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "41c270e7540d725e65ac7f1b212ac8ce349719624d7bcff99f8e2e488e8cf03f"
 
 [[package]]
+name = "cesu8"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d43a04d8753f35258c91f8ec639f792891f748a1edbd759cf1dcea3382ad83c"
+
+[[package]]
 name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -123,13 +123,23 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "futures",
- "iroh-quinn",
  "quic-rpc",
+ "quinn",
  "rustls",
  "serde",
  "tokio",
  "tracing-subscriber",
  "types",
+]
+
+[[package]]
+name = "combine"
+version = "4.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
+dependencies = [
+ "bytes",
+ "memchr",
 ]
 
 [[package]]
@@ -240,7 +250,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "nanorand",
- "spin 0.9.8",
+ "spin",
 ]
 
 [[package]]
@@ -502,58 +512,30 @@ dependencies = [
 ]
 
 [[package]]
-name = "iroh-quinn"
-version = "0.10.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b934380145fd5d53a583d01ae9500f4807efe6b0f0fe115c7be4afa2b35db99f"
-dependencies = [
- "bytes",
- "iroh-quinn-proto",
- "iroh-quinn-udp",
- "pin-project-lite",
- "rustc-hash",
- "rustls",
- "thiserror",
- "tokio",
- "tracing",
-]
-
-[[package]]
-name = "iroh-quinn-proto"
-version = "0.10.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16f2656b322c7f6cf3eb95e632d1c0f2fa546841915b0270da581f918c70c4be"
-dependencies = [
- "bytes",
- "rand",
- "ring 0.16.20",
- "rustc-hash",
- "rustls",
- "rustls-native-certs",
- "slab",
- "thiserror",
- "tinyvec",
- "tracing",
-]
-
-[[package]]
-name = "iroh-quinn-udp"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6679979a7271c24f9dae9622c0b4a543881508aa3a7396f55dfbaaa56f01c063"
-dependencies = [
- "bytes",
- "libc",
- "socket2",
- "tracing",
- "windows-sys 0.48.0",
-]
-
-[[package]]
 name = "itoa"
 version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b"
+
+[[package]]
+name = "jni"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6df18c2e3db7e453d3c6ac5b3e9d5182664d28788126d39b91f2d1e22b017ec"
+dependencies = [
+ "cesu8",
+ "combine",
+ "jni-sys",
+ "log",
+ "thiserror",
+ "walkdir",
+]
+
+[[package]]
+name = "jni-sys"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8eaf4bc02d17cbdd7ff4c7438cafcdf7fb9a4613313ad11b4f8fefe7d3fa0130"
 
 [[package]]
 name = "js-sys"
@@ -749,7 +731,7 @@ version = "3.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e459365e590736a54c3fa561947c84837534b8e9af6fc5bf781307e82658fae"
 dependencies = [
- "base64 0.22.1",
+ "base64",
  "serde",
 ]
 
@@ -825,10 +807,10 @@ dependencies = [
  "hex",
  "hyper",
  "interprocess",
- "iroh-quinn",
- "iroh-quinn-udp",
  "pin-project",
  "proc-macro2",
+ "quinn",
+ "quinn-udp",
  "rcgen",
  "rustls",
  "serde",
@@ -839,6 +821,54 @@ dependencies = [
  "tokio-util",
  "tracing",
  "tracing-subscriber",
+]
+
+[[package]]
+name = "quinn"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4ceeeeabace7857413798eb1ffa1e9c905a9946a57d81fb69b4b71c4d8eb3ad"
+dependencies = [
+ "bytes",
+ "pin-project-lite",
+ "quinn-proto",
+ "quinn-udp",
+ "rustc-hash",
+ "rustls",
+ "thiserror",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddf517c03a109db8100448a4be38d498df8a210a99fe0e1b9eaf39e78c640efe"
+dependencies = [
+ "bytes",
+ "rand",
+ "ring",
+ "rustc-hash",
+ "rustls",
+ "rustls-platform-verifier",
+ "slab",
+ "thiserror",
+ "tinyvec",
+ "tracing",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9096629c45860fc7fb143e125eb826b5e721e10be3263160c7d60ca832cf8c46"
+dependencies = [
+ "libc",
+ "once_cell",
+ "socket2",
+ "tracing",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -887,7 +917,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48406db8ac1f3cbc7dcdb56ec355343817958a356ff430259bb07baf7607e1e1"
 dependencies = [
  "pem",
- "ring 0.17.8",
+ "ring",
  "time",
  "yasna",
 ]
@@ -909,21 +939,6 @@ dependencies = [
 
 [[package]]
 name = "ring"
-version = "0.16.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3053cf52e236a3ed746dfc745aa9cacf1b791d846bdaf412f60a8d7d6e17c8fc"
-dependencies = [
- "cc",
- "libc",
- "once_cell",
- "spin 0.5.2",
- "untrusted 0.7.1",
- "web-sys",
- "winapi",
-]
-
-[[package]]
-name = "ring"
 version = "0.17.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c17fa4cb658e3583423e915b9f3acc01cceaee1860e33d59ebae66adc3a2dc0d"
@@ -932,8 +947,8 @@ dependencies = [
  "cfg-if",
  "getrandom",
  "libc",
- "spin 0.9.8",
- "untrusted 0.9.0",
+ "spin",
+ "untrusted",
  "windows-sys 0.52.0",
 ]
 
@@ -964,45 +979,92 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.21.12"
+version = "0.23.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f56a14d1f48b391359b22f731fd4bd7e43c97f3c50eee276f3aa09c94784d3e"
+checksum = "a218f0f6d05669de4eabfb24f31ce802035c952429d037507b4a4a39f0e60c5b"
 dependencies = [
- "log",
- "ring 0.17.8",
+ "once_cell",
+ "ring",
+ "rustls-pki-types",
  "rustls-webpki",
- "sct",
+ "subtle",
+ "zeroize",
 ]
 
 [[package]]
 name = "rustls-native-certs"
-version = "0.6.3"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9aace74cb666635c918e9c12bc0d348266037aa8eb599b5cba565709a8dff00"
+checksum = "8f1fb85efa936c42c6d5fc28d2629bb51e4b2f4b8a5211e297d599cc5a093792"
 dependencies = [
  "openssl-probe",
  "rustls-pemfile",
+ "rustls-pki-types",
  "schannel",
  "security-framework",
 ]
 
 [[package]]
 name = "rustls-pemfile"
-version = "1.0.4"
+version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c74cae0a4cf6ccbbf5f359f08efdf8ee7e1dc532573bf0db71968cb56b1448c"
+checksum = "29993a25686778eb88d4189742cd713c9bce943bc54251a33509dc63cbacf73d"
 dependencies = [
- "base64 0.21.7",
+ "base64",
+ "rustls-pki-types",
 ]
 
 [[package]]
-name = "rustls-webpki"
-version = "0.101.7"
+name = "rustls-pki-types"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765"
+checksum = "976295e77ce332211c0d24d92c0e83e50f5c5f046d11082cea19f3df13a3562d"
+
+[[package]]
+name = "rustls-platform-verifier"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5f0d26fa1ce3c790f9590868f0109289a044acb954525f933e2aa3b871c157d"
 dependencies = [
- "ring 0.17.8",
- "untrusted 0.9.0",
+ "core-foundation",
+ "core-foundation-sys",
+ "jni",
+ "log",
+ "once_cell",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-platform-verifier-android",
+ "rustls-webpki",
+ "security-framework",
+ "security-framework-sys",
+ "webpki-roots",
+ "winapi",
+]
+
+[[package]]
+name = "rustls-platform-verifier-android"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84e217e7fdc8466b5b35d30f8c0a30febd29173df4a3a0c2115d306b9c4117ad"
+
+[[package]]
+name = "rustls-webpki"
+version = "0.102.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff448f7e92e913c4b7d4c6d8e4540a1724b319b4152b8aef6d4cf8339712b33e"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
+]
+
+[[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
 ]
 
 [[package]]
@@ -1021,16 +1083,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
-name = "sct"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da046153aa2352493d6cb7da4b6e5c0c057d8a1d0a9aa8560baffdd945acd414"
-dependencies = [
- "ring 0.17.8",
- "untrusted 0.9.0",
-]
-
-[[package]]
 name = "security-framework"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1040,6 +1092,7 @@ dependencies = [
  "core-foundation",
  "core-foundation-sys",
  "libc",
+ "num-bigint",
  "security-framework-sys",
 ]
 
@@ -1080,8 +1133,8 @@ dependencies = [
  "anyhow",
  "async-stream",
  "futures",
- "iroh-quinn",
  "quic-rpc",
+ "quinn",
  "rcgen",
  "rustls",
  "serde",
@@ -1135,18 +1188,18 @@ dependencies = [
 
 [[package]]
 name = "spin"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
-
-[[package]]
-name = "spin"
 version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
 dependencies = [
  "lock_api",
 ]
+
+[[package]]
+name = "subtle"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81cdd64d312baedb58e21336b31bc043b77e01cc99033ce76ef539f78e965ebc"
 
 [[package]]
 name = "syn"
@@ -1404,12 +1457,6 @@ checksum = "f962df74c8c05a667b5ee8bcf162993134c104e96440b663c8daa176dc772d8c"
 
 [[package]]
 name = "untrusted"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
-
-[[package]]
-name = "untrusted"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
@@ -1419,6 +1466,16 @@ name = "valuable"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
+
+[[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
 
 [[package]]
 name = "want"
@@ -1490,13 +1547,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af190c94f2773fdb3729c55b007a722abb5384da03bc0986df4c289bf5567e96"
 
 [[package]]
-name = "web-sys"
-version = "0.3.69"
+name = "webpki-roots"
+version = "0.26.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77afa9a11836342370f4817622a2f0f418b134426d91a82dfb48f532d2ec13ef"
+checksum = "3c452ad30530b54a4d8e71952716a212b08efd0f3562baa66c29a618b07da7c3"
 dependencies = [
- "js-sys",
- "wasm-bindgen",
+ "rustls-pki-types",
 ]
 
 [[package]]
@@ -1520,6 +1576,15 @@ name = "winapi-i686-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-util"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d4cc384e1e73b93bafa6fb4f1df8c41695c8a91cf9c4c64358067d15a7b6c6b"
+dependencies = [
+ "windows-sys 0.52.0",
+]
 
 [[package]]
 name = "winapi-x86_64-pc-windows-gnu"
@@ -1674,3 +1739,9 @@ checksum = "e17bb3549cc1321ae1296b9cdc2698e2b6cb1992adfa19a8c72e5b7a738f44cd"
 dependencies = [
  "time",
 ]
+
+[[package]]
+name = "zeroize"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ced3678a2879b30306d323f4542626697a464a97c0a07c9aebf7ebca65cd4dde"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -123,8 +123,8 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "futures",
+ "iroh-quinn",
  "quic-rpc",
- "quinn",
  "rustls",
  "serde",
  "tokio",
@@ -512,6 +512,51 @@ dependencies = [
 ]
 
 [[package]]
+name = "iroh-quinn"
+version = "0.11.1"
+source = "git+https://github.com/n0-computer/quinn?branch=iroh-0.11.x#89f0588ccff30ff5c544e385d94aab8fa73bd399"
+dependencies = [
+ "bytes",
+ "iroh-quinn-proto",
+ "iroh-quinn-udp",
+ "pin-project-lite",
+ "rustc-hash",
+ "rustls",
+ "thiserror",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "iroh-quinn-proto"
+version = "0.11.2"
+source = "git+https://github.com/n0-computer/quinn?branch=iroh-0.11.x#89f0588ccff30ff5c544e385d94aab8fa73bd399"
+dependencies = [
+ "bytes",
+ "rand",
+ "ring",
+ "rustc-hash",
+ "rustls",
+ "rustls-platform-verifier",
+ "slab",
+ "thiserror",
+ "tinyvec",
+ "tracing",
+]
+
+[[package]]
+name = "iroh-quinn-udp"
+version = "0.5.1"
+source = "git+https://github.com/n0-computer/quinn?branch=iroh-0.11.x#89f0588ccff30ff5c544e385d94aab8fa73bd399"
+dependencies = [
+ "libc",
+ "once_cell",
+ "socket2",
+ "tracing",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -807,10 +852,9 @@ dependencies = [
  "hex",
  "hyper",
  "interprocess",
+ "iroh-quinn",
  "pin-project",
  "proc-macro2",
- "quinn",
- "quinn-udp",
  "rcgen",
  "rustls",
  "serde",
@@ -821,54 +865,6 @@ dependencies = [
  "tokio-util",
  "tracing",
  "tracing-subscriber",
-]
-
-[[package]]
-name = "quinn"
-version = "0.11.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4ceeeeabace7857413798eb1ffa1e9c905a9946a57d81fb69b4b71c4d8eb3ad"
-dependencies = [
- "bytes",
- "pin-project-lite",
- "quinn-proto",
- "quinn-udp",
- "rustc-hash",
- "rustls",
- "thiserror",
- "tokio",
- "tracing",
-]
-
-[[package]]
-name = "quinn-proto"
-version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddf517c03a109db8100448a4be38d498df8a210a99fe0e1b9eaf39e78c640efe"
-dependencies = [
- "bytes",
- "rand",
- "ring",
- "rustc-hash",
- "rustls",
- "rustls-platform-verifier",
- "slab",
- "thiserror",
- "tinyvec",
- "tracing",
-]
-
-[[package]]
-name = "quinn-udp"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9096629c45860fc7fb143e125eb826b5e721e10be3263160c7d60ca832cf8c46"
-dependencies = [
- "libc",
- "once_cell",
- "socket2",
- "tracing",
- "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1133,8 +1129,8 @@ dependencies = [
  "anyhow",
  "async-stream",
  "futures",
+ "iroh-quinn",
  "quic-rpc",
- "quinn",
  "rcgen",
  "rustls",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -835,7 +835,7 @@ dependencies = [
 
 [[package]]
 name = "quic-rpc"
-version = "0.10.2"
+version = "0.11.0"
 dependencies = [
  "anyhow",
  "async-stream",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -519,8 +519,8 @@ dependencies = [
 
 [[package]]
 name = "iroh-quinn"
-version = "0.11.1"
-source = "git+https://github.com/n0-computer/quinn?branch=iroh-0.11.x#89f0588ccff30ff5c544e385d94aab8fa73bd399"
+version = "0.11.3"
+source = "git+https://github.com/n0-computer/quinn?branch=iroh-0.11.x#a32092de403b798a911d27da5f00df6d21731aed"
 dependencies = [
  "bytes",
  "iroh-quinn-proto",
@@ -528,6 +528,7 @@ dependencies = [
  "pin-project-lite",
  "rustc-hash",
  "rustls",
+ "socket2",
  "thiserror",
  "tokio",
  "tracing",
@@ -535,8 +536,8 @@ dependencies = [
 
 [[package]]
 name = "iroh-quinn-proto"
-version = "0.11.2"
-source = "git+https://github.com/n0-computer/quinn?branch=iroh-0.11.x#89f0588ccff30ff5c544e385d94aab8fa73bd399"
+version = "0.11.6"
+source = "git+https://github.com/n0-computer/quinn?branch=iroh-0.11.x#a32092de403b798a911d27da5f00df6d21731aed"
 dependencies = [
  "bytes",
  "rand",
@@ -552,8 +553,8 @@ dependencies = [
 
 [[package]]
 name = "iroh-quinn-udp"
-version = "0.5.1"
-source = "git+https://github.com/n0-computer/quinn?branch=iroh-0.11.x#89f0588ccff30ff5c544e385d94aab8fa73bd399"
+version = "0.5.4"
+source = "git+https://github.com/n0-computer/quinn?branch=iroh-0.11.x#a32092de403b798a911d27da5f00df6d21731aed"
 dependencies = [
  "libc",
  "once_cell",
@@ -975,9 +976,9 @@ checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
 
 [[package]]
 name = "rustc-hash"
-version = "1.1.0"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
+checksum = "583034fd73374156e66797ed8e5b0d5690409c9226b22d87cb7f19821c05d152"
 
 [[package]]
 name = "rustix"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -392,6 +392,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4271d37baee1b8c7e4b708028c57d816cf9d2434acb33a549475f78c181f6253"
 
 [[package]]
+name = "glob"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
+
+[[package]]
 name = "h2"
 version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -868,6 +874,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "quic-rpc-derive"
+version = "0.11.0"
+dependencies = [
+ "derive_more",
+ "proc-macro2",
+ "quic-rpc",
+ "quote",
+ "serde",
+ "syn 1.0.109",
+ "trybuild",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1055,6 +1074,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ryu"
+version = "1.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f"
+
+[[package]]
 name = "same-file"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1104,22 +1129,42 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.202"
+version = "1.0.203"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "226b61a0d411b2ba5ff6d7f73a476ac4f8bb900373459cd00fab8512828ba395"
+checksum = "7253ab4de971e72fb7be983802300c30b5a7f0c2e56fab8abfc6a214307c0094"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.202"
+version = "1.0.203"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6048858004bcff69094cd972ed40a32500f153bd3be9f716b2eed2e8217c4838"
+checksum = "500cbc0ebeb6f46627f50f3f5811ccf6bf00643be300b4c3eabc0ef55dc5b5ba"
 dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.66",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.120"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e0d21c9a8cae1235ad58a00c11cb40d4b1e5c784f1ef2c537876ed6ffd8b7c5"
+dependencies = [
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
+name = "serde_spanned"
+version = "0.6.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79e674e01f999af37c49f70a6ede167a8a60b2503e56c5599532a65baa5969a0"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
@@ -1229,6 +1274,15 @@ dependencies = [
  "fastrand",
  "rustix",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "termcolor"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
+dependencies = [
+ "winapi-util",
 ]
 
 [[package]]
@@ -1360,6 +1414,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml"
+version = "0.8.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f49eb2ab21d2f26bd6db7bf383edc527a7ebaee412d17af4d40fdccd442f335"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_edit",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4badfd56924ae69bcc9039335b2e017639ce3f9b001c393c1b2d1ef846ce2cbf"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.22.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f21c7aaf97f1bd9ca9d4f9e73b0a6c74bd5afef56f2bc931943a6e1c37e04e38"
+dependencies = [
+ "indexmap",
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "winnow",
+]
+
+[[package]]
 name = "tower-service"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1428,6 +1516,20 @@ name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
+name = "trybuild"
+version = "1.0.96"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33a5f13f11071020bb12de7a16b925d2d58636175c20c11dc5f96cb64bb6c9b3"
+dependencies = [
+ "glob",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "termcolor",
+ "toml",
+]
 
 [[package]]
 name = "types"
@@ -1726,6 +1828,15 @@ name = "windows_x86_64_msvc"
 version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bec47e5bfd1bff0eeaf6d8b485cc1074891a197ab4225d504cb7a1ab88b02bf0"
+
+[[package]]
+name = "winnow"
+version = "0.6.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59b5e5f6c299a3c7890b876a2a587f3115162487e704907d9b6cd29473052ba1"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "yasna"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "quic-rpc"
-version = "0.10.2"
+version = "0.11.0"
 edition = "2021"
 authors = ["Rüdiger Klaehn <rklaehn@protonmail.com>"]
 keywords = ["api", "protocol", "network", "rpc"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,13 +22,13 @@ futures-sink = "0.3.30"
 futures-util = { version = "0.3.30", features = ["sink"] }
 hyper = { version = "0.14.16", features = ["full"], optional = true }
 pin-project = "1"
-quinn = { package = "iroh-quinn", version = "0.10", optional = true }
+quinn = { package = "quinn", version = "0.11", optional = true }
 serde = { version = "1.0.183", features = ["derive"] }
 tokio = { version = "1", default-features = false, features = ["macros", "sync"] }
 tokio-serde = { version = "0.8", features = ["bincode"], optional = true }
 tokio-util = { version = "0.7", features = ["codec"], optional = true }
 tracing = "0.1"
-quinn-udp = { package = "iroh-quinn-udp", version = "0.4.0", optional = true }
+quinn-udp = { package = "quinn-udp", version = "0.5.2", optional = true }
 interprocess = { version = "2.1", features = ["tokio"], optional = true }
 hex = "0.4.3"
 futures = { version = "0.3.30", optional = true }
@@ -46,9 +46,9 @@ async-stream = "0.3.3"
 
 serde = { version = "1", features = ["derive"] }
 tokio = { version = "1", features = ["full"] }
-quinn = { package = "iroh-quinn", version = "0.10" }
+quinn = { package = "quinn", version = "0.11" }
 rcgen = "0.12"
-rustls = "0.21"
+rustls = { version = "0.23", default-features = false, features = ["ring"] }
 thousands = "0.2.0"
 tracing-subscriber = "0.3.16"
 tempfile = "3.5.0"
@@ -59,9 +59,7 @@ futures-buffered = "0.2.4"
 hyper-transport = ["dep:flume", "dep:hyper", "dep:bincode", "dep:bytes", "dep:tokio-serde", "dep:tokio-util"]
 quinn-transport = ["dep:flume", "dep:quinn", "dep:bincode", "dep:tokio-serde", "dep:tokio-util"]
 flume-transport = ["dep:flume"]
-interprocess-transport = ["quinn-transport", "quinn-flume-socket", "dep:quinn-udp", "dep:interprocess", "dep:bytes", "dep:tokio-util", "dep:futures"]
 combined-transport = []
-quinn-flume-socket = ["dep:flume", "dep:quinn", "dep:quinn-udp", "dep:bytes", "dep:tokio-util"]
 macros = []
 default = ["flume-transport"]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -82,7 +82,7 @@ name = "modularize"
 required-features = ["flume-transport"]
 
 [workspace]
-members = ["examples/split/types", "examples/split/server", "examples/split/client"]
+members = ["examples/split/types", "examples/split/server", "examples/split/client", "quic-rpc-derive"]
 
 [patch.crates-io]
 iroh-quinn = { git = "https://github.com/n0-computer/quinn", branch = "iroh-0.11.x" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,13 +22,12 @@ futures-sink = "0.3.30"
 futures-util = { version = "0.3.30", features = ["sink"] }
 hyper = { version = "0.14.16", features = ["full"], optional = true }
 pin-project = "1"
-quinn = { package = "quinn", version = "0.11", optional = true }
+quinn = { package = "iroh-quinn", version = "0.11", optional = true }
 serde = { version = "1.0.183", features = ["derive"] }
 tokio = { version = "1", default-features = false, features = ["macros", "sync"] }
 tokio-serde = { version = "0.8", features = ["bincode"], optional = true }
 tokio-util = { version = "0.7", features = ["codec"], optional = true }
 tracing = "0.1"
-quinn-udp = { package = "quinn-udp", version = "0.5.2", optional = true }
 interprocess = { version = "2.1", features = ["tokio"], optional = true }
 hex = "0.4.3"
 futures = { version = "0.3.30", optional = true }
@@ -46,7 +45,7 @@ async-stream = "0.3.3"
 
 serde = { version = "1", features = ["derive"] }
 tokio = { version = "1", features = ["full"] }
-quinn = { package = "quinn", version = "0.11" }
+quinn = { package = "iroh-quinn", version = "0.11", features = ["ring"] }
 rcgen = "0.12"
 rustls = { version = "0.23", default-features = false, features = ["ring"] }
 thousands = "0.2.0"
@@ -84,3 +83,6 @@ required-features = ["flume-transport"]
 
 [workspace]
 members = ["examples/split/types", "examples/split/server", "examples/split/client"]
+
+[patch.crates-io]
+iroh-quinn = { git = "https://github.com/n0-computer/quinn", branch = "iroh-0.11.x" }

--- a/examples/errors.rs
+++ b/examples/errors.rs
@@ -60,7 +60,7 @@ async fn main() -> anyhow::Result<()> {
     let server = RpcServer::new(server);
     let handle = tokio::task::spawn(async move {
         for _ in 0..1 {
-            let (req, chan) = server.accept().await?;
+            let (req, chan) = server.accept().await?.read_first().await?;
             match req {
                 IoRequest::Write(req) => chan.rpc_map_err(req, fs, Fs::write).await,
             }?

--- a/examples/modularize.rs
+++ b/examples/modularize.rs
@@ -34,7 +34,10 @@ async fn main() -> Result<()> {
 async fn run_server<C: ServiceEndpoint<AppService>>(server_conn: C, handler: app::Handler) {
     let server = RpcServer::new(server_conn);
     loop {
-        match server.accept().await {
+        let Ok(accepting) = server.accept().await else {
+            continue;
+        };
+        match accepting.read_first().await {
             Err(err) => warn!(?err, "server accept failed"),
             Ok((req, chan)) => {
                 let handler = handler.clone();

--- a/examples/split/client/Cargo.toml
+++ b/examples/split/client/Cargo.toml
@@ -9,8 +9,8 @@ edition = "2021"
 anyhow = "1.0.14"
 futures = "0.3.26"
 quic-rpc = { path = "../../..", features = ["quinn-transport", "macros"] }
-quinn = { package = "iroh-quinn", version = "0.10" }
-rustls = { version = "0.21", features = ["dangerous_configuration"] }
+quinn = { package = "quinn", version = "0.11" }
+rustls = { version = "0.23", default-features = false, features = ["ring"] }
 tracing-subscriber = "0.3.16"
 serde = { version = "1", features = ["derive"] }
 tokio = { version = "1", features = ["full"] }

--- a/examples/split/client/Cargo.toml
+++ b/examples/split/client/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2021"
 anyhow = "1.0.14"
 futures = "0.3.26"
 quic-rpc = { path = "../../..", features = ["quinn-transport", "macros"] }
-quinn = { package = "quinn", version = "0.11" }
+quinn = { package = "iroh-quinn", version = "0.11" }
 rustls = { version = "0.23", default-features = false, features = ["ring"] }
 tracing-subscriber = "0.3.16"
 serde = { version = "1", features = ["derive"] }

--- a/examples/split/server/Cargo.toml
+++ b/examples/split/server/Cargo.toml
@@ -11,9 +11,9 @@ async-stream = "0.3.3"
 futures = "0.3.26"
 tracing-subscriber = "0.3.16"
 quic-rpc = { path = "../../..", features = ["quinn-transport", "macros"] }
-quinn = { package = "iroh-quinn", version = "0.10" }
+quinn = { package = "quinn", version = "0.11" }
 rcgen = "0.12.0"
-rustls = "0.21"
+rustls = { version = "0.23", default-features = false, features = ["ring"] }
 serde = { version = "1", features = ["derive"] }
 tokio = { version = "1", features = ["full"] }
 types = { path = "../types" }

--- a/examples/split/server/Cargo.toml
+++ b/examples/split/server/Cargo.toml
@@ -11,7 +11,7 @@ async-stream = "0.3.3"
 futures = "0.3.26"
 tracing-subscriber = "0.3.16"
 quic-rpc = { path = "../../..", features = ["quinn-transport", "macros"] }
-quinn = { package = "quinn", version = "0.11" }
+quinn = { package = "iroh-quinn", version = "0.11" }
 rcgen = "0.12.0"
 rustls = { version = "0.23", default-features = false, features = ["ring"] }
 serde = { version = "1", features = ["derive"] }

--- a/examples/split/server/src/main.rs
+++ b/examples/split/server/src/main.rs
@@ -84,10 +84,10 @@ fn configure_server() -> anyhow::Result<(ServerConfig, Vec<u8>)> {
     let cert = rcgen::generate_simple_self_signed(vec!["localhost".into()])?;
     let cert_der = cert.serialize_der()?;
     let priv_key = cert.serialize_private_key_der();
-    let priv_key = rustls::PrivateKey(priv_key);
-    let cert_chain = vec![rustls::Certificate(cert_der.clone())];
+    let priv_key = rustls::pki_types::PrivatePkcs8KeyDer::from(priv_key);
+    let cert_chain = vec![rustls::pki_types::CertificateDer::from(cert_der.clone())];
 
-    let mut server_config = ServerConfig::with_single_cert(cert_chain, priv_key)?;
+    let mut server_config = ServerConfig::with_single_cert(cert_chain, priv_key.into())?;
     Arc::get_mut(&mut server_config.transport)
         .unwrap()
         .max_concurrent_uni_streams(0_u8.into());

--- a/examples/store.rs
+++ b/examples/store.rs
@@ -168,7 +168,7 @@ async fn main() -> anyhow::Result<()> {
         let s = server;
         let store = Store;
         loop {
-            let (req, chan) = s.accept().await?;
+            let (req, chan) = s.accept().await?.read_first().await?;
             use StoreRequest::*;
             let store = store.clone();
             #[rustfmt::skip]
@@ -239,7 +239,7 @@ async fn _main_unsugared() -> anyhow::Result<()> {
     }
     let (server, client) = flume::connection::<Service>(1);
     let to_string_service = tokio::spawn(async move {
-        let (mut send, mut recv) = server.accept_bi().await?;
+        let (mut send, mut recv) = server.accept().await?;
         while let Some(item) = recv.next().await {
             let item = item?;
             println!("server got: {item:?}");
@@ -247,7 +247,7 @@ async fn _main_unsugared() -> anyhow::Result<()> {
         }
         anyhow::Ok(())
     });
-    let (mut send, mut recv) = client.open_bi().await?;
+    let (mut send, mut recv) = client.open().await?;
     let print_result_service = tokio::spawn(async move {
         while let Some(item) = recv.next().await {
             let item = item?;

--- a/quic-rpc-derive/Cargo.toml
+++ b/quic-rpc-derive/Cargo.toml
@@ -1,0 +1,24 @@
+[package]
+name = "quic-rpc-derive"
+version = "0.11.0"
+edition = "2021"
+authors = ["Rüdiger Klaehn <rklaehn@protonmail.com>"]
+keywords = ["api", "protocol", "network", "rpc", "macro"]
+categories = ["network-programming"]
+license = "Apache-2.0/MIT"
+repository = "https://github.com/n0-computer/quic-rpc"
+description = "Macros for quic-rpc"
+
+[lib]
+proc-macro = true
+
+[dependencies]
+syn = { version = "1.0", features = ["full"] }
+quote = "1.0"
+proc-macro2 = "1.0"
+quic-rpc = { version = "0.11", path = ".." }
+
+[dev-dependencies]
+derive_more = "1.0.0-beta.6"
+serde = { version = "1.0.203", features = ["serde_derive"] }
+trybuild = "1.0.96"

--- a/quic-rpc-derive/src/lib.rs
+++ b/quic-rpc-derive/src/lib.rs
@@ -1,0 +1,231 @@
+use proc_macro::TokenStream;
+use proc_macro2::{Span, TokenStream as TokenStream2};
+use quote::{quote, ToTokens};
+use std::collections::{BTreeMap, HashSet};
+use syn::{
+    parse::{Parse, ParseStream},
+    parse_macro_input,
+    spanned::Spanned,
+    Data, DeriveInput, Fields, Ident, Token, Type,
+};
+
+const SERVER_STREAMING: &str = "server_streaming";
+const CLIENT_STREAMING: &str = "client_streaming";
+const BIDI_STREAMING: &str = "bidi_streaming";
+const RPC: &str = "rpc";
+const TRY_SERVER_STREAMING: &str = "try_server_streaming";
+const IDENTS: [&str; 5] = [
+    SERVER_STREAMING,
+    CLIENT_STREAMING,
+    BIDI_STREAMING,
+    RPC,
+    TRY_SERVER_STREAMING,
+];
+
+fn generate_rpc_impls(
+    pat: &str,
+    mut args: RpcArgs,
+    service_name: &Ident,
+    request_type: &Type,
+    attr_span: Span,
+) -> syn::Result<TokenStream2> {
+    let res = match pat {
+        RPC => {
+            let response = args.get("response", pat, attr_span)?;
+            quote! {
+                impl ::quic_rpc::pattern::rpc::RpcMsg<#service_name> for #request_type {
+                    type Response = #response;
+                }
+            }
+        }
+        SERVER_STREAMING => {
+            let response = args.get("response", pat, attr_span)?;
+            quote! {
+                impl ::quic_rpc::message::Msg<#service_name> for #request_type {
+                    type Pattern = ::quic_rpc::pattern::server_streaming::ServerStreaming;
+                }
+                impl ::quic_rpc::pattern::server_streaming::ServerStreamingMsg<#service_name> for #request_type {
+                    type Response = #response;
+                }
+            }
+        }
+        BIDI_STREAMING => {
+            let update = args.get("update", pat, attr_span)?;
+            let response = args.get("response", pat, attr_span)?;
+            quote! {
+                impl ::quic_rpc::message::Msg<#service_name> for #request_type {
+                    type Pattern = ::quic_rpc::pattern::bidi_streaming::BidiStreaming;
+                }
+                impl ::quic_rpc::pattern::bidi_streaming::BidiStreamingMsg<#service_name> for #request_type {
+                    type Update = #update;
+                    type Response = #response;
+                }
+            }
+        }
+        CLIENT_STREAMING => {
+            let update = args.get("update", pat, attr_span)?;
+            let response = args.get("response", pat, attr_span)?;
+            quote! {
+                impl ::quic_rpc::message::Msg<#service_name> for #request_type {
+                    type Pattern = ::quic_rpc::pattern::client_streaming::ClientStreaming;
+                }
+                impl ::quic_rpc::pattern::client_streaming::ClientStreamingMsg<#service_name> for #request_type {
+                    type Update = #update;
+                    type Response = #response;
+                }
+            }
+        }
+        TRY_SERVER_STREAMING => {
+            let create_error = args.get("create_error", pat, attr_span)?;
+            let item_error = args.get("item_error", pat, attr_span)?;
+            let item = args.get("item", pat, attr_span)?;
+            quote! {
+                impl ::quic_rpc::message::Msg<#service_name> for #request_type {
+                    type Pattern = ::quic_rpc::pattern::try_server_streaming::TryServerStreaming;
+                }
+                impl ::quic_rpc::pattern::try_server_streaming::TryServerStreamingMsg<#service_name> for #request_type {
+                    type CreateError = #create_error;
+                    type ItemError = #item_error;
+                    type Item = #item;
+                }
+            }
+        }
+        _ => return Err(syn::Error::new(attr_span, "Unknown RPC pattern")),
+    };
+    args.check_empty(attr_span)?;
+
+    Ok(res)
+}
+
+#[proc_macro_attribute]
+pub fn rpc_requests(attr: TokenStream, item: TokenStream) -> TokenStream {
+    let mut input = parse_macro_input!(item as DeriveInput);
+    let service_name = parse_macro_input!(attr as Ident);
+
+    let input_span = input.span();
+    let data_enum = match &mut input.data {
+        Data::Enum(data_enum) => data_enum,
+        _ => {
+            return syn::Error::new(input.span(), "RpcRequests can only be applied to enums")
+                .to_compile_error()
+                .into()
+        }
+    };
+
+    let mut additional_items = Vec::new();
+    let mut types = HashSet::new();
+
+    for variant in &mut data_enum.variants {
+        // Check field structure for every variant
+        let request_type = match &variant.fields {
+            Fields::Unnamed(fields) if fields.unnamed.len() == 1 => &fields.unnamed[0].ty,
+            _ => {
+                return syn::Error::new(
+                    variant.span(),
+                    "Each variant must have exactly one unnamed field",
+                )
+                .to_compile_error()
+                .into()
+            }
+        };
+
+        if !types.insert(request_type.to_token_stream().to_string()) {
+            return syn::Error::new(input_span, "Each variant must have a unique request type")
+                .to_compile_error()
+                .into();
+        }
+
+        // Extract and remove RPC attributes
+        let mut rpc_attr = Vec::new();
+        variant.attrs.retain(|attr| {
+            for ident in IDENTS {
+                if attr.path.is_ident(ident) {
+                    rpc_attr.push((ident, attr.clone()));
+                    return false;
+                }
+            }
+            true
+        });
+
+        // Fail if there are multiple RPC patterns
+        if rpc_attr.len() > 1 {
+            return syn::Error::new(variant.span(), "Each variant can only have one RPC pattern")
+                .to_compile_error()
+                .into();
+        }
+
+        if let Some((ident, attr)) = rpc_attr.pop() {
+            let args = match attr.parse_args::<RpcArgs>() {
+                Ok(info) => info,
+                Err(e) => return e.to_compile_error().into(),
+            };
+
+            match generate_rpc_impls(ident, args, &service_name, request_type, attr.span()) {
+                Ok(impls) => additional_items.extend(impls),
+                Err(e) => return e.to_compile_error().into(),
+            }
+        }
+    }
+
+    let output = quote! {
+        #input
+
+        #(#additional_items)*
+    };
+
+    output.into()
+}
+
+struct RpcArgs {
+    types: BTreeMap<String, Type>,
+}
+
+impl RpcArgs {
+    /// Get and remove a type from the map, failing if it doesn't exist
+    fn get(&mut self, key: &str, kind: &str, span: Span) -> syn::Result<Type> {
+        self.types
+            .remove(key)
+            .ok_or_else(|| syn::Error::new(span, format!("{kind} requires a {key} type")))
+    }
+
+    /// Fail if there are any unknown arguments remaining
+    fn check_empty(&self, span: Span) -> syn::Result<()> {
+        if self.types.is_empty() {
+            Ok(())
+        } else {
+            Err(syn::Error::new(
+                span,
+                format!(
+                    "Unknown arguments provided: {:?}",
+                    self.types.keys().collect::<Vec<_>>()
+                ),
+            ))
+        }
+    }
+}
+
+/// Parse the rpc args as a comma separated list of name=type pairs
+impl Parse for RpcArgs {
+    fn parse(input: ParseStream) -> syn::Result<Self> {
+        let mut types = BTreeMap::new();
+
+        loop {
+            if input.is_empty() {
+                break;
+            }
+
+            let key: Ident = input.parse()?;
+            let _: Token![=] = input.parse()?;
+            let value: Type = input.parse()?;
+
+            types.insert(key.to_string(), value);
+
+            if !input.peek(Token![,]) {
+                break;
+            }
+            let _: Token![,] = input.parse()?;
+        }
+
+        Ok(RpcArgs { types })
+    }
+}

--- a/quic-rpc-derive/tests/compile_fail/duplicate_type.rs
+++ b/quic-rpc-derive/tests/compile_fail/duplicate_type.rs
@@ -1,0 +1,9 @@
+use quic_rpc_derive::rpc_requests;
+
+#[rpc_requests(Service)]
+enum Enum {
+    A(u8),
+    B(u8),
+}
+
+fn main() {}

--- a/quic-rpc-derive/tests/compile_fail/duplicate_type.stderr
+++ b/quic-rpc-derive/tests/compile_fail/duplicate_type.stderr
@@ -1,0 +1,5 @@
+error: Each variant must have a unique request type
+ --> tests/compile_fail/duplicate_type.rs:4:1
+  |
+4 | enum Enum {
+  | ^^^^

--- a/quic-rpc-derive/tests/compile_fail/extra_attr_types.rs
+++ b/quic-rpc-derive/tests/compile_fail/extra_attr_types.rs
@@ -1,0 +1,9 @@
+use quic_rpc_derive::rpc_requests;
+
+#[rpc_requests(Service)]
+enum Enum {
+    #[rpc(response = Bla, fnord = Foo)]
+    A(u8),
+}
+
+fn main() {}

--- a/quic-rpc-derive/tests/compile_fail/extra_attr_types.stderr
+++ b/quic-rpc-derive/tests/compile_fail/extra_attr_types.stderr
@@ -1,0 +1,5 @@
+error: Unknown arguments provided: ["fnord"]
+ --> tests/compile_fail/extra_attr_types.rs:5:5
+  |
+5 |     #[rpc(response = Bla, fnord = Foo)]
+  |     ^

--- a/quic-rpc-derive/tests/compile_fail/multiple_fields.rs
+++ b/quic-rpc-derive/tests/compile_fail/multiple_fields.rs
@@ -1,0 +1,8 @@
+use quic_rpc_derive::rpc_requests;
+
+#[rpc_requests(Service)]
+enum Enum {
+    A(u8, u8),
+}
+
+fn main() {}

--- a/quic-rpc-derive/tests/compile_fail/multiple_fields.stderr
+++ b/quic-rpc-derive/tests/compile_fail/multiple_fields.stderr
@@ -1,0 +1,5 @@
+error: Each variant must have exactly one unnamed field
+ --> tests/compile_fail/multiple_fields.rs:5:5
+  |
+5 |     A(u8, u8),
+  |     ^

--- a/quic-rpc-derive/tests/compile_fail/named_enum.rs
+++ b/quic-rpc-derive/tests/compile_fail/named_enum.rs
@@ -1,0 +1,8 @@
+use quic_rpc_derive::rpc_requests;
+
+#[rpc_requests(Service)]
+enum Enum {
+    A { name: u8 },
+}
+
+fn main() {}

--- a/quic-rpc-derive/tests/compile_fail/named_enum.stderr
+++ b/quic-rpc-derive/tests/compile_fail/named_enum.stderr
@@ -1,0 +1,5 @@
+error: Each variant must have exactly one unnamed field
+ --> tests/compile_fail/named_enum.rs:5:5
+  |
+5 |     A { name: u8 },
+  |     ^

--- a/quic-rpc-derive/tests/compile_fail/non_enum.rs
+++ b/quic-rpc-derive/tests/compile_fail/non_enum.rs
@@ -1,0 +1,6 @@
+use quic_rpc_derive::rpc_requests;
+
+#[rpc_requests(Service)]
+struct Foo;
+
+fn main() {}

--- a/quic-rpc-derive/tests/compile_fail/non_enum.stderr
+++ b/quic-rpc-derive/tests/compile_fail/non_enum.stderr
@@ -1,0 +1,5 @@
+error: RpcRequests can only be applied to enums
+ --> tests/compile_fail/non_enum.rs:4:1
+  |
+4 | struct Foo;
+  | ^^^^^^

--- a/quic-rpc-derive/tests/compile_fail/wrong_attr_types.rs
+++ b/quic-rpc-derive/tests/compile_fail/wrong_attr_types.rs
@@ -1,0 +1,9 @@
+use quic_rpc_derive::rpc_requests;
+
+#[rpc_requests(Service)]
+enum Enum {
+    #[rpc(fnord = Bla)]
+    A(u8),
+}
+
+fn main() {}

--- a/quic-rpc-derive/tests/compile_fail/wrong_attr_types.stderr
+++ b/quic-rpc-derive/tests/compile_fail/wrong_attr_types.stderr
@@ -1,0 +1,5 @@
+error: rpc requires a response type
+ --> tests/compile_fail/wrong_attr_types.rs:5:5
+  |
+5 |     #[rpc(fnord = Bla)]
+  |     ^

--- a/quic-rpc-derive/tests/smoke.rs
+++ b/quic-rpc-derive/tests/smoke.rs
@@ -1,0 +1,79 @@
+use quic_rpc_derive::rpc_requests;
+use serde::{Deserialize, Serialize};
+
+#[test]
+fn simple() {
+    #[derive(Debug, Serialize, Deserialize)]
+    struct RpcRequest;
+
+    #[derive(Debug, Serialize, Deserialize)]
+    struct ServerStreamingRequest;
+
+    #[derive(Debug, Serialize, Deserialize)]
+    struct ClientStreamingRequest;
+
+    #[derive(Debug, Serialize, Deserialize)]
+    struct BidiStreamingRequest;
+
+    #[derive(Debug, Serialize, Deserialize)]
+    struct Update1;
+
+    #[derive(Debug, Serialize, Deserialize)]
+    struct Update2;
+
+    #[derive(Debug, Serialize, Deserialize)]
+    struct Response1;
+
+    #[derive(Debug, Serialize, Deserialize)]
+    struct Response2;
+
+    #[derive(Debug, Serialize, Deserialize)]
+    struct Response3;
+
+    #[derive(Debug, Serialize, Deserialize)]
+    struct Response4;
+
+    #[rpc_requests(Service)]
+    #[derive(Debug, Serialize, Deserialize, derive_more::From, derive_more::TryInto)]
+    enum Request {
+        #[rpc(response=Response1)]
+        Rpc(RpcRequest),
+        #[server_streaming(response=Response2)]
+        ServerStreaming(ServerStreamingRequest),
+        #[bidi_streaming(update= Update1, response = Response3)]
+        BidiStreaming(BidiStreamingRequest),
+        #[client_streaming(update = Update2, response = Response4)]
+        ClientStreaming(ClientStreamingRequest),
+        Update1(Update1),
+        Update2(Update2),
+    }
+
+    #[derive(Debug, Serialize, Deserialize, derive_more::From, derive_more::TryInto)]
+    enum Response {
+        Response1(Response1),
+        Response2(Response2),
+        Response3(Response3),
+        Response4(Response4),
+    }
+
+    #[derive(Debug, Clone)]
+    struct Service;
+
+    impl quic_rpc::Service for Service {
+        type Req = Request;
+        type Res = Response;
+    }
+
+    let _ = Service;
+}
+
+/// Use
+///
+/// TRYBUILD=overwrite cargo test --test smoke
+///
+/// to update the snapshots
+#[test]
+fn compile_fail() {
+    let t = trybuild::TestCases::new();
+    t.compile_fail("tests/compile_fail/*.rs");
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -65,7 +65,7 @@
 //! let handler = Handler;
 //! loop {
 //!   // accept connections
-//!   let (msg, chan) = server.accept().await?;
+//!   let (msg, chan) = server.accept().await?.read_first().await?;
 //!   // dispatch the message to the appropriate handler
 //!   match msg {
 //!     PingRequest::Ping(ping) => chan.rpc(ping, handler, Handler::ping).await?,

--- a/src/pattern/bidi_streaming.rs
+++ b/src/pattern/bidi_streaming.rs
@@ -96,7 +96,7 @@ where
         M: BidiStreamingMsg<SInner>,
     {
         let msg = self.map.req_into_outer(msg.into());
-        let (mut send, recv) = self.source.open_bi().await.map_err(Error::Open)?;
+        let (mut send, recv) = self.source.open().await.map_err(Error::Open)?;
         send.send(msg).await.map_err(Error::<C>::Send)?;
         let send = UpdateSink(send, PhantomData, Arc::clone(&self.map));
         let map = Arc::clone(&self.map);

--- a/src/pattern/client_streaming.rs
+++ b/src/pattern/client_streaming.rs
@@ -98,7 +98,7 @@ where
         M: ClientStreamingMsg<SInner>,
     {
         let msg = self.map.req_into_outer(msg.into());
-        let (mut send, mut recv) = self.source.open_bi().await.map_err(Error::Open)?;
+        let (mut send, mut recv) = self.source.open().await.map_err(Error::Open)?;
         send.send(msg).map_err(Error::Send).await?;
         let send = UpdateSink::<S, C, M::Update, SInner>(send, PhantomData, Arc::clone(&self.map));
         let map = Arc::clone(&self.map);

--- a/src/pattern/rpc.rs
+++ b/src/pattern/rpc.rs
@@ -74,7 +74,7 @@ where
         M: RpcMsg<SInner>,
     {
         let msg = self.map.req_into_outer(msg.into());
-        let (mut send, mut recv) = self.source.open_bi().await.map_err(Error::Open)?;
+        let (mut send, mut recv) = self.source.open().await.map_err(Error::Open)?;
         send.send(msg).await.map_err(Error::<C>::Send)?;
         let res = recv
             .next()

--- a/src/pattern/server_streaming.rs
+++ b/src/pattern/server_streaming.rs
@@ -82,7 +82,7 @@ where
         M: ServerStreamingMsg<SInner>,
     {
         let msg = self.map.req_into_outer(msg.into());
-        let (mut send, recv) = self.source.open_bi().await.map_err(Error::Open)?;
+        let (mut send, recv) = self.source.open().await.map_err(Error::Open)?;
         send.send(msg).map_err(Error::<C>::Send).await?;
         let map = Arc::clone(&self.map);
         let recv = recv.map(move |x| match x {

--- a/src/pattern/try_server_streaming.rs
+++ b/src/pattern/try_server_streaming.rs
@@ -191,7 +191,7 @@ where
         Result<StreamCreated, M::CreateError>: Into<SInner::Res> + TryFrom<SInner::Res>,
     {
         let msg = self.map.req_into_outer(msg.into());
-        let (mut send, mut recv) = self.source.open_bi().await.map_err(Error::Open)?;
+        let (mut send, mut recv) = self.source.open().await.map_err(Error::Open)?;
         send.send(msg).map_err(Error::Send).await?;
         let map = Arc::clone(&self.map);
         let Some(initial) = recv.next().await else {

--- a/src/server.rs
+++ b/src/server.rs
@@ -117,8 +117,14 @@ where
     }
 }
 
-impl<S: Service, C: ServiceEndpoint<S>> RpcServer<S, C> {
-    /// Accepts a new channel from a client, and reads the first request.
+/// The result of accepting a new connection.
+pub struct Accepting<S: Service, C: ServiceEndpoint<S>> {
+    send: C::SendSink,
+    recv: C::RecvStream,
+}
+
+impl<S: Service, C: ServiceEndpoint<S>> Accepting<S, C> {
+    /// Read the first message from the client.
     ///
     /// The return value is a tuple of `(request, channel)`.  Here `request` is the
     /// first request which is already read from the stream.  The `channel` is a
@@ -127,13 +133,8 @@ impl<S: Service, C: ServiceEndpoint<S>> RpcServer<S, C> {
     ///
     /// Often sink and stream will wrap an an underlying byte stream. In this case you can
     /// call into_inner() on them to get it back to perform byte level reads and writes.
-    pub async fn accept(&self) -> result::Result<(S::Req, RpcChannel<S, C>), RpcServerError<C>> {
-        let (send, mut recv) = self
-            .source
-            .accept_bi()
-            .await
-            .map_err(RpcServerError::Accept)?;
-
+    pub async fn read_first(self) -> result::Result<(S::Req, RpcChannel<S, C>), RpcServerError<C>> {
+        let Accepting { send, mut recv } = self;
         // get the first message from the client. This will tell us what it wants to do.
         let request: S::Req = recv
             .next()
@@ -143,6 +144,15 @@ impl<S: Service, C: ServiceEndpoint<S>> RpcServer<S, C> {
             // recv error
             .map_err(RpcServerError::RecvError)?;
         Ok((request, RpcChannel::new(send, recv)))
+    }
+}
+
+impl<S: Service, C: ServiceEndpoint<S>> RpcServer<S, C> {
+    /// Accepts a new channel from a client. The result is an [Accepting] object that
+    /// can be used to read the first request.
+    pub async fn accept(&self) -> result::Result<Accepting<S, C>, RpcServerError<C>> {
+        let (send, recv) = self.source.accept().await.map_err(RpcServerError::Accept)?;
+        Ok(Accepting { send, recv })
     }
 
     /// Get the underlying service endpoint
@@ -309,7 +319,7 @@ where
 {
     let server = RpcServer::<S, C>::new(conn);
     loop {
-        let (req, chan) = server.accept().await?;
+        let (req, chan) = server.accept().await?.read_first().await?;
         let target = target.clone();
         handler(chan, req, target).await?;
     }

--- a/src/transport/boxed.rs
+++ b/src/transport/boxed.rs
@@ -142,7 +142,8 @@ impl<'a, In: RpcMessage, Out: RpcMessage> OpenFuture<'a, In, Out> {
         Self(OpenFutureInner::Direct(f))
     }
 
-    fn boxed(
+    /// Create a new boxed future
+    pub fn boxed(
         f: impl Future<Output = anyhow::Result<(SendSink<Out>, RecvStream<In>)>> + Send + Sync + 'a,
     ) -> Self {
         Self(OpenFutureInner::Boxed(Box::pin(f)))
@@ -179,7 +180,8 @@ impl<'a, In: RpcMessage, Out: RpcMessage> AcceptFuture<'a, In, Out> {
         Self(AcceptFutureInner::Direct(f))
     }
 
-    fn boxed(
+    /// Create a new boxed future
+    pub fn boxed(
         f: impl Future<Output = anyhow::Result<(SendSink<Out>, RecvStream<In>)>> + Send + Sync + 'a,
     ) -> Self {
         Self(AcceptFutureInner::Boxed(Box::pin(f)))
@@ -208,7 +210,7 @@ pub trait BoxableConnection<In: RpcMessage, Out: RpcMessage>:
     fn clone_box(&self) -> Box<dyn BoxableConnection<In, Out>>;
 
     /// Open a channel to the remote che
-    fn open_bi_boxed(&self) -> OpenFuture<In, Out>;
+    fn open_boxed(&self) -> OpenFuture<In, Out>;
 }
 
 /// A boxed connection
@@ -240,8 +242,8 @@ impl<S: Service> ConnectionErrors for Connection<S> {
 }
 
 impl<S: Service> super::Connection<S::Res, S::Req> for Connection<S> {
-    async fn open_bi(&self) -> Result<(Self::SendSink, Self::RecvStream), Self::OpenError> {
-        self.0.open_bi_boxed().await
+    async fn open(&self) -> Result<(Self::SendSink, Self::RecvStream), Self::OpenError> {
+        self.0.open_boxed().await
     }
 }
 
@@ -288,7 +290,7 @@ impl<In: RpcMessage, Out: RpcMessage> ConnectionErrors for ServerEndpoint<In, Ou
 }
 
 impl<In: RpcMessage, Out: RpcMessage> super::ServerEndpoint<In, Out> for ServerEndpoint<In, Out> {
-    fn accept_bi(
+    fn accept(
         &self,
     ) -> impl Future<Output = Result<(Self::SendSink, Self::RecvStream), Self::OpenError>> + Send
     {
@@ -306,9 +308,9 @@ impl<S: Service> BoxableConnection<S::Res, S::Req> for super::quinn::QuinnConnec
         Box::new(self.clone())
     }
 
-    fn open_bi_boxed(&self) -> OpenFuture<S::Res, S::Req> {
+    fn open_boxed(&self) -> OpenFuture<S::Res, S::Req> {
         let f = Box::pin(async move {
-            let (send, recv) = super::Connection::open_bi(self).await?;
+            let (send, recv) = super::Connection::open(self).await?;
             // map the error types to anyhow
             let send = send.sink_map_err(anyhow::Error::from);
             let recv = recv.map_err(anyhow::Error::from);
@@ -327,7 +329,7 @@ impl<S: Service> BoxableServerEndpoint<S::Req, S::Res> for super::quinn::QuinnSe
 
     fn accept_bi_boxed(&self) -> AcceptFuture<S::Req, S::Res> {
         let f = async move {
-            let (send, recv) = super::ServerEndpoint::accept_bi(self).await?;
+            let (send, recv) = super::ServerEndpoint::accept(self).await?;
             let send = send.sink_map_err(anyhow::Error::from);
             let recv = recv.map_err(anyhow::Error::from);
             anyhow::Ok((SendSink::boxed(send), RecvStream::boxed(recv)))
@@ -346,8 +348,8 @@ impl<S: Service> BoxableConnection<S::Res, S::Req> for super::flume::FlumeConnec
         Box::new(self.clone())
     }
 
-    fn open_bi_boxed(&self) -> OpenFuture<S::Res, S::Req> {
-        OpenFuture::direct(super::Connection::open_bi(self))
+    fn open_boxed(&self) -> OpenFuture<S::Res, S::Req> {
+        OpenFuture::direct(super::Connection::open(self))
     }
 }
 
@@ -358,7 +360,7 @@ impl<S: Service> BoxableServerEndpoint<S::Req, S::Res> for super::flume::FlumeSe
     }
 
     fn accept_bi_boxed(&self) -> AcceptFuture<S::Req, S::Res> {
-        AcceptFuture::direct(super::ServerEndpoint::accept_bi(self))
+        AcceptFuture::direct(super::ServerEndpoint::accept(self))
     }
 
     fn local_addr(&self) -> &[super::LocalAddr] {
@@ -391,14 +393,14 @@ mod tests {
         let client = super::Connection::<FooService>::new(client);
         // spawn echo server
         tokio::spawn(async move {
-            while let Ok((mut send, mut recv)) = server.accept_bi().await {
+            while let Ok((mut send, mut recv)) = server.accept().await {
                 if let Some(Ok(msg)) = recv.next().await {
                     send.send(msg).await.ok();
                 }
             }
             anyhow::Ok(())
         });
-        if let Ok((mut send, mut recv)) = client.open_bi().await {
+        if let Ok((mut send, mut recv)) = client.open().await {
             send.send(1).await.ok();
             let res = recv.next().await;
             println!("{:?}", res);

--- a/src/transport/flume.rs
+++ b/src/transport/flume.rs
@@ -131,7 +131,7 @@ impl<S: Service> ConnectionErrors for FlumeServerEndpoint<S> {
 
 type Socket<In, Out> = (self::SendSink<Out>, self::RecvStream<In>);
 
-/// Future returned by [FlumeConnection::open_bi]
+/// Future returned by [FlumeConnection::open]
 pub struct OpenBiFuture<In: RpcMessage, Out: RpcMessage> {
     inner: flume::r#async::SendFut<'static, Socket<Out, In>>,
     res: Option<Socket<In, Out>>,
@@ -202,7 +202,7 @@ impl<S: Service> ConnectionCommon<S::Req, S::Res> for FlumeServerEndpoint<S> {
 
 impl<S: Service> ServerEndpoint<S::Req, S::Res> for FlumeServerEndpoint<S> {
     #[allow(refining_impl_trait)]
-    fn accept_bi(&self) -> AcceptBiFuture<S::Req, S::Res> {
+    fn accept(&self) -> AcceptBiFuture<S::Req, S::Res> {
         AcceptBiFuture {
             wrapped: self.stream.clone().into_recv_async(),
             _p: PhantomData,
@@ -229,7 +229,7 @@ impl<S: Service> ConnectionCommon<S::Res, S::Req> for FlumeConnection<S> {
 
 impl<S: Service> Connection<S::Res, S::Req> for FlumeConnection<S> {
     #[allow(refining_impl_trait)]
-    fn open_bi(&self) -> OpenBiFuture<S::Res, S::Req> {
+    fn open(&self) -> OpenBiFuture<S::Res, S::Req> {
         let (local_send, remote_recv) = flume::bounded::<S::Req>(128);
         let (remote_send, local_recv) = flume::bounded::<S::Res>(128);
         let remote_chan = (

--- a/src/transport/hyper.rs
+++ b/src/transport/hyper.rs
@@ -581,7 +581,7 @@ impl<S: Service> ConnectionCommon<S::Res, S::Req> for HyperConnection<S> {
 }
 
 impl<S: Service> Connection<S::Res, S::Req> for HyperConnection<S> {
-    async fn open_bi(&self) -> Result<(Self::SendSink, Self::RecvStream), Self::OpenError> {
+    async fn open(&self) -> Result<(Self::SendSink, Self::RecvStream), Self::OpenError> {
         let (out_tx, out_rx) = flume::bounded::<io::Result<Bytes>>(32);
         let req: Request<Body> = Request::post(&self.inner.uri)
             .body(Body::wrap_stream(out_rx.into_stream()))
@@ -619,7 +619,7 @@ impl<S: Service> ServerEndpoint<S::Req, S::Res> for HyperServerEndpoint<S> {
         &self.local_addr
     }
 
-    async fn accept_bi(&self) -> Result<(Self::SendSink, Self::RecvStream), AcceptBiError> {
+    async fn accept(&self) -> Result<(Self::SendSink, Self::RecvStream), AcceptBiError> {
         let (recv, send) = self
             .channel
             .recv_async()

--- a/src/transport/misc/mod.rs
+++ b/src/transport/misc/mod.rs
@@ -30,7 +30,7 @@ impl<In: RpcMessage, Out: RpcMessage> ConnectionCommon<In, Out> for DummyServerE
 }
 
 impl<In: RpcMessage, Out: RpcMessage> ServerEndpoint<In, Out> for DummyServerEndpoint {
-    async fn accept_bi(&self) -> Result<(Self::SendSink, Self::RecvStream), Self::OpenError> {
+    async fn accept(&self) -> Result<(Self::SendSink, Self::RecvStream), Self::OpenError> {
         futures_lite::future::pending().await
     }
 

--- a/src/transport/mod.rs
+++ b/src/transport/mod.rs
@@ -45,10 +45,10 @@ pub trait ConnectionCommon<In, Out>: ConnectionErrors {
 
 /// A connection to a specific remote machine
 ///
-/// A connection can be used to open bidirectional typed channels using [`Connection::open_bi`].
+/// A connection can be used to open bidirectional typed channels using [`Connection::open`].
 pub trait Connection<In, Out>: ConnectionCommon<In, Out> {
     /// Open a channel to the remote che
-    fn open_bi(
+    fn open(
         &self,
     ) -> impl Future<Output = Result<(Self::SendSink, Self::RecvStream), Self::OpenError>> + Send;
 }
@@ -60,7 +60,7 @@ pub trait Connection<In, Out>: ConnectionCommon<In, Out> {
 pub trait ServerEndpoint<In, Out>: ConnectionCommon<In, Out> {
     /// Accept a new typed bidirectional channel on any of the connections we
     /// have currently opened.
-    fn accept_bi(
+    fn accept(
         &self,
     ) -> impl Future<Output = Result<(Self::SendSink, Self::RecvStream), Self::OpenError>> + Send;
 

--- a/src/transport/quinn.rs
+++ b/src/transport/quinn.rs
@@ -198,7 +198,7 @@ impl<S: Service> ConnectionCommon<S::Req, S::Res> for QuinnServerEndpoint<S> {
 }
 
 impl<S: Service> ServerEndpoint<S::Req, S::Res> for QuinnServerEndpoint<S> {
-    async fn accept_bi(&self) -> Result<(Self::SendSink, Self::RecvStream), AcceptBiError> {
+    async fn accept(&self) -> Result<(Self::SendSink, Self::RecvStream), AcceptBiError> {
         let (send, recv) = self
             .inner
             .receiver
@@ -627,7 +627,7 @@ impl<S: Service> ConnectionCommon<S::Res, S::Req> for QuinnConnection<S> {
 }
 
 impl<S: Service> Connection<S::Res, S::Req> for QuinnConnection<S> {
-    async fn open_bi(&self) -> Result<(Self::SendSink, Self::RecvStream), Self::OpenError> {
+    async fn open(&self) -> Result<(Self::SendSink, Self::RecvStream), Self::OpenError> {
         let (sender, receiver) = oneshot::channel();
         self.inner
             .sender
@@ -737,10 +737,10 @@ impl<In: DeserializeOwned> Stream for RecvStream<In> {
     }
 }
 
-/// Error for open_bi. Currently just a quinn::ConnectionError
+/// Error for open. Currently just a quinn::ConnectionError
 pub type OpenBiError = quinn::ConnectionError;
 
-/// Error for accept_bi. Currently just a quinn::ConnectionError
+/// Error for accept. Currently just a quinn::ConnectionError
 pub type AcceptBiError = quinn::ConnectionError;
 
 /// CreateChannelError for quinn channels.

--- a/tests/flume.rs
+++ b/tests/flume.rs
@@ -67,7 +67,7 @@ async fn flume_channel_mapped_bench() -> anyhow::Result<()> {
         tokio::task::spawn(async move {
             let service = ComputeService;
             loop {
-                let (req, chan) = server.accept().await?;
+                let (req, chan) = server.accept().await?.read_first().await?;
                 let service = service.clone();
                 tokio::spawn(async move {
                     let req: OuterRequest = req;

--- a/tests/hyper.rs
+++ b/tests/hyper.rs
@@ -176,8 +176,10 @@ async fn hyper_channel_errors() -> anyhow::Result<()> {
         let (res_tx, res_rx) = flume::unbounded();
         let handle = tokio::spawn(async move {
             loop {
-                let x = server.accept().await;
-                let res = match x {
+                let Ok(x) = server.accept().await else {
+                    continue;
+                };
+                let res = match x.read_first().await {
                     Ok((req, chan)) => match req {
                         TestRequest::BigRequest(req) => {
                             chan.rpc(req, TestService, TestService::big).await

--- a/tests/math.rs
+++ b/tests/math.rs
@@ -167,7 +167,7 @@ impl ComputeService {
         let s = server;
         let service = ComputeService;
         loop {
-            let (req, chan) = s.accept().await?;
+            let (req, chan) = s.accept().await?.read_first().await?;
             let service = service.clone();
             tokio::spawn(async move { Self::handle_rpc_request(service, req, chan).await });
         }
@@ -206,7 +206,7 @@ impl ComputeService {
         let service = ComputeService;
         while received < count {
             received += 1;
-            let (req, chan) = s.accept().await?;
+            let (req, chan) = s.accept().await?.read_first().await?;
             let service = service.clone();
             tokio::spawn(async move {
                 use ComputeRequest::*;
@@ -236,7 +236,7 @@ impl ComputeService {
         let service = ComputeService;
         let request_stream = stream! {
             loop {
-                yield s2.accept().await;
+                yield s2.accept().await?.read_first().await;
             }
         };
         let process_stream = request_stream.map(move |r| {

--- a/tests/slow_math.rs
+++ b/tests/slow_math.rs
@@ -113,7 +113,7 @@ impl ComputeService {
         let s = server;
         let service = ComputeService;
         loop {
-            let (req, chan) = s.accept().await?;
+            let (req, chan) = s.accept().await?.read_first().await?;
             use ComputeRequest::*;
             let service = service.clone();
             #[rustfmt::skip]

--- a/tests/try.rs
+++ b/tests/try.rs
@@ -77,7 +77,7 @@ async fn try_server_streaming() -> anyhow::Result<()> {
     let server = RpcServer::<TryService, _>::new(server);
     let server_handle = tokio::task::spawn(async move {
         loop {
-            let (req, chan) = server.accept().await?;
+            let (req, chan) = server.accept().await?.read_first().await?;
             let handler = Handler;
             match req {
                 TryRequest::StreamN(req) => {


### PR DESCRIPTION
This upgrades the Quinn and Rustls dependencies.

Currently we have no released iroh-quinn yet for those versions so it points back to upstream Quinn.  We should fix this before merging.

Note this targets #83 as base.  That should be merged first.