### PR TITLE
deps: Remove direct rustls dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -901,7 +901,6 @@ dependencies = [
  "pin-project",
  "proc-macro2",
  "rcgen",
- "rustls",
  "serde",
  "slab",
  "tempfile",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,6 @@ serde = { version = "1", features = ["derive"] }
 tokio = { version = "1", features = ["full"] }
 quinn = { package = "iroh-quinn", version = "0.11", features = ["ring"] }
 rcgen = "0.12"
-rustls = { version = "0.23", default-features = false, features = ["ring"] }
 thousands = "0.2.0"
 tracing-subscriber = "0.3.16"
 tempfile = "3.5.0"

--- a/tests/quinn.rs
+++ b/tests/quinn.rs
@@ -7,7 +7,7 @@ use std::{
 use quic_rpc::{transport, RpcClient, RpcServer};
 use quinn::{
     crypto::rustls::{QuicClientConfig, QuicServerConfig},
-    ClientConfig, Endpoint, ServerConfig,
+    rustls, ClientConfig, Endpoint, ServerConfig,
 };
 use tokio::task::JoinHandle;
 


### PR DESCRIPTION
Quinn now re-exports the correct version of rustls that should be used with it.  Let's depend on that instead of having to manually keep the dependency in sync.