### PR TITLE
Composable service refactor

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -881,7 +881,7 @@ dependencies = [
 
 [[package]]
 name = "quic-rpc"
-version = "0.12.1"
+version = "0.13.0"
 dependencies = [
  "anyhow",
  "async-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "quic-rpc"
-version = "0.12.1"
+version = "0.13.0"
 edition = "2021"
 authors = ["Rüdiger Klaehn <rklaehn@protonmail.com>", "n0 team"]
 keywords = ["api", "protocol", "network", "rpc"]

--- a/examples/errors.rs
+++ b/examples/errors.rs
@@ -55,7 +55,7 @@ impl Fs {
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     let fs = Fs;
-    let (server, client) = quic_rpc::transport::flume::connection::<IoService>(1);
+    let (server, client) = quic_rpc::transport::flume::service_connection::<IoService>(1);
     let client = RpcClient::new(client);
     let server = RpcServer::new(server);
     let handle = tokio::task::spawn(async move {

--- a/examples/macro.rs
+++ b/examples/macro.rs
@@ -110,7 +110,7 @@ async fn main() -> anyhow::Result<()> {
         let target = Store;
         run_server_loop(StoreService, server, target, dispatch_store_request).await
     });
-    let client = RpcClient::<StoreService, _, _>::new(client);
+    let client = RpcClient::<StoreService, _>::new(client);
 
     // a rpc call
     for i in 0..3 {

--- a/examples/macro.rs
+++ b/examples/macro.rs
@@ -105,7 +105,7 @@ create_store_dispatch!(Store, dispatch_store_request);
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
-    let (server, client) = flume::connection::<StoreService>(1);
+    let (server, client) = flume::service_connection::<StoreService>(1);
     let server_handle = tokio::task::spawn(async move {
         let target = Store;
         run_server_loop(StoreService, server, target, dispatch_store_request).await

--- a/examples/macro.rs
+++ b/examples/macro.rs
@@ -110,7 +110,7 @@ async fn main() -> anyhow::Result<()> {
         let target = Store;
         run_server_loop(StoreService, server, target, dispatch_store_request).await
     });
-    let client = RpcClient::<StoreService, _>::new(client);
+    let client = RpcClient::<StoreService, _, _>::new(client);
 
     // a rpc call
     for i in 0..3 {

--- a/examples/modularize.rs
+++ b/examples/modularize.rs
@@ -236,7 +236,7 @@ mod iroh {
         pub async fn handle_rpc_request<S, E>(
             self,
             req: Request,
-            chan: RpcChannel<S, IrohService, E>,
+            chan: RpcChannel<IrohService, S, E>,
         ) -> Result<()>
         where
             S: Service,
@@ -340,7 +340,7 @@ mod calc {
         pub async fn handle_rpc_request<S, E>(
             self,
             req: Request,
-            chan: RpcChannel<S, CalcService, E>,
+            chan: RpcChannel<CalcService, S, E>,
         ) -> Result<()>
         where
             S: Service,
@@ -478,7 +478,7 @@ mod clock {
         pub async fn handle_rpc_request<S, E>(
             self,
             req: Request,
-            chan: RpcChannel<S, ClockService, E>,
+            chan: RpcChannel<ClockService, S, E>,
         ) -> Result<()>
         where
             S: Service,

--- a/examples/modularize.rs
+++ b/examples/modularize.rs
@@ -172,8 +172,8 @@ mod app {
 
     #[derive(Debug, Clone)]
     pub struct Client<S: Service, C: ServiceConnection<S>> {
-        pub iroh: iroh::Client<C, S>,
-        client: RpcClient<S, C, AppService>,
+        pub iroh: iroh::Client<S, C>,
+        client: RpcClient<S, AppService, C>,
     }
 
     impl<S, C> Client<S, C>
@@ -181,7 +181,7 @@ mod app {
         S: Service,
         C: ServiceConnection<S>,
     {
-        pub fn new(client: RpcClient<S, C, AppService>) -> Self {
+        pub fn new(client: RpcClient<S, AppService, C>) -> Self {
             Self {
                 iroh: iroh::Client::new(client.clone().map()),
                 client,
@@ -251,17 +251,17 @@ mod iroh {
     }
 
     #[derive(Debug, Clone)]
-    pub struct Client<C, S = IrohService> {
-        pub calc: calc::Client<C, S>,
-        pub clock: clock::Client<C, S>,
+    pub struct Client<S, C> {
+        pub calc: calc::Client<S, C>,
+        pub clock: clock::Client<S, C>,
     }
 
-    impl<C, S> Client<C, S>
+    impl<S, C> Client<S, C>
     where
-        C: ServiceConnection<S>,
         S: Service,
+        C: ServiceConnection<S>,
     {
-        pub fn new(client: RpcClient<S, C, IrohService>) -> Self {
+        pub fn new(client: RpcClient<S, IrohService, C>) -> Self {
             Self {
                 calc: calc::Client::new(client.clone().map()),
                 clock: clock::Client::new(client.clone().map()),
@@ -373,16 +373,16 @@ mod calc {
     }
 
     #[derive(Debug, Clone)]
-    pub struct Client<C, S = CalcService> {
-        client: RpcClient<S, C, CalcService>,
+    pub struct Client<S, C> {
+        client: RpcClient<S, CalcService, C>,
     }
 
-    impl<C, S> Client<C, S>
+    impl<S, C> Client<S, C>
     where
         C: ServiceConnection<S>,
         S: Service,
     {
-        pub fn new(client: RpcClient<S, C, CalcService>) -> Self {
+        pub fn new(client: RpcClient<S, CalcService, C>) -> Self {
             Self { client }
         }
         pub async fn add(&self, a: i64, b: i64) -> anyhow::Result<i64> {
@@ -517,16 +517,16 @@ mod clock {
     }
 
     #[derive(Debug, Clone)]
-    pub struct Client<C, S = ClockService> {
-        client: RpcClient<S, C, ClockService>,
+    pub struct Client<S, C> {
+        client: RpcClient<S, ClockService, C>,
     }
 
-    impl<C, S> Client<C, S>
+    impl<S, C> Client<S, C>
     where
         C: ServiceConnection<S>,
         S: Service,
     {
-        pub fn new(client: RpcClient<S, C, ClockService>) -> Self {
+        pub fn new(client: RpcClient<S, ClockService, C>) -> Self {
             Self { client }
         }
         pub async fn tick(&self) -> Result<BoxStream<Result<usize>>> {

--- a/examples/modularize.rs
+++ b/examples/modularize.rs
@@ -32,7 +32,7 @@ async fn main() -> Result<()> {
 }
 
 async fn run_server<C: ServiceEndpoint<AppService>>(server_conn: C, handler: app::Handler) {
-    let server = RpcServer::new(server_conn);
+    let server = RpcServer::<AppService, _>::new(server_conn);
     loop {
         let Ok(accepting) = server.accept().await else {
             continue;
@@ -156,7 +156,7 @@ mod app {
         pub async fn handle_rpc_request<E: ServiceEndpoint<AppService>>(
             self,
             req: Request,
-            chan: RpcChannel<AppService, E>,
+            chan: RpcChannel<AppService, AppService, E>,
         ) -> Result<()> {
             match req {
                 Request::Iroh(req) => self.iroh.handle_rpc_request(req, chan.map()).await?,
@@ -236,7 +236,7 @@ mod iroh {
         pub async fn handle_rpc_request<S, E>(
             self,
             req: Request,
-            chan: RpcChannel<S, E, IrohService>,
+            chan: RpcChannel<S, IrohService, E>,
         ) -> Result<()>
         where
             S: Service,
@@ -340,7 +340,7 @@ mod calc {
         pub async fn handle_rpc_request<S, E>(
             self,
             req: Request,
-            chan: RpcChannel<S, E, CalcService>,
+            chan: RpcChannel<S, CalcService, E>,
         ) -> Result<()>
         where
             S: Service,
@@ -478,7 +478,7 @@ mod clock {
         pub async fn handle_rpc_request<S, E>(
             self,
             req: Request,
-            chan: RpcChannel<S, E, ClockService>,
+            chan: RpcChannel<S, ClockService, E>,
         ) -> Result<()>
         where
             S: Service,

--- a/examples/modularize.rs
+++ b/examples/modularize.rs
@@ -19,7 +19,7 @@ use app::AppService;
 async fn main() -> Result<()> {
     // Spawn an inmemory connection.
     // Could use quic equally (all code in this example is generic over the transport)
-    let (server_conn, client_conn) = flume::connection::<AppService>(1);
+    let (server_conn, client_conn) = flume::service_connection::<AppService>(1);
 
     // spawn the server
     let handler = app::Handler::default();
@@ -173,7 +173,7 @@ mod app {
     #[derive(Debug, Clone)]
     pub struct Client<S: Service, C: ServiceConnection<S>> {
         pub iroh: iroh::Client<S, C>,
-        client: RpcClient<S, AppService, C>,
+        client: RpcClient<AppService, S, C>,
     }
 
     impl<S, C> Client<S, C>
@@ -181,7 +181,7 @@ mod app {
         S: Service,
         C: ServiceConnection<S>,
     {
-        pub fn new(client: RpcClient<S, AppService, C>) -> Self {
+        pub fn new(client: RpcClient<AppService, S, C>) -> Self {
             Self {
                 iroh: iroh::Client::new(client.clone().map()),
                 client,
@@ -261,7 +261,7 @@ mod iroh {
         S: Service,
         C: ServiceConnection<S>,
     {
-        pub fn new(client: RpcClient<S, IrohService, C>) -> Self {
+        pub fn new(client: RpcClient<IrohService, S, C>) -> Self {
             Self {
                 calc: calc::Client::new(client.clone().map()),
                 clock: clock::Client::new(client.clone().map()),
@@ -374,7 +374,7 @@ mod calc {
 
     #[derive(Debug, Clone)]
     pub struct Client<S, C> {
-        client: RpcClient<S, CalcService, C>,
+        client: RpcClient<CalcService, S, C>,
     }
 
     impl<S, C> Client<S, C>
@@ -382,7 +382,7 @@ mod calc {
         C: ServiceConnection<S>,
         S: Service,
     {
-        pub fn new(client: RpcClient<S, CalcService, C>) -> Self {
+        pub fn new(client: RpcClient<CalcService, S, C>) -> Self {
             Self { client }
         }
         pub async fn add(&self, a: i64, b: i64) -> anyhow::Result<i64> {
@@ -518,7 +518,7 @@ mod clock {
 
     #[derive(Debug, Clone)]
     pub struct Client<S, C> {
-        client: RpcClient<S, ClockService, C>,
+        client: RpcClient<ClockService, S, C>,
     }
 
     impl<S, C> Client<S, C>
@@ -526,7 +526,7 @@ mod clock {
         C: ServiceConnection<S>,
         S: Service,
     {
-        pub fn new(client: RpcClient<S, ClockService, C>) -> Self {
+        pub fn new(client: RpcClient<ClockService, S, C>) -> Self {
             Self { client }
         }
         pub async fn tick(&self) -> Result<BoxStream<Result<usize>>> {

--- a/examples/modularize.rs
+++ b/examples/modularize.rs
@@ -156,7 +156,7 @@ mod app {
         pub async fn handle_rpc_request<E: ServiceEndpoint<AppService>>(
             self,
             req: Request,
-            chan: RpcChannel<AppService, AppService, E>,
+            chan: RpcChannel<AppService, E, AppService>,
         ) -> Result<()> {
             match req {
                 Request::Iroh(req) => self.iroh.handle_rpc_request(req, chan.map()).await?,
@@ -173,7 +173,7 @@ mod app {
     #[derive(Debug, Clone)]
     pub struct Client<S: Service, C: ServiceConnection<S>> {
         pub iroh: iroh::Client<S, C>,
-        client: RpcClient<AppService, S, C>,
+        client: RpcClient<AppService, C, S>,
     }
 
     impl<S, C> Client<S, C>
@@ -181,7 +181,7 @@ mod app {
         S: Service,
         C: ServiceConnection<S>,
     {
-        pub fn new(client: RpcClient<AppService, S, C>) -> Self {
+        pub fn new(client: RpcClient<AppService, C, S>) -> Self {
             Self {
                 iroh: iroh::Client::new(client.clone().map()),
                 client,
@@ -236,7 +236,7 @@ mod iroh {
         pub async fn handle_rpc_request<S, E>(
             self,
             req: Request,
-            chan: RpcChannel<IrohService, S, E>,
+            chan: RpcChannel<IrohService, E, S>,
         ) -> Result<()>
         where
             S: Service,
@@ -261,7 +261,7 @@ mod iroh {
         S: Service,
         C: ServiceConnection<S>,
     {
-        pub fn new(client: RpcClient<IrohService, S, C>) -> Self {
+        pub fn new(client: RpcClient<IrohService, C, S>) -> Self {
             Self {
                 calc: calc::Client::new(client.clone().map()),
                 clock: clock::Client::new(client.clone().map()),
@@ -340,7 +340,7 @@ mod calc {
         pub async fn handle_rpc_request<S, E>(
             self,
             req: Request,
-            chan: RpcChannel<CalcService, S, E>,
+            chan: RpcChannel<CalcService, E, S>,
         ) -> Result<()>
         where
             S: Service,
@@ -374,7 +374,7 @@ mod calc {
 
     #[derive(Debug, Clone)]
     pub struct Client<S, C> {
-        client: RpcClient<CalcService, S, C>,
+        client: RpcClient<CalcService, C, S>,
     }
 
     impl<S, C> Client<S, C>
@@ -382,7 +382,7 @@ mod calc {
         C: ServiceConnection<S>,
         S: Service,
     {
-        pub fn new(client: RpcClient<CalcService, S, C>) -> Self {
+        pub fn new(client: RpcClient<CalcService, C, S>) -> Self {
             Self { client }
         }
         pub async fn add(&self, a: i64, b: i64) -> anyhow::Result<i64> {
@@ -478,7 +478,7 @@ mod clock {
         pub async fn handle_rpc_request<S, E>(
             self,
             req: Request,
-            chan: RpcChannel<ClockService, S, E>,
+            chan: RpcChannel<ClockService, E, S>,
         ) -> Result<()>
         where
             S: Service,
@@ -518,7 +518,7 @@ mod clock {
 
     #[derive(Debug, Clone)]
     pub struct Client<S, C> {
-        client: RpcClient<ClockService, S, C>,
+        client: RpcClient<ClockService, C, S>,
     }
 
     impl<S, C> Client<S, C>
@@ -526,7 +526,7 @@ mod clock {
         C: ServiceConnection<S>,
         S: Service,
     {
-        pub fn new(client: RpcClient<ClockService, S, C>) -> Self {
+        pub fn new(client: RpcClient<ClockService, C, S>) -> Self {
             Self { client }
         }
         pub async fn tick(&self) -> Result<BoxStream<Result<usize>>> {

--- a/examples/split/client/src/main.rs
+++ b/examples/split/client/src/main.rs
@@ -19,8 +19,7 @@ async fn main() -> anyhow::Result<()> {
     tracing_subscriber::fmt::init();
     let server_addr: SocketAddr = "127.0.0.1:12345".parse()?;
     let endpoint = make_insecure_client_endpoint("0.0.0.0:0".parse()?)?;
-    let client =
-        QuinnConnection::<ComputeService>::new(endpoint, server_addr, "localhost".to_string());
+    let client = QuinnConnection::new(endpoint, server_addr, "localhost".to_string());
     let client = RpcClient::new(client);
     // let mut client = ComputeClient(client);
 

--- a/examples/split/server/src/main.rs
+++ b/examples/split/server/src/main.rs
@@ -62,7 +62,7 @@ async fn main() -> anyhow::Result<()> {
     tracing_subscriber::fmt::init();
     let server_addr: SocketAddr = "127.0.0.1:12345".parse()?;
     let (server, _server_certs) = make_server_endpoint(server_addr)?;
-    let channel = QuinnServerEndpoint::<ComputeService>::new(server)?;
+    let channel = QuinnServerEndpoint::new(server)?;
     let target = Compute;
     run_server_loop(
         ComputeService,

--- a/examples/store.rs
+++ b/examples/store.rs
@@ -185,7 +185,7 @@ async fn main() -> anyhow::Result<()> {
     }
 
     let (server, client) = flume::connection::<StoreService>(1);
-    let client = RpcClient::<StoreService, _>::new(client);
+    let client = RpcClient::<StoreService, StoreService, _>::new(client);
     let server = RpcServer::<StoreService, _>::new(server);
     let server_handle = tokio::task::spawn(server_future(server));
 

--- a/examples/store.rs
+++ b/examples/store.rs
@@ -185,7 +185,7 @@ async fn main() -> anyhow::Result<()> {
     }
 
     let (server, client) = flume::service_connection::<StoreService>(1);
-    let client = RpcClient::<StoreService, StoreService, _>::new(client);
+    let client = RpcClient::<StoreService, _>::new(client);
     let server = RpcServer::<StoreService, _>::new(server);
     let server_handle = tokio::task::spawn(server_future(server));
 

--- a/examples/store.rs
+++ b/examples/store.rs
@@ -184,7 +184,7 @@ async fn main() -> anyhow::Result<()> {
         }
     }
 
-    let (server, client) = flume::connection::<StoreService>(1);
+    let (server, client) = flume::service_connection::<StoreService>(1);
     let client = RpcClient::<StoreService, StoreService, _>::new(client);
     let server = RpcServer::<StoreService, _>::new(server);
     let server_handle = tokio::task::spawn(server_future(server));
@@ -237,7 +237,7 @@ async fn _main_unsugared() -> anyhow::Result<()> {
         type Req = u64;
         type Res = String;
     }
-    let (server, client) = flume::connection::<Service>(1);
+    let (server, client) = flume::service_connection::<Service>(1);
     let to_string_service = tokio::spawn(async move {
         let (mut send, mut recv) = server.accept().await?;
         while let Some(item) = recv.next().await {

--- a/quic-rpc-derive/Cargo.toml
+++ b/quic-rpc-derive/Cargo.toml
@@ -16,7 +16,7 @@ proc-macro = true
 syn = { version = "1.0", features = ["full"] }
 quote = "1.0"
 proc-macro2 = "1.0"
-quic-rpc = { version = "0.12", path = ".." }
+quic-rpc = { version = "0.13", path = ".." }
 
 [dev-dependencies]
 derive_more = "1.0.0-beta.6"

--- a/src/client.rs
+++ b/src/client.rs
@@ -29,7 +29,7 @@ pub type BoxStreamSync<'a, T> = Pin<Box<dyn Stream<Item = T> + Send + Sync + 'a>
 /// This is a wrapper around a [ServiceConnection] that serves as the entry point
 /// for the client DSL. `S` is the service type, `C` is the substream source.
 #[derive(Debug)]
-pub struct RpcClient<S, SInner = S, C = BoxedServiceConnection<S>> {
+pub struct RpcClient<SInner, S = SInner, C = BoxedServiceConnection<SInner>> {
     pub(crate) source: C,
     pub(crate) map: Arc<dyn MapService<S, SInner>>,
 }
@@ -102,7 +102,7 @@ where
     }
 }
 
-impl<S, SInner, C> RpcClient<S, SInner, C>
+impl<SInner, S, C> RpcClient<SInner, S, C>
 where
     S: Service,
     C: ServiceConnection<S>,
@@ -122,7 +122,7 @@ where
     /// Where SNext is the new service to map to and SInner is the current inner service.
     ///
     /// This method can be chained infintely.
-    pub fn map<SNext>(self) -> RpcClient<S, SNext, C>
+    pub fn map<SNext>(self) -> RpcClient<SNext, S, C>
     where
         SNext: Service,
         SNext::Req: Into<SInner::Req> + TryFrom<SInner::Req>,

--- a/src/client.rs
+++ b/src/client.rs
@@ -35,12 +35,12 @@ pub type BoxStreamSync<'a, T> = Pin<Box<dyn Stream<Item = T> + Send + Sync + 'a>
 /// `SC` is the service type that is compatible with the connection.
 /// `C` is the substream source.
 #[derive(Debug)]
-pub struct RpcClient<S, SC = S, C = BoxedServiceConnection<SC>> {
+pub struct RpcClient<S, C = BoxedServiceConnection<S>, SC = S> {
     pub(crate) source: C,
     pub(crate) map: Arc<dyn MapService<SC, S>>,
 }
 
-impl<SC, S, C: Clone> Clone for RpcClient<S, SC, C> {
+impl<SC, S, C: Clone> Clone for RpcClient<S, C, SC> {
     fn clone(&self) -> Self {
         Self {
             source: self.source.clone(),
@@ -91,7 +91,7 @@ where
     }
 }
 
-impl<S, C> RpcClient<S, S, C>
+impl<S, C> RpcClient<S, C, S>
 where
     S: Service,
     C: ServiceConnection<S>,
@@ -114,7 +114,7 @@ where
     }
 }
 
-impl<S, SC, C> RpcClient<S, SC, C>
+impl<S, C, SC> RpcClient<S, C, SC>
 where
     S: Service,
     SC: Service,
@@ -134,7 +134,7 @@ where
     /// Where SNext is the new service to map to and S is the current inner service.
     ///
     /// This method can be chained infintely.
-    pub fn map<SNext>(self) -> RpcClient<SNext, SC, C>
+    pub fn map<SNext>(self) -> RpcClient<SNext, C, SC>
     where
         SNext: Service,
         SNext::Req: Into<S::Req> + TryFrom<S::Req>,
@@ -148,7 +148,7 @@ where
     }
 }
 
-impl<S, SC, C> AsRef<C> for RpcClient<S, SC, C>
+impl<S, C, SC> AsRef<C> for RpcClient<S, C, SC>
 where
     S: Service,
     SC: Service,

--- a/src/client.rs
+++ b/src/client.rs
@@ -17,6 +17,9 @@ use std::{
     task::{Context, Poll},
 };
 
+/// Type alias for a boxed connection to a specific service
+pub type BoxedServiceConnection<S> = crate::transport::boxed::Connection<<S as crate::Service>::Res, <S as crate::Service>::Req>;
+
 /// Sync version of `future::stream::BoxStream`.
 pub type BoxStreamSync<'a, T> = Pin<Box<dyn Stream<Item = T> + Send + Sync + 'a>>;
 
@@ -25,7 +28,7 @@ pub type BoxStreamSync<'a, T> = Pin<Box<dyn Stream<Item = T> + Send + Sync + 'a>
 /// This is a wrapper around a [ServiceConnection] that serves as the entry point
 /// for the client DSL. `S` is the service type, `C` is the substream source.
 #[derive(Debug)]
-pub struct RpcClient<S, C, SInner = S> {
+pub struct RpcClient<S, C = BoxedServiceConnection<S>, SInner = S> {
     pub(crate) source: C,
     pub(crate) map: Arc<dyn MapService<S, SInner>>,
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -49,7 +49,7 @@
 //! }
 //!
 //! // create a transport channel, here a memory channel for testing
-//! let (server, client) = quic_rpc::transport::flume::connection::<PingService>(1);
+//! let (server, client) = quic_rpc::transport::flume::service_connection::<PingService>(1);
 //!
 //! // client side
 //! // create the rpc client given the channel and the service type

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -53,7 +53,7 @@
 //!
 //! // client side
 //! // create the rpc client given the channel and the service type
-//! let mut client = RpcClient::<PingService, _>::new(client);
+//! let mut client = RpcClient::<PingService,PingService, _>::new(client);
 //!
 //! // call the service
 //! let res = client.rpc(Ping).await?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -53,7 +53,7 @@
 //!
 //! // client side
 //! // create the rpc client given the channel and the service type
-//! let mut client = RpcClient::<PingService,PingService, _>::new(client);
+//! let mut client = RpcClient::<PingService,_>::new(client);
 //!
 //! // call the service
 //! let res = client.rpc(Ping).await?;

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -199,7 +199,7 @@ macro_rules! __derive_create_dispatch {
         macro_rules! $create_dispatch {
             ($target:ident, $handler:ident) => {
                 pub async fn $handler<C: $crate::ServiceEndpoint<$service>>(
-                    mut chan: $crate::server::RpcChannel<$service, $service, C>,
+                    mut chan: $crate::server::RpcChannel<$service, C, $service>,
                     msg: <$service as $crate::Service>::Req,
                     target: $target,
                 ) -> Result<(), $crate::server::RpcServerError<C>> {

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -199,7 +199,7 @@ macro_rules! __derive_create_dispatch {
         macro_rules! $create_dispatch {
             ($target:ident, $handler:ident) => {
                 pub async fn $handler<C: $crate::ServiceEndpoint<$service>>(
-                    mut chan: $crate::server::RpcChannel<$service, C>,
+                    mut chan: $crate::server::RpcChannel<$service, $service, C>,
                     msg: <$service as $crate::Service>::Req,
                     target: $target,
                 ) -> Result<(), $crate::server::RpcServerError<C>> {

--- a/src/pattern/bidi_streaming.rs
+++ b/src/pattern/bidi_streaming.rs
@@ -75,7 +75,7 @@ impl<C: ConnectionErrors> fmt::Display for ItemError<C> {
 
 impl<C: ConnectionErrors> error::Error for ItemError<C> {}
 
-impl<S, C, SInner> RpcClient<S, C, SInner>
+impl<S, SInner, C> RpcClient<S, SInner, C>
 where
     S: Service,
     C: ServiceConnection<S>,

--- a/src/pattern/bidi_streaming.rs
+++ b/src/pattern/bidi_streaming.rs
@@ -75,7 +75,7 @@ impl<C: ConnectionErrors> fmt::Display for ItemError<C> {
 
 impl<C: ConnectionErrors> error::Error for ItemError<C> {}
 
-impl<S, SC, C> RpcClient<S, SC, C>
+impl<S, C, SC> RpcClient<S, C, SC>
 where
     SC: Service,
     C: ServiceConnection<SC>,
@@ -113,7 +113,7 @@ where
     }
 }
 
-impl<SC, C, S> RpcChannel<S, SC, C>
+impl<SC, C, S> RpcChannel<S, C, SC>
 where
     SC: Service,
     C: ServiceEndpoint<SC>,

--- a/src/pattern/bidi_streaming.rs
+++ b/src/pattern/bidi_streaming.rs
@@ -113,7 +113,7 @@ where
     }
 }
 
-impl<S, C, SInner> RpcChannel<S, C, SInner>
+impl<S, C, SInner> RpcChannel<S, SInner, C>
 where
     S: Service,
     C: ServiceEndpoint<S>,

--- a/src/pattern/bidi_streaming.rs
+++ b/src/pattern/bidi_streaming.rs
@@ -75,11 +75,11 @@ impl<C: ConnectionErrors> fmt::Display for ItemError<C> {
 
 impl<C: ConnectionErrors> error::Error for ItemError<C> {}
 
-impl<SInner, S, C> RpcClient<SInner, S, C>
+impl<S, SC, C> RpcClient<S, SC, C>
 where
+    SC: Service,
+    C: ServiceConnection<SC>,
     S: Service,
-    C: ServiceConnection<S>,
-    SInner: Service,
 {
     /// Bidi call to the server, request opens a stream, response is a stream
     pub async fn bidi<M>(
@@ -87,13 +87,13 @@ where
         msg: M,
     ) -> result::Result<
         (
-            UpdateSink<S, C, M::Update, SInner>,
+            UpdateSink<SC, C, M::Update, S>,
             BoxStreamSync<'static, result::Result<M::Response, ItemError<C>>>,
         ),
         Error<C>,
     >
     where
-        M: BidiStreamingMsg<SInner>,
+        M: BidiStreamingMsg<S>,
     {
         let msg = self.map.req_into_outer(msg.into());
         let (mut send, recv) = self.source.open().await.map_err(Error::Open)?;
@@ -113,11 +113,11 @@ where
     }
 }
 
-impl<S, C, SInner> RpcChannel<S, SInner, C>
+impl<SC, C, S> RpcChannel<S, SC, C>
 where
+    SC: Service,
+    C: ServiceEndpoint<SC>,
     S: Service,
-    C: ServiceEndpoint<S>,
-    SInner: Service,
 {
     /// handle the message M using the given function on the target object
     ///
@@ -129,8 +129,8 @@ where
         f: F,
     ) -> result::Result<(), RpcServerError<C>>
     where
-        M: BidiStreamingMsg<SInner>,
-        F: FnOnce(T, M, UpdateStream<S, C, M::Update, SInner>) -> Str + Send + 'static,
+        M: BidiStreamingMsg<S>,
+        F: FnOnce(T, M, UpdateStream<SC, C, M::Update, S>) -> Str + Send + 'static,
         Str: Stream<Item = M::Response> + Send + 'static,
         T: Send + 'static,
     {

--- a/src/pattern/bidi_streaming.rs
+++ b/src/pattern/bidi_streaming.rs
@@ -75,7 +75,7 @@ impl<C: ConnectionErrors> fmt::Display for ItemError<C> {
 
 impl<C: ConnectionErrors> error::Error for ItemError<C> {}
 
-impl<S, SInner, C> RpcClient<S, SInner, C>
+impl<SInner, S, C> RpcClient<SInner, S, C>
 where
     S: Service,
     C: ServiceConnection<S>,

--- a/src/pattern/client_streaming.rs
+++ b/src/pattern/client_streaming.rs
@@ -120,7 +120,7 @@ where
     }
 }
 
-impl<S, C, SInner> RpcChannel<S, C, SInner>
+impl<S, C, SInner> RpcChannel<S, SInner, C>
 where
     S: Service,
     C: ServiceEndpoint<S>,

--- a/src/pattern/client_streaming.rs
+++ b/src/pattern/client_streaming.rs
@@ -77,7 +77,7 @@ impl<C: ConnectionErrors> fmt::Display for ItemError<C> {
 
 impl<C: ConnectionErrors> error::Error for ItemError<C> {}
 
-impl<S, C, SInner> RpcClient<S, C, SInner>
+impl<S, SInner, C> RpcClient<S, SInner, C>
 where
     S: Service,
     C: ServiceConnection<S>,

--- a/src/pattern/client_streaming.rs
+++ b/src/pattern/client_streaming.rs
@@ -77,7 +77,7 @@ impl<C: ConnectionErrors> fmt::Display for ItemError<C> {
 
 impl<C: ConnectionErrors> error::Error for ItemError<C> {}
 
-impl<S, SC, C> RpcClient<S, SC, C>
+impl<S, C, SC> RpcClient<S, C, SC>
 where
     S: Service,
     SC: Service,
@@ -120,7 +120,7 @@ where
     }
 }
 
-impl<S, SC, C> RpcChannel<S, SC, C>
+impl<S, C, SC> RpcChannel<S, C, SC>
 where
     S: Service,
     SC: Service,

--- a/src/pattern/client_streaming.rs
+++ b/src/pattern/client_streaming.rs
@@ -77,7 +77,7 @@ impl<C: ConnectionErrors> fmt::Display for ItemError<C> {
 
 impl<C: ConnectionErrors> error::Error for ItemError<C> {}
 
-impl<S, SInner, C> RpcClient<S, SInner, C>
+impl<SInner, S, C> RpcClient<SInner, S, C>
 where
     S: Service,
     C: ServiceConnection<S>,

--- a/src/pattern/rpc.rs
+++ b/src/pattern/rpc.rs
@@ -62,7 +62,7 @@ impl<C: ConnectionErrors> fmt::Display for Error<C> {
 
 impl<C: ConnectionErrors> error::Error for Error<C> {}
 
-impl<S, C, SInner> RpcClient<S, SInner, C>
+impl<SInner, S, C> RpcClient<SInner, S, C>
 where
     S: Service,
     C: ServiceConnection<S>,

--- a/src/pattern/rpc.rs
+++ b/src/pattern/rpc.rs
@@ -91,7 +91,7 @@ where
     }
 }
 
-impl<S, C, SInner> RpcChannel<S, C, SInner>
+impl<S, C, SInner> RpcChannel<S, SInner, C>
 where
     S: Service,
     C: ServiceEndpoint<S>,

--- a/src/pattern/rpc.rs
+++ b/src/pattern/rpc.rs
@@ -62,7 +62,7 @@ impl<C: ConnectionErrors> fmt::Display for Error<C> {
 
 impl<C: ConnectionErrors> error::Error for Error<C> {}
 
-impl<S, SC, C> RpcClient<S, SC, C>
+impl<S, C, SC> RpcClient<S, C, SC>
 where
     S: Service,
     SC: Service,
@@ -91,7 +91,7 @@ where
     }
 }
 
-impl<S, SC, C> RpcChannel<S, SC, C>
+impl<S, C, SC> RpcChannel<S, C, SC>
 where
     S: Service,
     SC: Service,

--- a/src/pattern/rpc.rs
+++ b/src/pattern/rpc.rs
@@ -62,16 +62,16 @@ impl<C: ConnectionErrors> fmt::Display for Error<C> {
 
 impl<C: ConnectionErrors> error::Error for Error<C> {}
 
-impl<SInner, S, C> RpcClient<SInner, S, C>
+impl<S, SC, C> RpcClient<S, SC, C>
 where
     S: Service,
-    C: ServiceConnection<S>,
-    SInner: Service,
+    SC: Service,
+    C: ServiceConnection<SC>,
 {
     /// RPC call to the server, single request, single response
     pub async fn rpc<M>(&self, msg: M) -> result::Result<M::Response, Error<C>>
     where
-        M: RpcMsg<SInner>,
+        M: RpcMsg<S>,
     {
         let msg = self.map.req_into_outer(msg.into());
         let (mut send, mut recv) = self.source.open().await.map_err(Error::Open)?;
@@ -91,11 +91,11 @@ where
     }
 }
 
-impl<S, C, SInner> RpcChannel<S, SInner, C>
+impl<S, SC, C> RpcChannel<S, SC, C>
 where
     S: Service,
-    C: ServiceEndpoint<S>,
-    SInner: Service,
+    SC: Service,
+    C: ServiceEndpoint<SC>,
 {
     /// handle the message of type `M` using the given function on the target object
     ///
@@ -107,7 +107,7 @@ where
         f: F,
     ) -> result::Result<(), RpcServerError<C>>
     where
-        M: RpcMsg<SInner>,
+        M: RpcMsg<S>,
         F: FnOnce(T, M) -> Fut,
         Fut: Future<Output = M::Response>,
         T: Send + 'static,
@@ -142,7 +142,7 @@ where
         f: F,
     ) -> result::Result<(), RpcServerError<C>>
     where
-        M: RpcMsg<SInner, Response = result::Result<R, E2>>,
+        M: RpcMsg<S, Response = result::Result<R, E2>>,
         F: FnOnce(T, M) -> Fut,
         Fut: Future<Output = result::Result<R, E1>>,
         E2: From<E1>,

--- a/src/pattern/rpc.rs
+++ b/src/pattern/rpc.rs
@@ -62,7 +62,7 @@ impl<C: ConnectionErrors> fmt::Display for Error<C> {
 
 impl<C: ConnectionErrors> error::Error for Error<C> {}
 
-impl<S, C, SInner> RpcClient<S, C, SInner>
+impl<S, C, SInner> RpcClient<S, SInner, C>
 where
     S: Service,
     C: ServiceConnection<S>,

--- a/src/pattern/server_streaming.rs
+++ b/src/pattern/server_streaming.rs
@@ -67,7 +67,7 @@ impl<S: ConnectionErrors> fmt::Display for ItemError<S> {
 
 impl<S: ConnectionErrors> error::Error for ItemError<S> {}
 
-impl<S, C, SInner> RpcClient<S, C, SInner>
+impl<S, C, SInner> RpcClient<S, SInner, C>
 where
     S: Service,
     C: ServiceConnection<S>,

--- a/src/pattern/server_streaming.rs
+++ b/src/pattern/server_streaming.rs
@@ -67,7 +67,7 @@ impl<S: ConnectionErrors> fmt::Display for ItemError<S> {
 
 impl<S: ConnectionErrors> error::Error for ItemError<S> {}
 
-impl<S, SC, C> RpcClient<S, SC, C>
+impl<S, C, SC> RpcClient<S, C, SC>
 where
     SC: Service,
     C: ServiceConnection<SC>,
@@ -100,7 +100,7 @@ where
     }
 }
 
-impl<S, SC, C> RpcChannel<S, SC, C>
+impl<S, C, SC> RpcChannel<S, C, SC>
 where
     S: Service,
     SC: Service,

--- a/src/pattern/server_streaming.rs
+++ b/src/pattern/server_streaming.rs
@@ -100,7 +100,7 @@ where
     }
 }
 
-impl<S, C, SInner> RpcChannel<S, C, SInner>
+impl<S, C, SInner> RpcChannel<S, SInner, C>
 where
     S: Service,
     C: ServiceEndpoint<S>,

--- a/src/pattern/server_streaming.rs
+++ b/src/pattern/server_streaming.rs
@@ -67,7 +67,7 @@ impl<S: ConnectionErrors> fmt::Display for ItemError<S> {
 
 impl<S: ConnectionErrors> error::Error for ItemError<S> {}
 
-impl<S, C, SInner> RpcClient<S, SInner, C>
+impl<SInner, S, C> RpcClient<SInner, S, C>
 where
     S: Service,
     C: ServiceConnection<S>,

--- a/src/pattern/try_server_streaming.rs
+++ b/src/pattern/try_server_streaming.rs
@@ -171,7 +171,7 @@ where
     }
 }
 
-impl<S, C, SInner> RpcClient<S, SInner, C>
+impl<SInner, S, C> RpcClient<SInner, S, C>
 where
     S: Service,
     C: ServiceConnection<S>,

--- a/src/pattern/try_server_streaming.rs
+++ b/src/pattern/try_server_streaming.rs
@@ -98,11 +98,11 @@ impl<S: ConnectionErrors, E: Debug> fmt::Display for ItemError<S, E> {
 
 impl<S: ConnectionErrors, E: Debug> error::Error for ItemError<S, E> {}
 
-impl<S, C, SInner> RpcChannel<S, SInner, C>
+impl<SC, C, S> RpcChannel<S, SC, C>
 where
+    SC: Service,
+    C: ServiceEndpoint<SC>,
     S: Service,
-    C: ServiceEndpoint<S>,
-    SInner: Service,
 {
     /// handle the message M using the given function on the target object
     ///
@@ -117,10 +117,9 @@ where
         f: F,
     ) -> result::Result<(), RpcServerError<C>>
     where
-        M: TryServerStreamingMsg<SInner>,
-        std::result::Result<M::Item, M::ItemError>: Into<SInner::Res> + TryFrom<SInner::Res>,
-        std::result::Result<StreamCreated, M::CreateError>:
-            Into<SInner::Res> + TryFrom<SInner::Res>,
+        M: TryServerStreamingMsg<S>,
+        std::result::Result<M::Item, M::ItemError>: Into<S::Res> + TryFrom<S::Res>,
+        std::result::Result<StreamCreated, M::CreateError>: Into<S::Res> + TryFrom<S::Res>,
         F: FnOnce(T, M) -> Fut + Send + 'static,
         Fut: Future<Output = std::result::Result<Str, M::CreateError>> + Send + 'static,
         Str: Stream<Item = std::result::Result<M::Item, M::ItemError>> + Send + 'static,
@@ -171,11 +170,11 @@ where
     }
 }
 
-impl<SInner, S, C> RpcClient<SInner, S, C>
+impl<S, SC, C> RpcClient<S, SC, C>
 where
+    SC: Service,
+    C: ServiceConnection<SC>,
     S: Service,
-    C: ServiceConnection<S>,
-    SInner: Service,
 {
     /// Bidi call to the server, request opens a stream, response is a stream
     pub async fn try_server_streaming<M>(
@@ -186,9 +185,9 @@ where
         Error<C, M::CreateError>,
     >
     where
-        M: TryServerStreamingMsg<SInner>,
-        Result<M::Item, M::ItemError>: Into<SInner::Res> + TryFrom<SInner::Res>,
-        Result<StreamCreated, M::CreateError>: Into<SInner::Res> + TryFrom<SInner::Res>,
+        M: TryServerStreamingMsg<S>,
+        Result<M::Item, M::ItemError>: Into<S::Res> + TryFrom<S::Res>,
+        Result<StreamCreated, M::CreateError>: Into<S::Res> + TryFrom<S::Res>,
     {
         let msg = self.map.req_into_outer(msg.into());
         let (mut send, mut recv) = self.source.open().await.map_err(Error::Open)?;

--- a/src/pattern/try_server_streaming.rs
+++ b/src/pattern/try_server_streaming.rs
@@ -98,7 +98,7 @@ impl<S: ConnectionErrors, E: Debug> fmt::Display for ItemError<S, E> {
 
 impl<S: ConnectionErrors, E: Debug> error::Error for ItemError<S, E> {}
 
-impl<SC, C, S> RpcChannel<S, SC, C>
+impl<SC, C, S> RpcChannel<S, C, SC>
 where
     SC: Service,
     C: ServiceEndpoint<SC>,
@@ -170,7 +170,7 @@ where
     }
 }
 
-impl<S, SC, C> RpcClient<S, SC, C>
+impl<S, C, SC> RpcClient<S, C, SC>
 where
     SC: Service,
     C: ServiceConnection<SC>,

--- a/src/pattern/try_server_streaming.rs
+++ b/src/pattern/try_server_streaming.rs
@@ -171,7 +171,7 @@ where
     }
 }
 
-impl<S, C, SInner> RpcClient<S, C, SInner>
+impl<S, C, SInner> RpcClient<S, SInner, C>
 where
     S: Service,
     C: ServiceConnection<S>,

--- a/src/pattern/try_server_streaming.rs
+++ b/src/pattern/try_server_streaming.rs
@@ -98,7 +98,7 @@ impl<S: ConnectionErrors, E: Debug> fmt::Display for ItemError<S, E> {
 
 impl<S: ConnectionErrors, E: Debug> error::Error for ItemError<S, E> {}
 
-impl<S, C, SInner> RpcChannel<S, C, SInner>
+impl<S, C, SInner> RpcChannel<S, SInner, C>
 where
     S: Service,
     C: ServiceEndpoint<S>,

--- a/src/server.rs
+++ b/src/server.rs
@@ -19,12 +19,15 @@ use std::{
 };
 use tokio::sync::oneshot;
 
+/// Type alias for a service endpoint
+pub type BoxedServiceEndpoint<S> = crate::transport::boxed::ServerEndpoint<<S as crate::Service>::Req, <S as crate::Service>::Res>;
+
 /// A server channel for a specific service.
 ///
 /// This is a wrapper around a [ServiceEndpoint] that serves as the entry point for the server DSL.
 /// `S` is the service type, `C` is the channel type.
 #[derive(Debug)]
-pub struct RpcServer<S, C> {
+pub struct RpcServer<S, C = BoxedServiceEndpoint<S>> {
     /// The channel on which new requests arrive.
     ///
     /// Each new request is a receiver and channel pair on which messages for this request
@@ -63,7 +66,7 @@ impl<S: Service, C: ServiceEndpoint<S>> RpcServer<S, C> {
 /// Sink and stream are independent, so you can take the channel apart and use
 /// them independently.
 #[derive(Debug)]
-pub struct RpcChannel<S: Service, C: ServiceEndpoint<S>, SInner: Service = S> {
+pub struct RpcChannel<S: Service, C: ServiceEndpoint<S> = BoxedServiceEndpoint<S>, SInner: Service = S> {
     /// Sink to send responses to the client.
     pub send: C::SendSink,
     /// Stream to receive requests from the client.

--- a/src/server.rs
+++ b/src/server.rs
@@ -20,7 +20,8 @@ use std::{
 use tokio::sync::oneshot;
 
 /// Type alias for a service endpoint
-pub type BoxedServiceEndpoint<S> = crate::transport::boxed::ServerEndpoint<<S as crate::Service>::Req, <S as crate::Service>::Res>;
+pub type BoxedServiceEndpoint<S> =
+    crate::transport::boxed::ServerEndpoint<<S as crate::Service>::Req, <S as crate::Service>::Res>;
 
 /// A server channel for a specific service.
 ///
@@ -66,7 +67,11 @@ impl<S: Service, C: ServiceEndpoint<S>> RpcServer<S, C> {
 /// Sink and stream are independent, so you can take the channel apart and use
 /// them independently.
 #[derive(Debug)]
-pub struct RpcChannel<S: Service, C: ServiceEndpoint<S> = BoxedServiceEndpoint<S>, SInner: Service = S> {
+pub struct RpcChannel<
+    S: Service,
+    C: ServiceEndpoint<S> = BoxedServiceEndpoint<S>,
+    SInner: Service = S,
+> {
     /// Sink to send responses to the client.
     pub send: C::SendSink,
     /// Stream to receive requests from the client.

--- a/src/transport/boxed.rs
+++ b/src/transport/boxed.rs
@@ -396,7 +396,7 @@ mod tests {
 
         use crate::transport::{Connection, ServerEndpoint};
 
-        let (server, client) = crate::transport::flume::connection::<FooService>(1);
+        let (server, client) = crate::transport::flume::service_connection::<FooService>(1);
         let server = super::ServerEndpoint::new(server);
         let client = super::Connection::new(client);
         // spawn echo server

--- a/src/transport/flume.rs
+++ b/src/transport/flume.rs
@@ -343,6 +343,7 @@ pub fn connection<Req: RpcMessage, Res: RpcMessage>(
 }
 
 /// Create a flume server endpoint and a connected flume client channel for a specific service.
+#[allow(clippy::type_complexity)]
 pub fn service_connection<S: crate::Service>(
     buffer: usize,
 ) -> (

--- a/src/transport/flume.rs
+++ b/src/transport/flume.rs
@@ -337,10 +337,7 @@ impl std::error::Error for CreateChannelError {}
 /// `buffer` the size of the buffer for each channel. Keep this at a low value to get backpressure
 pub fn connection<Req: RpcMessage, Res: RpcMessage>(
     buffer: usize,
-) -> (
-    FlumeServerEndpoint<Req, Res>,
-    FlumeConnection<Res, Req>,
-) {
+) -> (FlumeServerEndpoint<Req, Res>, FlumeConnection<Res, Req>) {
     let (sink, stream) = flume::bounded(buffer);
     (FlumeServerEndpoint { stream }, FlumeConnection { sink })
 }

--- a/src/transport/mod.rs
+++ b/src/transport/mod.rs
@@ -1,4 +1,22 @@
 //! Transports for quic-rpc
+//!
+//! There are two sides to a transport, a server side where connections are
+//! accepted and a client side where connections are initiated.
+//!
+//! Connections are bidirectional typed channels, with a distinct type for
+//! the send and receive side. They are *unrelated* to services.
+//!
+//! In the transport module, the message types are referred to as `In` and `Out`.
+//!
+//! A [`Connection`] can be used to *open* bidirectional typed channels using
+//! [`Connection::open`]. A [`ServerEndpoint`] can be used to *accept* bidirectional
+//! typed channels from any of the currently opened connections to clients, using
+//! [`ServerEndpoint::accept`].
+//!
+//! In both cases, the result is a tuple of a send side and a receive side. These
+//! types are defined by implementing the [`ConnectionCommon`] trait.
+//!
+//! Errors for both sides are defined by implementing the [`ConnectionErrors`] trait.
 use futures_lite::{Future, Stream};
 use futures_sink::Sink;
 

--- a/tests/flume.rs
+++ b/tests/flume.rs
@@ -11,7 +11,7 @@ use quic_rpc::{
 #[tokio::test]
 async fn flume_channel_bench() -> anyhow::Result<()> {
     tracing_subscriber::fmt::try_init().ok();
-    let (server, client) = flume::connection::<ComputeService>(1);
+    let (server, client) = flume::service_connection::<ComputeService>(1);
 
     let server = RpcServer::<ComputeService, _>::new(server);
     let server_handle = tokio::task::spawn(ComputeService::server(server));
@@ -60,7 +60,7 @@ async fn flume_channel_mapped_bench() -> anyhow::Result<()> {
         type Req = InnerRequest;
         type Res = InnerResponse;
     }
-    let (server, client) = flume::connection::<OuterService>(1);
+    let (server, client) = flume::service_connection::<OuterService>(1);
 
     let server = RpcServer::new(server);
     let server_handle: tokio::task::JoinHandle<Result<(), RpcServerError<_>>> =
@@ -83,8 +83,8 @@ async fn flume_channel_mapped_bench() -> anyhow::Result<()> {
         });
 
     let client = RpcClient::<OuterService, OuterService, _>::new(client);
-    let client: RpcClient<OuterService, InnerService, _> = client.map();
-    let client: RpcClient<OuterService, ComputeService, _> = client.map();
+    let client: RpcClient<InnerService, OuterService, _> = client.map();
+    let client: RpcClient<ComputeService, OuterService, _> = client.map();
     bench(client, 1000000).await?;
     // dropping the client will cause the server to terminate
     match server_handle.await? {
@@ -98,7 +98,7 @@ async fn flume_channel_mapped_bench() -> anyhow::Result<()> {
 #[tokio::test]
 async fn flume_channel_smoke() -> anyhow::Result<()> {
     tracing_subscriber::fmt::try_init().ok();
-    let (server, client) = flume::connection::<ComputeService>(1);
+    let (server, client) = flume::service_connection::<ComputeService>(1);
 
     let server = RpcServer::<ComputeService, _>::new(server);
     let server_handle = tokio::task::spawn(ComputeService::server(server));

--- a/tests/flume.rs
+++ b/tests/flume.rs
@@ -15,7 +15,7 @@ async fn flume_channel_bench() -> anyhow::Result<()> {
 
     let server = RpcServer::<ComputeService, _>::new(server);
     let server_handle = tokio::task::spawn(ComputeService::server(server));
-    let client = RpcClient::<ComputeService, ComputeService, _>::new(client);
+    let client = RpcClient::<ComputeService, _>::new(client);
     bench(client, 1000000).await?;
     // dropping the client will cause the server to terminate
     match server_handle.await? {
@@ -73,8 +73,8 @@ async fn flume_channel_mapped_bench() -> anyhow::Result<()> {
                     let req: OuterRequest = req;
                     match req {
                         OuterRequest::Inner(InnerRequest::Compute(req)) => {
-                            let chan: RpcChannel<InnerService, OuterService, _> = chan.map();
-                            let chan: RpcChannel<ComputeService, OuterService, _> = chan.map();
+                            let chan: RpcChannel<InnerService, _, OuterService> = chan.map();
+                            let chan: RpcChannel<ComputeService, _, OuterService> = chan.map();
                             ComputeService::handle_rpc_request(service, req, chan).await
                         }
                     }
@@ -82,9 +82,9 @@ async fn flume_channel_mapped_bench() -> anyhow::Result<()> {
             }
         });
 
-    let client = RpcClient::<OuterService, OuterService, _>::new(client);
-    let client: RpcClient<InnerService, OuterService, _> = client.map();
-    let client: RpcClient<ComputeService, OuterService, _> = client.map();
+    let client = RpcClient::<OuterService, _>::new(client);
+    let client: RpcClient<InnerService, _, OuterService> = client.map();
+    let client: RpcClient<ComputeService, _, OuterService> = client.map();
     bench(client, 1000000).await?;
     // dropping the client will cause the server to terminate
     match server_handle.await? {

--- a/tests/flume.rs
+++ b/tests/flume.rs
@@ -15,7 +15,7 @@ async fn flume_channel_bench() -> anyhow::Result<()> {
 
     let server = RpcServer::<ComputeService, _>::new(server);
     let server_handle = tokio::task::spawn(ComputeService::server(server));
-    let client = RpcClient::<ComputeService, _>::new(client);
+    let client = RpcClient::<ComputeService, ComputeService, _>::new(client);
     bench(client, 1000000).await?;
     // dropping the client will cause the server to terminate
     match server_handle.await? {
@@ -82,9 +82,9 @@ async fn flume_channel_mapped_bench() -> anyhow::Result<()> {
             }
         });
 
-    let client = RpcClient::<OuterService, _>::new(client);
-    let client: RpcClient<OuterService, _, InnerService> = client.map();
-    let client: RpcClient<OuterService, _, ComputeService> = client.map();
+    let client = RpcClient::<OuterService, OuterService, _>::new(client);
+    let client: RpcClient<OuterService, InnerService, _> = client.map();
+    let client: RpcClient<OuterService, ComputeService, _> = client.map();
     bench(client, 1000000).await?;
     // dropping the client will cause the server to terminate
     match server_handle.await? {

--- a/tests/flume.rs
+++ b/tests/flume.rs
@@ -73,8 +73,8 @@ async fn flume_channel_mapped_bench() -> anyhow::Result<()> {
                     let req: OuterRequest = req;
                     match req {
                         OuterRequest::Inner(InnerRequest::Compute(req)) => {
-                            let chan: RpcChannel<OuterService, _, InnerService> = chan.map();
-                            let chan: RpcChannel<OuterService, _, ComputeService> = chan.map();
+                            let chan: RpcChannel<OuterService, InnerService, _> = chan.map();
+                            let chan: RpcChannel<OuterService, ComputeService, _> = chan.map();
                             ComputeService::handle_rpc_request(service, req, chan).await
                         }
                     }

--- a/tests/flume.rs
+++ b/tests/flume.rs
@@ -62,7 +62,7 @@ async fn flume_channel_mapped_bench() -> anyhow::Result<()> {
     }
     let (server, client) = flume::service_connection::<OuterService>(1);
 
-    let server = RpcServer::new(server);
+    let server = RpcServer::<OuterService, _>::new(server);
     let server_handle: tokio::task::JoinHandle<Result<(), RpcServerError<_>>> =
         tokio::task::spawn(async move {
             let service = ComputeService;
@@ -73,8 +73,8 @@ async fn flume_channel_mapped_bench() -> anyhow::Result<()> {
                     let req: OuterRequest = req;
                     match req {
                         OuterRequest::Inner(InnerRequest::Compute(req)) => {
-                            let chan: RpcChannel<OuterService, InnerService, _> = chan.map();
-                            let chan: RpcChannel<OuterService, ComputeService, _> = chan.map();
+                            let chan: RpcChannel<InnerService, OuterService, _> = chan.map();
+                            let chan: RpcChannel<ComputeService, OuterService, _> = chan.map();
                             ComputeService::handle_rpc_request(service, req, chan).await
                         }
                     }

--- a/tests/hyper.rs
+++ b/tests/hyper.rs
@@ -18,7 +18,7 @@ use math::*;
 mod util;
 
 fn run_server(addr: &SocketAddr) -> JoinHandle<anyhow::Result<()>> {
-    let channel = HyperServerEndpoint::<ComputeService>::serve(addr).unwrap();
+    let channel = HyperServerEndpoint::serve(addr).unwrap();
     let server = RpcServer::new(channel);
     tokio::spawn(async move {
         loop {
@@ -38,7 +38,7 @@ enum TestResponse {
     NoDeser(NoDeser),
 }
 
-type SC = HyperServerEndpoint<TestService>;
+type SC = HyperServerEndpoint<TestRequest, TestResponse>;
 
 /// request that can be too big
 #[derive(Debug, Serialize, Deserialize)]
@@ -134,7 +134,7 @@ async fn hyper_channel_bench() -> anyhow::Result<()> {
     let addr: SocketAddr = "127.0.0.1:3000".parse()?;
     let uri: Uri = "http://127.0.0.1:3000".parse()?;
     let server_handle = run_server(&addr);
-    let client = HyperConnection::<ComputeService>::new(uri);
+    let client = HyperConnection::new(uri);
     let client = RpcClient::new(client);
     bench(client, 50000).await?;
     println!("terminating server");
@@ -148,7 +148,7 @@ async fn hyper_channel_smoke() -> anyhow::Result<()> {
     let addr: SocketAddr = "127.0.0.1:3001".parse()?;
     let uri: Uri = "http://127.0.0.1:3001".parse()?;
     let server_handle = run_server(&addr);
-    let client = HyperConnection::<ComputeService>::new(uri);
+    let client = HyperConnection::new(uri);
     smoke_test(client).await?;
     server_handle.abort();
     let _ = server_handle.await;
@@ -171,7 +171,7 @@ async fn hyper_channel_errors() -> anyhow::Result<()> {
         JoinHandle<anyhow::Result<()>>,
         Receiver<result::Result<(), RpcServerError<SC>>>,
     ) {
-        let channel = HyperServerEndpoint::<TestService>::serve(addr).unwrap();
+        let channel = HyperServerEndpoint::serve(addr).unwrap();
         let server = RpcServer::new(channel);
         let (res_tx, res_rx) = flume::unbounded();
         let handle = tokio::spawn(async move {
@@ -214,7 +214,7 @@ async fn hyper_channel_errors() -> anyhow::Result<()> {
     let addr: SocketAddr = "127.0.0.1:3002".parse()?;
     let uri: Uri = "http://127.0.0.1:3002".parse()?;
     let (server_handle, server_results) = run_test_server(&addr);
-    let client = HyperConnection::<TestService>::new(uri);
+    let client = HyperConnection::new(uri);
     let client = RpcClient::new(client);
 
     macro_rules! assert_matches {

--- a/tests/math.rs
+++ b/tests/math.rs
@@ -175,7 +175,7 @@ impl ComputeService {
     pub async fn handle_rpc_request<S, E>(
         service: ComputeService,
         req: ComputeRequest,
-        chan: RpcChannel<S, E, ComputeService>,
+        chan: RpcChannel<S, ComputeService, E>,
     ) -> Result<(), RpcServerError<E>>
     where
         S: Service,

--- a/tests/math.rs
+++ b/tests/math.rs
@@ -175,7 +175,7 @@ impl ComputeService {
     pub async fn handle_rpc_request<S, E>(
         service: ComputeService,
         req: ComputeRequest,
-        chan: RpcChannel<ComputeService, S, E>,
+        chan: RpcChannel<ComputeService, E, S>,
     ) -> Result<(), RpcServerError<E>>
     where
         S: Service,
@@ -268,7 +268,7 @@ impl ComputeService {
 }
 
 pub async fn smoke_test<C: ServiceConnection<ComputeService>>(client: C) -> anyhow::Result<()> {
-    let client = RpcClient::<ComputeService, ComputeService, C>::new(client);
+    let client = RpcClient::<ComputeService, C>::new(client);
     // a rpc call
     tracing::debug!("calling rpc S(1234)");
     let res = client.rpc(Sqr(1234)).await?;
@@ -316,7 +316,7 @@ fn clear_line() {
     print!("\r{}\r", " ".repeat(80));
 }
 
-pub async fn bench<S, C>(client: RpcClient<ComputeService, S, C>, n: u64) -> anyhow::Result<()>
+pub async fn bench<S, C>(client: RpcClient<ComputeService, C, S>, n: u64) -> anyhow::Result<()>
 where
     C::SendError: std::error::Error,
     S: Service,

--- a/tests/math.rs
+++ b/tests/math.rs
@@ -316,7 +316,7 @@ fn clear_line() {
     print!("\r{}\r", " ".repeat(80));
 }
 
-pub async fn bench<S, C>(client: RpcClient<S, ComputeService, C>, n: u64) -> anyhow::Result<()>
+pub async fn bench<S, C>(client: RpcClient<ComputeService, S, C>, n: u64) -> anyhow::Result<()>
 where
     C::SendError: std::error::Error,
     S: Service,

--- a/tests/math.rs
+++ b/tests/math.rs
@@ -268,7 +268,7 @@ impl ComputeService {
 }
 
 pub async fn smoke_test<C: ServiceConnection<ComputeService>>(client: C) -> anyhow::Result<()> {
-    let client = RpcClient::<ComputeService, C>::new(client);
+    let client = RpcClient::<ComputeService, ComputeService, C>::new(client);
     // a rpc call
     tracing::debug!("calling rpc S(1234)");
     let res = client.rpc(Sqr(1234)).await?;
@@ -316,7 +316,7 @@ fn clear_line() {
     print!("\r{}\r", " ".repeat(80));
 }
 
-pub async fn bench<S, C>(client: RpcClient<S, C, ComputeService>, n: u64) -> anyhow::Result<()>
+pub async fn bench<S, C>(client: RpcClient<S, ComputeService, C>, n: u64) -> anyhow::Result<()>
 where
     C::SendError: std::error::Error,
     S: Service,

--- a/tests/math.rs
+++ b/tests/math.rs
@@ -175,7 +175,7 @@ impl ComputeService {
     pub async fn handle_rpc_request<S, E>(
         service: ComputeService,
         req: ComputeRequest,
-        chan: RpcChannel<S, ComputeService, E>,
+        chan: RpcChannel<ComputeService, S, E>,
     ) -> Result<(), RpcServerError<E>>
     where
         S: Service,

--- a/tests/quinn.rs
+++ b/tests/quinn.rs
@@ -114,7 +114,7 @@ pub fn make_endpoints(port: u16) -> anyhow::Result<Endpoints> {
 
 fn run_server(server: quinn::Endpoint) -> JoinHandle<anyhow::Result<()>> {
     tokio::task::spawn(async move {
-        let connection = transport::quinn::QuinnServerEndpoint::<ComputeService>::new(server)?;
+        let connection = transport::quinn::QuinnServerEndpoint::new(server)?;
         let server = RpcServer::new(connection);
         ComputeService::server(server).await?;
         anyhow::Ok(())
@@ -133,11 +133,7 @@ async fn quinn_channel_bench() -> anyhow::Result<()> {
     tracing::debug!("Starting server");
     let server_handle = run_server(server);
     tracing::debug!("Starting client");
-    let client = transport::quinn::QuinnConnection::<ComputeService>::new(
-        client,
-        server_addr,
-        "localhost".into(),
-    );
+    let client = transport::quinn::QuinnConnection::new(client, server_addr, "localhost".into());
     let client = RpcClient::new(client);
     tracing::debug!("Starting benchmark");
     bench(client, 50000).await?;
@@ -154,11 +150,8 @@ async fn quinn_channel_smoke() -> anyhow::Result<()> {
         server_addr,
     } = make_endpoints(12346)?;
     let server_handle = run_server(server);
-    let client_connection = transport::quinn::QuinnConnection::<ComputeService>::new(
-        client,
-        server_addr,
-        "localhost".into(),
-    );
+    let client_connection =
+        transport::quinn::QuinnConnection::new(client, server_addr, "localhost".into());
     smoke_test(client_connection).await?;
     server_handle.abort();
     Ok(())
@@ -178,11 +171,8 @@ async fn server_away_and_back() -> anyhow::Result<()> {
 
     // create the RPC client
     let client = make_client_endpoint("0.0.0.0:0".parse()?, &[&server_cert])?;
-    let client_connection = transport::quinn::QuinnConnection::<ComputeService>::new(
-        client,
-        server_addr,
-        "localhost".into(),
-    );
+    let client_connection =
+        transport::quinn::QuinnConnection::new(client, server_addr, "localhost".into());
     let client = RpcClient::new(client_connection);
 
     // send a request. No server available so it should fail
@@ -190,7 +180,7 @@ async fn server_away_and_back() -> anyhow::Result<()> {
 
     // create the RPC Server
     let server = Endpoint::server(server_config.clone(), server_addr)?;
-    let connection = transport::quinn::QuinnServerEndpoint::<ComputeService>::new(server)?;
+    let connection = transport::quinn::QuinnServerEndpoint::new(server)?;
     let server = RpcServer::new(connection);
     let server_handle = tokio::task::spawn(ComputeService::server_bounded(server, 1));
 
@@ -205,7 +195,7 @@ async fn server_away_and_back() -> anyhow::Result<()> {
 
     // make the server run again
     let server = Endpoint::server(server_config, server_addr)?;
-    let connection = transport::quinn::QuinnServerEndpoint::<ComputeService>::new(server)?;
+    let connection = transport::quinn::QuinnServerEndpoint::new(server)?;
     let server = RpcServer::new(connection);
     let server_handle = tokio::task::spawn(ComputeService::server_bounded(server, 5));
 

--- a/tests/try.rs
+++ b/tests/try.rs
@@ -89,7 +89,7 @@ async fn try_server_streaming() -> anyhow::Result<()> {
         #[allow(unreachable_code)]
         Ok(())
     });
-    let client = RpcClient::<TryService, TryService, _>::new(client);
+    let client = RpcClient::<TryService, _>::new(client);
     let stream_n = client.try_server_streaming(StreamN { n: 10 }).await?;
     let items: Vec<_> = stream_n.collect().await;
     println!("{:?}", items);

--- a/tests/try.rs
+++ b/tests/try.rs
@@ -89,7 +89,7 @@ async fn try_server_streaming() -> anyhow::Result<()> {
         #[allow(unreachable_code)]
         Ok(())
     });
-    let client = RpcClient::<TryService, _>::new(client);
+    let client = RpcClient::<TryService, TryService, _>::new(client);
     let stream_n = client.try_server_streaming(StreamN { n: 10 }).await?;
     let items: Vec<_> = stream_n.collect().await;
     println!("{:?}", items);

--- a/tests/try.rs
+++ b/tests/try.rs
@@ -72,7 +72,7 @@ impl Handler {
 #[tokio::test]
 async fn try_server_streaming() -> anyhow::Result<()> {
     tracing_subscriber::fmt::try_init().ok();
-    let (server, client) = flume::connection::<TryService>(1);
+    let (server, client) = flume::service_connection::<TryService>(1);
 
     let server = RpcServer::<TryService, _>::new(server);
     let server_handle = tokio::task::spawn(async move {


### PR DESCRIPTION
This moves the service type parameter that determines what rpc methods will actually be available on a RpcClient or RpcChannel, to the front.

For users that don't use modular services, this does not make a difference. For users that do, this makes it easier to specify the most more important visible service type.

It also disentangles the concept of services from the transport module. Ideally the transport module should be thought of as its own crate without any knowledge of the Service trait.