### PR TITLE
Add macro crate to allow placing rpc interation patterns directly on the request enum.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -133,6 +133,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "convert_case"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e"
+
+[[package]]
 name = "core-foundation"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -155,6 +161,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b42b6fa04a440b495c8b04d0e71b707c585f83cb9cb28cf8cd0d976c315e31b4"
 dependencies = [
  "powerfmt",
+]
+
+[[package]]
+name = "derive_more"
+version = "0.99.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f33878137e4dafd7fa914ad4e259e18a4e8e532b9617a2d0150262bf53abfce"
+dependencies = [
+ "convert_case",
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -814,7 +833,7 @@ dependencies = [
  "async-stream",
  "bincode",
  "bytes",
- "derive_more",
+ "derive_more 1.0.0-beta.6",
  "educe",
  "flume",
  "futures",
@@ -839,6 +858,18 @@ dependencies = [
  "tokio-util",
  "tracing",
  "tracing-subscriber",
+]
+
+[[package]]
+name = "quic-rpc-derive"
+version = "0.1.0"
+dependencies = [
+ "derive_more 0.99.18",
+ "proc-macro2",
+ "quic-rpc",
+ "quote",
+ "serde",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -950,6 +981,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
+name = "rustc_version"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
+dependencies = [
+ "semver",
+]
+
+[[package]]
 name = "rustix"
 version = "0.38.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1054,19 +1094,25 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde"
-version = "1.0.202"
+name = "semver"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "226b61a0d411b2ba5ff6d7f73a476ac4f8bb900373459cd00fab8512828ba395"
+checksum = "61697e0a1c7e512e84a621326239844a24d8207b4669b41bc18b32ea5cbf988b"
+
+[[package]]
+name = "serde"
+version = "1.0.203"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7253ab4de971e72fb7be983802300c30b5a7f0c2e56fab8abfc6a214307c0094"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.202"
+version = "1.0.203"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6048858004bcff69094cd972ed40a32500f153bd3be9f716b2eed2e8217c4838"
+checksum = "500cbc0ebeb6f46627f50f3f5811ccf6bf00643be300b4c3eabc0ef55dc5b5ba"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1384,7 +1430,7 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 name = "types"
 version = "0.1.0"
 dependencies = [
- "derive_more",
+ "derive_more 1.0.0-beta.6",
  "futures",
  "quic-rpc",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -401,6 +401,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4271d37baee1b8c7e4b708028c57d816cf9d2434acb33a549475f78c181f6253"
 
 [[package]]
+name = "glob"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
+
+[[package]]
 name = "h2"
 version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -870,6 +876,7 @@ dependencies = [
  "quote",
  "serde",
  "syn 1.0.109",
+ "trybuild",
 ]
 
 [[package]]
@@ -1046,6 +1053,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ryu"
+version = "1.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f"
+
+[[package]]
 name = "schannel"
 version = "0.1.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1117,6 +1130,26 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.66",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.120"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e0d21c9a8cae1235ad58a00c11cb40d4b1e5c784f1ef2c537876ed6ffd8b7c5"
+dependencies = [
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
+name = "serde_spanned"
+version = "0.6.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79e674e01f999af37c49f70a6ede167a8a60b2503e56c5599532a65baa5969a0"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
@@ -1226,6 +1259,15 @@ dependencies = [
  "fastrand",
  "rustix",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "termcolor"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
+dependencies = [
+ "winapi-util",
 ]
 
 [[package]]
@@ -1357,6 +1399,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml"
+version = "0.8.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f49eb2ab21d2f26bd6db7bf383edc527a7ebaee412d17af4d40fdccd442f335"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_edit",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4badfd56924ae69bcc9039335b2e017639ce3f9b001c393c1b2d1ef846ce2cbf"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.22.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f21c7aaf97f1bd9ca9d4f9e73b0a6c74bd5afef56f2bc931943a6e1c37e04e38"
+dependencies = [
+ "indexmap",
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "winnow",
+]
+
+[[package]]
 name = "tower-service"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1425,6 +1501,20 @@ name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
+name = "trybuild"
+version = "1.0.96"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33a5f13f11071020bb12de7a16b925d2d58636175c20c11dc5f96cb64bb6c9b3"
+dependencies = [
+ "glob",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "termcolor",
+ "toml",
+]
 
 [[package]]
 name = "types"
@@ -1566,6 +1656,15 @@ name = "winapi-i686-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-util"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d4cc384e1e73b93bafa6fb4f1df8c41695c8a91cf9c4c64358067d15a7b6c6b"
+dependencies = [
+ "windows-sys 0.52.0",
+]
 
 [[package]]
 name = "winapi-x86_64-pc-windows-gnu"
@@ -1711,6 +1810,15 @@ name = "windows_x86_64_msvc"
 version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bec47e5bfd1bff0eeaf6d8b485cc1074891a197ab4225d504cb7a1ab88b02bf0"
+
+[[package]]
+name = "winnow"
+version = "0.6.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59b5e5f6c299a3c7890b876a2a587f3115162487e704907d9b6cd29473052ba1"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "yasna"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -133,12 +133,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "convert_case"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e"
-
-[[package]]
 name = "core-foundation"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -161,19 +155,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b42b6fa04a440b495c8b04d0e71b707c585f83cb9cb28cf8cd0d976c315e31b4"
 dependencies = [
  "powerfmt",
-]
-
-[[package]]
-name = "derive_more"
-version = "0.99.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f33878137e4dafd7fa914ad4e259e18a4e8e532b9617a2d0150262bf53abfce"
-dependencies = [
- "convert_case",
- "proc-macro2",
- "quote",
- "rustc_version",
- "syn 2.0.66",
 ]
 
 [[package]]
@@ -839,7 +820,7 @@ dependencies = [
  "async-stream",
  "bincode",
  "bytes",
- "derive_more 1.0.0-beta.6",
+ "derive_more",
  "educe",
  "flume",
  "futures",
@@ -870,7 +851,7 @@ dependencies = [
 name = "quic-rpc-derive"
 version = "0.1.0"
 dependencies = [
- "derive_more 0.99.18",
+ "derive_more",
  "proc-macro2",
  "quic-rpc",
  "quote",
@@ -988,15 +969,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
-name = "rustc_version"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
-dependencies = [
- "semver",
-]
-
-[[package]]
 name = "rustix"
 version = "0.38.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1105,12 +1077,6 @@ dependencies = [
  "core-foundation-sys",
  "libc",
 ]
-
-[[package]]
-name = "semver"
-version = "1.0.23"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61697e0a1c7e512e84a621326239844a24d8207b4669b41bc18b32ea5cbf988b"
 
 [[package]]
 name = "serde"
@@ -1520,7 +1486,7 @@ dependencies = [
 name = "types"
 version = "0.1.0"
 dependencies = [
- "derive_more 1.0.0-beta.6",
+ "derive_more",
  "futures",
  "quic-rpc",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -849,7 +849,7 @@ dependencies = [
 
 [[package]]
 name = "quic-rpc-derive"
-version = "0.1.0"
+version = "0.11.0"
 dependencies = [
  "derive_more",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -85,4 +85,4 @@ name = "modularize"
 required-features = ["flume-transport"]
 
 [workspace]
-members = ["examples/split/types", "examples/split/server", "examples/split/client"]
+members = ["examples/split/types", "examples/split/server", "examples/split/client", "quic-rpc-derive"]

--- a/quic-rpc-derive/Cargo.toml
+++ b/quic-rpc-derive/Cargo.toml
@@ -13,6 +13,6 @@ proc-macro2 = "1.0"
 quic-rpc = { path = ".." }
 
 [dev-dependencies]
-derive_more = "0.99.18"
+derive_more = "1.0.0-beta.6"
 serde = { version = "1.0.203", features = ["serde_derive"] }
 trybuild = "1.0.96"

--- a/quic-rpc-derive/Cargo.toml
+++ b/quic-rpc-derive/Cargo.toml
@@ -15,3 +15,4 @@ quic-rpc = { path = ".." }
 [dev-dependencies]
 derive_more = "0.99.18"
 serde = { version = "1.0.203", features = ["serde_derive"] }
+trybuild = "1.0.96"

--- a/quic-rpc-derive/Cargo.toml
+++ b/quic-rpc-derive/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "quic-rpc-derive"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+proc-macro = true
+
+[dependencies]
+syn = { version = "1.0", features = ["full"] }
+quote = "1.0"
+proc-macro2 = "1.0"
+quic-rpc = { path = ".." }
+
+[dev-dependencies]
+derive_more = "0.99.18"
+serde = { version = "1.0.203", features = ["serde_derive"] }

--- a/quic-rpc-derive/Cargo.toml
+++ b/quic-rpc-derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "quic-rpc-derive"
-version = "0.1.0"
+version = "0.11.0"
 edition = "2021"
 
 [lib]

--- a/quic-rpc-derive/src/lib.rs
+++ b/quic-rpc-derive/src/lib.rs
@@ -143,7 +143,7 @@ pub fn rpc_requests(attr: TokenStream, item: TokenStream) -> TokenStream {
                     return false;
                 }
             }
-            return true;
+            true
         });
 
         // Fail if there are multiple RPC patterns

--- a/quic-rpc-derive/src/lib.rs
+++ b/quic-rpc-derive/src/lib.rs
@@ -1,0 +1,222 @@
+use proc_macro::TokenStream;
+use proc_macro2::Span;
+use quote::{format_ident, quote, ToTokens};
+use std::{collections::HashMap, fmt::Debug};
+use syn::{
+    parse::{Parse, ParseStream},
+    parse_macro_input,
+    spanned::Spanned,
+    Attribute, Data, DeriveInput, Fields, Ident, Lit, Meta, NestedMeta, Token, Type,
+};
+
+struct RpcArgs {
+    types: HashMap<String, Type>,
+}
+
+impl Debug for RpcArgs {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("RpcInfo")
+            .field(
+                "types",
+                &self
+                    .types
+                    .iter()
+                    .map(|(k, v)| (k.clone(), v.to_token_stream().to_string()))
+                    .collect::<Vec<_>>(),
+            )
+            .finish()
+    }
+}
+impl Parse for RpcArgs {
+    fn parse(input: ParseStream) -> syn::Result<Self> {
+        let mut types = HashMap::new();
+
+        loop {
+            if input.is_empty() {
+                break;
+            }
+
+            let key: Ident = input.parse()?;
+            let _: Token![=] = input.parse()?;
+            let value: Type = input.parse()?;
+
+            types.insert(key.to_string(), value);
+
+            if !input.peek(Token![,]) {
+                break;
+            }
+            let _: Token![,] = input.parse()?;
+        }
+
+        Ok(RpcArgs { types })
+    }
+}
+
+fn parse_rpc_attr(attr: &Attribute) -> syn::Result<RpcArgs> {
+    attr.parse_args()
+}
+
+fn generate_rpc_impls(
+    ident: &Ident,
+    rpc_info: &RpcArgs,
+    service_name: &Ident,
+    request_type: &Type,
+) -> syn::Result<Vec<proc_macro2::TokenStream>> {
+    let pattern = ident;
+    let pattern_ident = format_ident!("{}", pattern);
+
+    let mut impls = vec![];
+
+    let specific_impl = match pattern.to_string().as_str() {
+        "rpc" => {
+            let response_type = rpc_info.types.get("response").ok_or_else(|| {
+                syn::Error::new(Span::call_site(), "Unary RPC requires a response type")
+            })?;
+            quote! {
+                impl ::quic_rpc::pattern::rpc::RpcMsg<#service_name> for #request_type {
+                    type Response = #response_type;
+                }
+            }
+        }
+        "server_streaming" => {
+            let response_type = rpc_info.types.get("response").ok_or_else(|| {
+                syn::Error::new(
+                    Span::call_site(),
+                    "Server streaming RPC requires an update type",
+                )
+            })?;
+            quote! {
+                impl ::quic_rpc::message::Msg<#service_name> for #request_type {
+                    type Pattern = ::quic_rpc::pattern::server_streaming::ServerStreaming;
+                }
+                impl ::quic_rpc::pattern::server_streaming::ServerStreamingMsg<#service_name> for #request_type {
+                    type Response = #response_type;
+                }
+            }
+        }
+        "bidi_streaming" => {
+            let update_type = rpc_info.types.get("update").ok_or_else(|| {
+                syn::Error::new(
+                    Span::call_site(),
+                    "Bidi streaming RPC requires an update type",
+                )
+            })?;
+            let response_type = rpc_info.types.get("response").ok_or_else(|| {
+                syn::Error::new(
+                    Span::call_site(),
+                    "Bidi streaming RPC requires a response type",
+                )
+            })?;
+            quote! {
+                impl ::quic_rpc::message::Msg<#service_name> for #request_type {
+                    type Pattern = ::quic_rpc::pattern::bidi_streaming::BidiStreaming;
+                }
+                impl ::quic_rpc::pattern::bidi_streaming::BidiStreamingMsg<#service_name> for #request_type {
+                    type Update = #update_type;
+                    type Response = #response_type;
+                }
+            }
+        }
+        "client_streaming" => {
+            let update_type = rpc_info.types.get("update").ok_or_else(|| {
+                syn::Error::new(
+                    Span::call_site(),
+                    "Client streaming RPC requires an update type",
+                )
+            })?;
+            let response_type = rpc_info.types.get("response").ok_or_else(|| {
+                syn::Error::new(
+                    Span::call_site(),
+                    "Client streaming RPC requires a response type",
+                )
+            })?;
+            quote! {
+                impl ::quic_rpc::message::Msg<#service_name> for #request_type {
+                    type Pattern = ::quic_rpc::pattern::client_streaming::ClientStreaming;
+                }
+                impl ::quic_rpc::pattern::client_streaming::ClientStreamingMsg<#service_name> for #request_type {
+                    type Update = #update_type;
+                    type Response = #response_type;
+                }
+            }
+        }
+        _ => return Err(syn::Error::new(Span::call_site(), "Unknown RPC pattern")),
+    };
+
+    impls.push(specific_impl);
+    Ok(impls)
+}
+
+#[proc_macro_attribute]
+pub fn rpc_requests(attr: TokenStream, item: TokenStream) -> TokenStream {
+    let mut input = parse_macro_input!(item as DeriveInput);
+    let service_name = parse_macro_input!(attr as Ident);
+
+    let data_enum = match &mut input.data {
+        Data::Enum(data_enum) => data_enum,
+        _ => {
+            return syn::Error::new(
+                Span::call_site(),
+                "RpcRequests can only be applied to enums",
+            )
+            .to_compile_error()
+            .into()
+        }
+    };
+
+    let mut additional_items = Vec::new();
+
+    for variant in &mut data_enum.variants {
+        // Check field structure for every variant
+        let request_type = match &variant.fields {
+            Fields::Unnamed(fields) if fields.unnamed.len() == 1 => &fields.unnamed[0].ty,
+            _ => {
+                return syn::Error::new(
+                    variant.span(),
+                    "Each variant must have exactly one unnamed field",
+                )
+                .to_compile_error()
+                .into()
+            }
+        };
+
+        let mut rpc_attr = None;
+        variant.attrs.retain(|attr| {
+            if attr.path.is_ident("rpc")
+                || attr.path.is_ident("bidi_streaming")
+                || attr.path.is_ident("server_streaming")
+                || attr.path.is_ident("client_streaming")
+            {
+                rpc_attr = Some(attr.clone());
+                false
+            } else {
+                true
+            }
+        });
+
+        if let Some(attr) = rpc_attr {
+            let ident = attr.path.get_ident().unwrap();
+            println!("{}", attr.to_token_stream());
+            let rpc_info = match parse_rpc_attr(&attr) {
+                Ok(info) => info,
+                Err(e) => return e.to_compile_error().into(),
+            };
+            println!("{:?}", rpc_info);
+
+            match generate_rpc_impls(ident, &rpc_info, &service_name, request_type) {
+                Ok(impls) => additional_items.extend(impls),
+                Err(e) => return e.to_compile_error().into(),
+            }
+        }
+    }
+
+    let output = quote! {
+        #input
+
+        #(#additional_items)*
+    };
+
+    println!("{}", output);
+
+    output.into()
+}

--- a/quic-rpc-derive/src/lib.rs
+++ b/quic-rpc-derive/src/lib.rs
@@ -134,7 +134,7 @@ pub fn rpc_requests(attr: TokenStream, item: TokenStream) -> TokenStream {
                 .into();
         }
 
-        //
+        // Extract and remove RPC attributes
         let mut rpc_attr = Vec::new();
         variant.attrs.retain(|attr| {
             for ident in IDENTS {

--- a/quic-rpc-derive/src/lib.rs
+++ b/quic-rpc-derive/src/lib.rs
@@ -102,6 +102,7 @@ pub fn rpc_requests(attr: TokenStream, item: TokenStream) -> TokenStream {
     let mut input = parse_macro_input!(item as DeriveInput);
     let service_name = parse_macro_input!(attr as Ident);
 
+    let input_span = input.span();
     let data_enum = match &mut input.data {
         Data::Enum(data_enum) => data_enum,
         _ => {
@@ -129,7 +130,7 @@ pub fn rpc_requests(attr: TokenStream, item: TokenStream) -> TokenStream {
         };
 
         if !types.insert(request_type.to_token_stream().to_string()) {
-            return syn::Error::new(input.span(), "Each variant must have a unique request type")
+            return syn::Error::new(input_span, "Each variant must have a unique request type")
                 .to_compile_error()
                 .into();
         }

--- a/quic-rpc-derive/src/lib.rs
+++ b/quic-rpc-derive/src/lib.rs
@@ -1,35 +1,212 @@
 use proc_macro::TokenStream;
-use proc_macro2::Span;
-use quote::{format_ident, quote, ToTokens};
-use std::{collections::HashMap, fmt::Debug};
+use proc_macro2::{Span, TokenStream as TokenStream2};
+use quote::{quote, ToTokens};
+use std::collections::{BTreeMap, HashSet};
 use syn::{
     parse::{Parse, ParseStream},
     parse_macro_input,
     spanned::Spanned,
-    Attribute, Data, DeriveInput, Fields, Ident, Lit, Meta, NestedMeta, Token, Type,
+    Data, DeriveInput, Fields, Ident, Token, Type,
 };
 
-struct RpcArgs {
-    types: HashMap<String, Type>,
+const SERVER_STREAMING: &str = "server_streaming";
+const CLIENT_STREAMING: &str = "client_streaming";
+const BIDI_STREAMING: &str = "bidi_streaming";
+const RPC: &str = "rpc";
+const TRY_SERVER_STREAMING: &str = "try_server_streaming";
+const IDENTS: [&str; 5] = [
+    SERVER_STREAMING,
+    CLIENT_STREAMING,
+    BIDI_STREAMING,
+    RPC,
+    TRY_SERVER_STREAMING,
+];
+
+fn generate_rpc_impls(
+    pat: &str,
+    mut args: RpcArgs,
+    service_name: &Ident,
+    request_type: &Type,
+    attr_span: Span,
+) -> syn::Result<TokenStream2> {
+    let res = match pat {
+        RPC => {
+            let response = args.get("response", pat, attr_span)?;
+            quote! {
+                impl ::quic_rpc::pattern::rpc::RpcMsg<#service_name> for #request_type {
+                    type Response = #response;
+                }
+            }
+        }
+        SERVER_STREAMING => {
+            let response = args.get("response", pat, attr_span)?;
+            quote! {
+                impl ::quic_rpc::message::Msg<#service_name> for #request_type {
+                    type Pattern = ::quic_rpc::pattern::server_streaming::ServerStreaming;
+                }
+                impl ::quic_rpc::pattern::server_streaming::ServerStreamingMsg<#service_name> for #request_type {
+                    type Response = #response;
+                }
+            }
+        }
+        BIDI_STREAMING => {
+            let update = args.get("update", pat, attr_span)?;
+            let response = args.get("response", pat, attr_span)?;
+            quote! {
+                impl ::quic_rpc::message::Msg<#service_name> for #request_type {
+                    type Pattern = ::quic_rpc::pattern::bidi_streaming::BidiStreaming;
+                }
+                impl ::quic_rpc::pattern::bidi_streaming::BidiStreamingMsg<#service_name> for #request_type {
+                    type Update = #update;
+                    type Response = #response;
+                }
+            }
+        }
+        CLIENT_STREAMING => {
+            let update = args.get("update", pat, attr_span)?;
+            let response = args.get("response", pat, attr_span)?;
+            quote! {
+                impl ::quic_rpc::message::Msg<#service_name> for #request_type {
+                    type Pattern = ::quic_rpc::pattern::client_streaming::ClientStreaming;
+                }
+                impl ::quic_rpc::pattern::client_streaming::ClientStreamingMsg<#service_name> for #request_type {
+                    type Update = #update;
+                    type Response = #response;
+                }
+            }
+        }
+        TRY_SERVER_STREAMING => {
+            let create_error = args.get("create_error", pat, attr_span)?;
+            let item_error = args.get("item_error", pat, attr_span)?;
+            let item = args.get("item", pat, attr_span)?;
+            quote! {
+                impl ::quic_rpc::message::Msg<#service_name> for #request_type {
+                    type Pattern = ::quic_rpc::pattern::try_server_streaming::TryServerStreaming;
+                }
+                impl ::quic_rpc::pattern::try_server_streaming::TryServerStreamingMsg<#service_name> for #request_type {
+                    type CreateError = #create_error;
+                    type ItemError = #item_error;
+                    type Item = #item;
+                }
+            }
+        }
+        _ => return Err(syn::Error::new(attr_span, "Unknown RPC pattern")),
+    };
+    args.check_empty(attr_span)?;
+
+    Ok(res)
 }
 
-impl Debug for RpcArgs {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("RpcInfo")
-            .field(
-                "types",
-                &self
-                    .types
-                    .iter()
-                    .map(|(k, v)| (k.clone(), v.to_token_stream().to_string()))
-                    .collect::<Vec<_>>(),
-            )
-            .finish()
+#[proc_macro_attribute]
+pub fn rpc_requests(attr: TokenStream, item: TokenStream) -> TokenStream {
+    let mut input = parse_macro_input!(item as DeriveInput);
+    let service_name = parse_macro_input!(attr as Ident);
+
+    let data_enum = match &mut input.data {
+        Data::Enum(data_enum) => data_enum,
+        _ => {
+            return syn::Error::new(input.span(), "RpcRequests can only be applied to enums")
+                .to_compile_error()
+                .into()
+        }
+    };
+
+    let mut additional_items = Vec::new();
+    let mut types = HashSet::new();
+
+    for variant in &mut data_enum.variants {
+        // Check field structure for every variant
+        let request_type = match &variant.fields {
+            Fields::Unnamed(fields) if fields.unnamed.len() == 1 => &fields.unnamed[0].ty,
+            _ => {
+                return syn::Error::new(
+                    variant.span(),
+                    "Each variant must have exactly one unnamed field",
+                )
+                .to_compile_error()
+                .into()
+            }
+        };
+
+        if !types.insert(request_type.to_token_stream().to_string()) {
+            return syn::Error::new(input.span(), "Each variant must have a unique request type")
+                .to_compile_error()
+                .into();
+        }
+
+        //
+        let mut rpc_attr = Vec::new();
+        variant.attrs.retain(|attr| {
+            for ident in IDENTS {
+                if attr.path.is_ident(ident) {
+                    rpc_attr.push((ident, attr.clone()));
+                    return false;
+                }
+            }
+            return true;
+        });
+
+        // Fail if there are multiple RPC patterns
+        if rpc_attr.len() > 1 {
+            return syn::Error::new(variant.span(), "Each variant can only have one RPC pattern")
+                .to_compile_error()
+                .into();
+        }
+
+        if let Some((ident, attr)) = rpc_attr.pop() {
+            let args = match attr.parse_args::<RpcArgs>() {
+                Ok(info) => info,
+                Err(e) => return e.to_compile_error().into(),
+            };
+
+            match generate_rpc_impls(ident, args, &service_name, request_type, attr.span()) {
+                Ok(impls) => additional_items.extend(impls),
+                Err(e) => return e.to_compile_error().into(),
+            }
+        }
+    }
+
+    let output = quote! {
+        #input
+
+        #(#additional_items)*
+    };
+
+    output.into()
+}
+
+struct RpcArgs {
+    types: BTreeMap<String, Type>,
+}
+
+impl RpcArgs {
+    /// Get and remove a type from the map, failing if it doesn't exist
+    fn get(&mut self, key: &str, kind: &str, span: Span) -> syn::Result<Type> {
+        self.types
+            .remove(key)
+            .ok_or_else(|| syn::Error::new(span, format!("{kind} requires a {key} type")))
+    }
+
+    /// Fail if there are any unknown arguments remaining
+    fn check_empty(&self, span: Span) -> syn::Result<()> {
+        if self.types.is_empty() {
+            Ok(())
+        } else {
+            Err(syn::Error::new(
+                span,
+                format!(
+                    "Unknown arguments provided: {:?}",
+                    self.types.keys().collect::<Vec<_>>()
+                ),
+            ))
+        }
     }
 }
+
+/// Parse the rpc args as a comma separated list of name=type pairs
 impl Parse for RpcArgs {
     fn parse(input: ParseStream) -> syn::Result<Self> {
-        let mut types = HashMap::new();
+        let mut types = BTreeMap::new();
 
         loop {
             if input.is_empty() {
@@ -50,173 +227,4 @@ impl Parse for RpcArgs {
 
         Ok(RpcArgs { types })
     }
-}
-
-fn parse_rpc_attr(attr: &Attribute) -> syn::Result<RpcArgs> {
-    attr.parse_args()
-}
-
-fn generate_rpc_impls(
-    ident: &Ident,
-    rpc_info: &RpcArgs,
-    service_name: &Ident,
-    request_type: &Type,
-) -> syn::Result<Vec<proc_macro2::TokenStream>> {
-    let pattern = ident;
-    let pattern_ident = format_ident!("{}", pattern);
-
-    let mut impls = vec![];
-
-    let specific_impl = match pattern.to_string().as_str() {
-        "rpc" => {
-            let response_type = rpc_info.types.get("response").ok_or_else(|| {
-                syn::Error::new(Span::call_site(), "Unary RPC requires a response type")
-            })?;
-            quote! {
-                impl ::quic_rpc::pattern::rpc::RpcMsg<#service_name> for #request_type {
-                    type Response = #response_type;
-                }
-            }
-        }
-        "server_streaming" => {
-            let response_type = rpc_info.types.get("response").ok_or_else(|| {
-                syn::Error::new(
-                    Span::call_site(),
-                    "Server streaming RPC requires an update type",
-                )
-            })?;
-            quote! {
-                impl ::quic_rpc::message::Msg<#service_name> for #request_type {
-                    type Pattern = ::quic_rpc::pattern::server_streaming::ServerStreaming;
-                }
-                impl ::quic_rpc::pattern::server_streaming::ServerStreamingMsg<#service_name> for #request_type {
-                    type Response = #response_type;
-                }
-            }
-        }
-        "bidi_streaming" => {
-            let update_type = rpc_info.types.get("update").ok_or_else(|| {
-                syn::Error::new(
-                    Span::call_site(),
-                    "Bidi streaming RPC requires an update type",
-                )
-            })?;
-            let response_type = rpc_info.types.get("response").ok_or_else(|| {
-                syn::Error::new(
-                    Span::call_site(),
-                    "Bidi streaming RPC requires a response type",
-                )
-            })?;
-            quote! {
-                impl ::quic_rpc::message::Msg<#service_name> for #request_type {
-                    type Pattern = ::quic_rpc::pattern::bidi_streaming::BidiStreaming;
-                }
-                impl ::quic_rpc::pattern::bidi_streaming::BidiStreamingMsg<#service_name> for #request_type {
-                    type Update = #update_type;
-                    type Response = #response_type;
-                }
-            }
-        }
-        "client_streaming" => {
-            let update_type = rpc_info.types.get("update").ok_or_else(|| {
-                syn::Error::new(
-                    Span::call_site(),
-                    "Client streaming RPC requires an update type",
-                )
-            })?;
-            let response_type = rpc_info.types.get("response").ok_or_else(|| {
-                syn::Error::new(
-                    Span::call_site(),
-                    "Client streaming RPC requires a response type",
-                )
-            })?;
-            quote! {
-                impl ::quic_rpc::message::Msg<#service_name> for #request_type {
-                    type Pattern = ::quic_rpc::pattern::client_streaming::ClientStreaming;
-                }
-                impl ::quic_rpc::pattern::client_streaming::ClientStreamingMsg<#service_name> for #request_type {
-                    type Update = #update_type;
-                    type Response = #response_type;
-                }
-            }
-        }
-        _ => return Err(syn::Error::new(Span::call_site(), "Unknown RPC pattern")),
-    };
-
-    impls.push(specific_impl);
-    Ok(impls)
-}
-
-#[proc_macro_attribute]
-pub fn rpc_requests(attr: TokenStream, item: TokenStream) -> TokenStream {
-    let mut input = parse_macro_input!(item as DeriveInput);
-    let service_name = parse_macro_input!(attr as Ident);
-
-    let data_enum = match &mut input.data {
-        Data::Enum(data_enum) => data_enum,
-        _ => {
-            return syn::Error::new(
-                Span::call_site(),
-                "RpcRequests can only be applied to enums",
-            )
-            .to_compile_error()
-            .into()
-        }
-    };
-
-    let mut additional_items = Vec::new();
-
-    for variant in &mut data_enum.variants {
-        // Check field structure for every variant
-        let request_type = match &variant.fields {
-            Fields::Unnamed(fields) if fields.unnamed.len() == 1 => &fields.unnamed[0].ty,
-            _ => {
-                return syn::Error::new(
-                    variant.span(),
-                    "Each variant must have exactly one unnamed field",
-                )
-                .to_compile_error()
-                .into()
-            }
-        };
-
-        let mut rpc_attr = None;
-        variant.attrs.retain(|attr| {
-            if attr.path.is_ident("rpc")
-                || attr.path.is_ident("bidi_streaming")
-                || attr.path.is_ident("server_streaming")
-                || attr.path.is_ident("client_streaming")
-            {
-                rpc_attr = Some(attr.clone());
-                false
-            } else {
-                true
-            }
-        });
-
-        if let Some(attr) = rpc_attr {
-            let ident = attr.path.get_ident().unwrap();
-            println!("{}", attr.to_token_stream());
-            let rpc_info = match parse_rpc_attr(&attr) {
-                Ok(info) => info,
-                Err(e) => return e.to_compile_error().into(),
-            };
-            println!("{:?}", rpc_info);
-
-            match generate_rpc_impls(ident, &rpc_info, &service_name, request_type) {
-                Ok(impls) => additional_items.extend(impls),
-                Err(e) => return e.to_compile_error().into(),
-            }
-        }
-    }
-
-    let output = quote! {
-        #input
-
-        #(#additional_items)*
-    };
-
-    println!("{}", output);
-
-    output.into()
 }

--- a/quic-rpc-derive/tests/compile_fail/duplicate_type.rs
+++ b/quic-rpc-derive/tests/compile_fail/duplicate_type.rs
@@ -1,0 +1,9 @@
+use quic_rpc_derive::rpc_requests;
+
+#[rpc_requests(Service)]
+enum Enum {
+    A(u8),
+    B(u8),
+}
+
+fn main() {}

--- a/quic-rpc-derive/tests/compile_fail/duplicate_type.stderr
+++ b/quic-rpc-derive/tests/compile_fail/duplicate_type.stderr
@@ -1,0 +1,5 @@
+error: Each variant must have a unique request type
+ --> tests/compile_fail/duplicate_type.rs:4:1
+  |
+4 | enum Enum {
+  | ^^^^

--- a/quic-rpc-derive/tests/compile_fail/extra_attr_types.rs
+++ b/quic-rpc-derive/tests/compile_fail/extra_attr_types.rs
@@ -1,0 +1,9 @@
+use quic_rpc_derive::rpc_requests;
+
+#[rpc_requests(Service)]
+enum Enum {
+    #[rpc(response = Bla, fnord = Foo)]
+    A(u8),
+}
+
+fn main() {}

--- a/quic-rpc-derive/tests/compile_fail/extra_attr_types.stderr
+++ b/quic-rpc-derive/tests/compile_fail/extra_attr_types.stderr
@@ -1,0 +1,5 @@
+error: Unknown arguments provided: ["fnord"]
+ --> tests/compile_fail/extra_attr_types.rs:5:5
+  |
+5 |     #[rpc(response = Bla, fnord = Foo)]
+  |     ^

--- a/quic-rpc-derive/tests/compile_fail/multiple_fields.rs
+++ b/quic-rpc-derive/tests/compile_fail/multiple_fields.rs
@@ -1,0 +1,8 @@
+use quic_rpc_derive::rpc_requests;
+
+#[rpc_requests(Service)]
+enum Enum {
+    A(u8, u8),
+}
+
+fn main() {}

--- a/quic-rpc-derive/tests/compile_fail/multiple_fields.stderr
+++ b/quic-rpc-derive/tests/compile_fail/multiple_fields.stderr
@@ -1,0 +1,5 @@
+error: Each variant must have exactly one unnamed field
+ --> tests/compile_fail/multiple_fields.rs:5:5
+  |
+5 |     A(u8, u8),
+  |     ^

--- a/quic-rpc-derive/tests/compile_fail/named_enum.rs
+++ b/quic-rpc-derive/tests/compile_fail/named_enum.rs
@@ -1,0 +1,8 @@
+use quic_rpc_derive::rpc_requests;
+
+#[rpc_requests(Service)]
+enum Enum {
+    A { name: u8 },
+}
+
+fn main() {}

--- a/quic-rpc-derive/tests/compile_fail/named_enum.stderr
+++ b/quic-rpc-derive/tests/compile_fail/named_enum.stderr
@@ -1,0 +1,5 @@
+error: Each variant must have exactly one unnamed field
+ --> tests/compile_fail/named_enum.rs:5:5
+  |
+5 |     A { name: u8 },
+  |     ^

--- a/quic-rpc-derive/tests/compile_fail/non_enum.rs
+++ b/quic-rpc-derive/tests/compile_fail/non_enum.rs
@@ -1,0 +1,6 @@
+use quic_rpc_derive::rpc_requests;
+
+#[rpc_requests(Service)]
+struct Foo;
+
+fn main() {}

--- a/quic-rpc-derive/tests/compile_fail/non_enum.stderr
+++ b/quic-rpc-derive/tests/compile_fail/non_enum.stderr
@@ -1,0 +1,5 @@
+error: RpcRequests can only be applied to enums
+ --> tests/compile_fail/non_enum.rs:4:1
+  |
+4 | struct Foo;
+  | ^^^^^^

--- a/quic-rpc-derive/tests/compile_fail/wrong_attr_types.rs
+++ b/quic-rpc-derive/tests/compile_fail/wrong_attr_types.rs
@@ -1,0 +1,9 @@
+use quic_rpc_derive::rpc_requests;
+
+#[rpc_requests(Service)]
+enum Enum {
+    #[rpc(fnord = Bla)]
+    A(u8),
+}
+
+fn main() {}

--- a/quic-rpc-derive/tests/compile_fail/wrong_attr_types.stderr
+++ b/quic-rpc-derive/tests/compile_fail/wrong_attr_types.stderr
@@ -1,0 +1,5 @@
+error: rpc requires a response type
+ --> tests/compile_fail/wrong_attr_types.rs:5:5
+  |
+5 |     #[rpc(fnord = Bla)]
+  |     ^

--- a/quic-rpc-derive/tests/smoke.rs
+++ b/quic-rpc-derive/tests/smoke.rs
@@ -15,25 +15,45 @@ fn simple() {
     #[derive(Debug, Serialize, Deserialize)]
     struct BidiStreamingRequest;
 
+    #[derive(Debug, Serialize, Deserialize)]
+    struct Update1;
+
+    #[derive(Debug, Serialize, Deserialize)]
+    struct Update2;
+
+    #[derive(Debug, Serialize, Deserialize)]
+    struct Response1;
+
+    #[derive(Debug, Serialize, Deserialize)]
+    struct Response2;
+
+    #[derive(Debug, Serialize, Deserialize)]
+    struct Response3;
+
+    #[derive(Debug, Serialize, Deserialize)]
+    struct Response4;
+
     #[rpc_requests(Service)]
     #[derive(Debug, Serialize, Deserialize, derive_more::From, derive_more::TryInto)]
     enum Request {
-        #[rpc(response=u32)]
+        #[rpc(response=Response1)]
         Rpc(RpcRequest),
-        #[server_streaming(response=())]
+        #[server_streaming(response=Response2)]
         ServerStreaming(ServerStreamingRequest),
-        #[bidi_streaming(update=(), response = ())]
+        #[bidi_streaming(update= Update1, response = Response3)]
         BidiStreaming(BidiStreamingRequest),
-        #[client_streaming(update = (), response = ())]
+        #[client_streaming(update = Update2, response = Response4)]
         ClientStreaming(ClientStreamingRequest),
-        // an update, you will never get this as the first message
-        GenericUpdate(()),
+        Update1(Update1),
+        Update2(Update2),
     }
 
     #[derive(Debug, Serialize, Deserialize, derive_more::From, derive_more::TryInto)]
     enum Response {
-        Void(()),
-        Rpc(u32),
+        Response1(Response1),
+        Response2(Response2),
+        Response3(Response3),
+        Response4(Response4),
     }
 
     #[derive(Debug, Clone)]

--- a/quic-rpc-derive/tests/smoke.rs
+++ b/quic-rpc-derive/tests/smoke.rs
@@ -1,4 +1,3 @@
-use quic_rpc::pattern::{bidi_streaming, server_streaming};
 use quic_rpc_derive::rpc_requests;
 use serde::{Deserialize, Serialize};
 
@@ -19,20 +18,22 @@ fn simple() {
     #[rpc_requests(Service)]
     #[derive(Debug, Serialize, Deserialize, derive_more::From, derive_more::TryInto)]
     enum Request {
-        #[rpc(response=())]
+        #[rpc(response=u32)]
         Rpc(RpcRequest),
         #[server_streaming(response=())]
         ServerStreaming(ServerStreamingRequest),
-        #[bidi_streaming(update=(), response=())]
+        #[bidi_streaming(update=(), response = ())]
         BidiStreaming(BidiStreamingRequest),
-        #[client_streaming(update=(), response=())]
+        #[client_streaming(update = (), response = ())]
         ClientStreaming(ClientStreamingRequest),
+        // an update, you will never get this as the first message
         GenericUpdate(()),
     }
 
     #[derive(Debug, Serialize, Deserialize, derive_more::From, derive_more::TryInto)]
     enum Response {
         Void(()),
+        Rpc(u32),
     }
 
     #[derive(Debug, Clone)]
@@ -42,4 +43,17 @@ fn simple() {
         type Req = Request;
         type Res = Response;
     }
+
+    let _ = Service;
+}
+
+/// Use
+///
+/// TRYBUILD=overwrite cargo test --test smoke
+///
+/// to update the snapshots
+#[test]
+fn compile_fail() {
+    let t = trybuild::TestCases::new();
+    t.compile_fail("tests/compile_fail/*.rs");
 }

--- a/quic-rpc-derive/tests/smoke.rs
+++ b/quic-rpc-derive/tests/smoke.rs
@@ -1,0 +1,45 @@
+use quic_rpc::pattern::{bidi_streaming, server_streaming};
+use quic_rpc_derive::rpc_requests;
+use serde::{Deserialize, Serialize};
+
+#[test]
+fn simple() {
+    #[derive(Debug, Serialize, Deserialize)]
+    struct RpcRequest;
+
+    #[derive(Debug, Serialize, Deserialize)]
+    struct ServerStreamingRequest;
+
+    #[derive(Debug, Serialize, Deserialize)]
+    struct ClientStreamingRequest;
+
+    #[derive(Debug, Serialize, Deserialize)]
+    struct BidiStreamingRequest;
+
+    #[rpc_requests(Service)]
+    #[derive(Debug, Serialize, Deserialize, derive_more::From, derive_more::TryInto)]
+    enum Request {
+        #[rpc(response=())]
+        Rpc(RpcRequest),
+        #[server_streaming(response=())]
+        ServerStreaming(ServerStreamingRequest),
+        #[bidi_streaming(update=(), response=())]
+        BidiStreaming(BidiStreamingRequest),
+        #[client_streaming(update=(), response=())]
+        ClientStreaming(ClientStreamingRequest),
+        GenericUpdate(()),
+    }
+
+    #[derive(Debug, Serialize, Deserialize, derive_more::From, derive_more::TryInto)]
+    enum Response {
+        Void(()),
+    }
+
+    #[derive(Debug, Clone)]
+    struct Service;
+
+    impl quic_rpc::Service for Service {
+        type Req = Request;
+        type Res = Response;
+    }
+}


### PR DESCRIPTION
The way the interaction patterns are specified is very flexible and does a very good job explaining it to the compiler.

However, a downside is that it is pretty verbose and that you don't have a single place to grasp how a service works.

This PR adds an additional macro crate that allows annotating the request enum with the interaction pattern for each request type. It does not require any changes to quic-rpc itself, just basically derives the various quic-rpc message traits.

Example syntax:

```rust
  #[rpc_requests(Service)]
  #[derive(Debug, Serialize, Deserialize, derive_more::From, derive_more::TryInto)]
  enum Request {
      #[rpc(response=u32)]
      Rpc(RpcRequest),
      #[server_streaming(response=())]
      ServerStreaming(ServerStreamingRequest),
      #[bidi_streaming(update=(), response = ())]
      BidiStreaming(BidiStreamingRequest),
      #[client_streaming(update = (), response = ())]
      ClientStreaming(ClientStreamingRequest),
      // an update, you will never get this as the first message
      GenericUpdate(()),
  }
```

Enforced rules:

- only unnamed single field enum
- distinct types
- one pattern per variant
- variant type args must be completely consumed
- no extra variant type args

Rules are checked using trybuild.

The service type itself still has to be defined manually, since we want to leave the possibility open that the service enum is a nested enum that works for multiple subsystems.

We might do a macro to do the service definition itself, but it is not much code either way.

```rust
    impl quic_rpc::Service for Service {
        type Req = Request;
        type Res = Response;
    }
```