### PR TITLE
Rename open_bi and accept_bi to just open and accept

### DIFF
--- a/examples/store.rs
+++ b/examples/store.rs
@@ -239,7 +239,7 @@ async fn _main_unsugared() -> anyhow::Result<()> {
     }
     let (server, client) = flume::connection::<Service>(1);
     let to_string_service = tokio::spawn(async move {
-        let (mut send, mut recv) = server.accept_bi().await?;
+        let (mut send, mut recv) = server.accept().await?;
         while let Some(item) = recv.next().await {
             let item = item?;
             println!("server got: {item:?}");
@@ -247,7 +247,7 @@ async fn _main_unsugared() -> anyhow::Result<()> {
         }
         anyhow::Ok(())
     });
-    let (mut send, mut recv) = client.open_bi().await?;
+    let (mut send, mut recv) = client.open().await?;
     let print_result_service = tokio::spawn(async move {
         while let Some(item) = recv.next().await {
             let item = item?;

--- a/src/pattern/bidi_streaming.rs
+++ b/src/pattern/bidi_streaming.rs
@@ -96,7 +96,7 @@ where
         M: BidiStreamingMsg<SInner>,
     {
         let msg = self.map.req_into_outer(msg.into());
-        let (mut send, recv) = self.source.open_bi().await.map_err(Error::Open)?;
+        let (mut send, recv) = self.source.open().await.map_err(Error::Open)?;
         send.send(msg).await.map_err(Error::<C>::Send)?;
         let send = UpdateSink(send, PhantomData, Arc::clone(&self.map));
         let map = Arc::clone(&self.map);

--- a/src/pattern/client_streaming.rs
+++ b/src/pattern/client_streaming.rs
@@ -98,7 +98,7 @@ where
         M: ClientStreamingMsg<SInner>,
     {
         let msg = self.map.req_into_outer(msg.into());
-        let (mut send, mut recv) = self.source.open_bi().await.map_err(Error::Open)?;
+        let (mut send, mut recv) = self.source.open().await.map_err(Error::Open)?;
         send.send(msg).map_err(Error::Send).await?;
         let send = UpdateSink::<S, C, M::Update, SInner>(send, PhantomData, Arc::clone(&self.map));
         let map = Arc::clone(&self.map);

--- a/src/pattern/rpc.rs
+++ b/src/pattern/rpc.rs
@@ -74,7 +74,7 @@ where
         M: RpcMsg<SInner>,
     {
         let msg = self.map.req_into_outer(msg.into());
-        let (mut send, mut recv) = self.source.open_bi().await.map_err(Error::Open)?;
+        let (mut send, mut recv) = self.source.open().await.map_err(Error::Open)?;
         send.send(msg).await.map_err(Error::<C>::Send)?;
         let res = recv
             .next()

--- a/src/pattern/server_streaming.rs
+++ b/src/pattern/server_streaming.rs
@@ -82,7 +82,7 @@ where
         M: ServerStreamingMsg<SInner>,
     {
         let msg = self.map.req_into_outer(msg.into());
-        let (mut send, recv) = self.source.open_bi().await.map_err(Error::Open)?;
+        let (mut send, recv) = self.source.open().await.map_err(Error::Open)?;
         send.send(msg).map_err(Error::<C>::Send).await?;
         let map = Arc::clone(&self.map);
         let recv = recv.map(move |x| match x {

--- a/src/pattern/try_server_streaming.rs
+++ b/src/pattern/try_server_streaming.rs
@@ -191,7 +191,7 @@ where
         Result<StreamCreated, M::CreateError>: Into<SInner::Res> + TryFrom<SInner::Res>,
     {
         let msg = self.map.req_into_outer(msg.into());
-        let (mut send, mut recv) = self.source.open_bi().await.map_err(Error::Open)?;
+        let (mut send, mut recv) = self.source.open().await.map_err(Error::Open)?;
         send.send(msg).map_err(Error::Send).await?;
         let map = Arc::clone(&self.map);
         let Some(initial) = recv.next().await else {

--- a/src/server.rs
+++ b/src/server.rs
@@ -151,11 +151,7 @@ impl<S: Service, C: ServiceEndpoint<S>> RpcServer<S, C> {
     /// Accepts a new channel from a client. The result is an [Accepting] object that
     /// can be used to read the first request.
     pub async fn accept(&self) -> result::Result<Accepting<S, C>, RpcServerError<C>> {
-        let (send, recv) = self
-            .source
-            .accept_bi()
-            .await
-            .map_err(RpcServerError::Accept)?;
+        let (send, recv) = self.source.accept().await.map_err(RpcServerError::Accept)?;
         Ok(Accepting { send, recv })
     }
 

--- a/src/transport/flume.rs
+++ b/src/transport/flume.rs
@@ -131,7 +131,7 @@ impl<S: Service> ConnectionErrors for FlumeServerEndpoint<S> {
 
 type Socket<In, Out> = (self::SendSink<Out>, self::RecvStream<In>);
 
-/// Future returned by [FlumeConnection::open_bi]
+/// Future returned by [FlumeConnection::open]
 pub struct OpenBiFuture<In: RpcMessage, Out: RpcMessage> {
     inner: flume::r#async::SendFut<'static, Socket<Out, In>>,
     res: Option<Socket<In, Out>>,
@@ -202,7 +202,7 @@ impl<S: Service> ConnectionCommon<S::Req, S::Res> for FlumeServerEndpoint<S> {
 
 impl<S: Service> ServerEndpoint<S::Req, S::Res> for FlumeServerEndpoint<S> {
     #[allow(refining_impl_trait)]
-    fn accept_bi(&self) -> AcceptBiFuture<S::Req, S::Res> {
+    fn accept(&self) -> AcceptBiFuture<S::Req, S::Res> {
         AcceptBiFuture {
             wrapped: self.stream.clone().into_recv_async(),
             _p: PhantomData,
@@ -229,7 +229,7 @@ impl<S: Service> ConnectionCommon<S::Res, S::Req> for FlumeConnection<S> {
 
 impl<S: Service> Connection<S::Res, S::Req> for FlumeConnection<S> {
     #[allow(refining_impl_trait)]
-    fn open_bi(&self) -> OpenBiFuture<S::Res, S::Req> {
+    fn open(&self) -> OpenBiFuture<S::Res, S::Req> {
         let (local_send, remote_recv) = flume::bounded::<S::Req>(128);
         let (remote_send, local_recv) = flume::bounded::<S::Res>(128);
         let remote_chan = (

--- a/src/transport/hyper.rs
+++ b/src/transport/hyper.rs
@@ -581,7 +581,7 @@ impl<S: Service> ConnectionCommon<S::Res, S::Req> for HyperConnection<S> {
 }
 
 impl<S: Service> Connection<S::Res, S::Req> for HyperConnection<S> {
-    async fn open_bi(&self) -> Result<(Self::SendSink, Self::RecvStream), Self::OpenError> {
+    async fn open(&self) -> Result<(Self::SendSink, Self::RecvStream), Self::OpenError> {
         let (out_tx, out_rx) = flume::bounded::<io::Result<Bytes>>(32);
         let req: Request<Body> = Request::post(&self.inner.uri)
             .body(Body::wrap_stream(out_rx.into_stream()))
@@ -619,7 +619,7 @@ impl<S: Service> ServerEndpoint<S::Req, S::Res> for HyperServerEndpoint<S> {
         &self.local_addr
     }
 
-    async fn accept_bi(&self) -> Result<(Self::SendSink, Self::RecvStream), AcceptBiError> {
+    async fn accept(&self) -> Result<(Self::SendSink, Self::RecvStream), AcceptBiError> {
         let (recv, send) = self
             .channel
             .recv_async()

--- a/src/transport/misc/mod.rs
+++ b/src/transport/misc/mod.rs
@@ -30,7 +30,7 @@ impl<In: RpcMessage, Out: RpcMessage> ConnectionCommon<In, Out> for DummyServerE
 }
 
 impl<In: RpcMessage, Out: RpcMessage> ServerEndpoint<In, Out> for DummyServerEndpoint {
-    async fn accept_bi(&self) -> Result<(Self::SendSink, Self::RecvStream), Self::OpenError> {
+    async fn accept(&self) -> Result<(Self::SendSink, Self::RecvStream), Self::OpenError> {
         futures_lite::future::pending().await
     }
 

--- a/src/transport/mod.rs
+++ b/src/transport/mod.rs
@@ -49,10 +49,10 @@ pub trait ConnectionCommon<In, Out>: ConnectionErrors {
 
 /// A connection to a specific remote machine
 ///
-/// A connection can be used to open bidirectional typed channels using [`Connection::open_bi`].
+/// A connection can be used to open bidirectional typed channels using [`Connection::open`].
 pub trait Connection<In, Out>: ConnectionCommon<In, Out> {
     /// Open a channel to the remote che
-    fn open_bi(
+    fn open(
         &self,
     ) -> impl Future<Output = Result<(Self::SendSink, Self::RecvStream), Self::OpenError>> + Send;
 }
@@ -64,7 +64,7 @@ pub trait Connection<In, Out>: ConnectionCommon<In, Out> {
 pub trait ServerEndpoint<In, Out>: ConnectionCommon<In, Out> {
     /// Accept a new typed bidirectional channel on any of the connections we
     /// have currently opened.
-    fn accept_bi(
+    fn accept(
         &self,
     ) -> impl Future<Output = Result<(Self::SendSink, Self::RecvStream), Self::OpenError>> + Send;
 

--- a/src/transport/quinn.rs
+++ b/src/transport/quinn.rs
@@ -198,7 +198,7 @@ impl<S: Service> ConnectionCommon<S::Req, S::Res> for QuinnServerEndpoint<S> {
 }
 
 impl<S: Service> ServerEndpoint<S::Req, S::Res> for QuinnServerEndpoint<S> {
-    async fn accept_bi(&self) -> Result<(Self::SendSink, Self::RecvStream), AcceptBiError> {
+    async fn accept(&self) -> Result<(Self::SendSink, Self::RecvStream), AcceptBiError> {
         let (send, recv) = self
             .inner
             .receiver
@@ -627,7 +627,7 @@ impl<S: Service> ConnectionCommon<S::Res, S::Req> for QuinnConnection<S> {
 }
 
 impl<S: Service> Connection<S::Res, S::Req> for QuinnConnection<S> {
-    async fn open_bi(&self) -> Result<(Self::SendSink, Self::RecvStream), Self::OpenError> {
+    async fn open(&self) -> Result<(Self::SendSink, Self::RecvStream), Self::OpenError> {
         let (sender, receiver) = oneshot::channel();
         self.inner
             .sender
@@ -737,10 +737,10 @@ impl<In: DeserializeOwned> Stream for RecvStream<In> {
     }
 }
 
-/// Error for open_bi. Currently just a quinn::ConnectionError
+/// Error for open. Currently just a quinn::ConnectionError
 pub type OpenBiError = quinn::ConnectionError;
 
-/// Error for accept_bi. Currently just a quinn::ConnectionError
+/// Error for accept. Currently just a quinn::ConnectionError
 pub type AcceptBiError = quinn::ConnectionError;
 
 /// CreateChannelError for quinn channels.


### PR DESCRIPTION
We only support bidirectional, so no need to disambiguate...