### PR TITLE
chore: Consistently format imports...

### DIFF
--- a/examples/errors.rs
+++ b/examples/errors.rs
@@ -1,7 +1,8 @@
+use std::result;
+
 use derive_more::{Display, From, TryInto};
 use quic_rpc::{message::RpcMsg, RpcClient, RpcServer, Service};
 use serde::{Deserialize, Serialize};
-use std::result;
 
 #[derive(Debug, Serialize, Deserialize)]
 struct WriteRequest(String, Vec<u8>);

--- a/examples/macro.rs
+++ b/examples/macro.rs
@@ -1,7 +1,8 @@
 mod store_rpc {
+    use std::fmt::Debug;
+
     use quic_rpc::rpc_service;
     use serde::{Deserialize, Serialize};
-    use std::fmt::Debug;
 
     pub type Cid = [u8; 32];
 
@@ -51,9 +52,7 @@ mod store_rpc {
 use async_stream::stream;
 use futures_lite::{Stream, StreamExt};
 use futures_util::SinkExt;
-use quic_rpc::client::RpcClient;
-use quic_rpc::server::run_server_loop;
-use quic_rpc::transport::flume;
+use quic_rpc::{client::RpcClient, server::run_server_loop, transport::flume};
 use store_rpc::*;
 
 #[derive(Clone)]

--- a/examples/modularize.rs
+++ b/examples/modularize.rs
@@ -8,12 +8,11 @@
 //! unchanged.
 
 use anyhow::Result;
+use app::AppService;
 use futures_lite::StreamExt;
 use futures_util::SinkExt;
 use quic_rpc::{client::BoxedConnector, transport::flume, Listener, RpcClient, RpcServer};
 use tracing::warn;
-
-use app::AppService;
 
 #[tokio::main]
 async fn main() -> Result<()> {
@@ -99,11 +98,12 @@ mod app {
     //!
     //! It could also easily compose services from other crates or internal modules.
 
-    use super::iroh;
     use anyhow::Result;
     use derive_more::{From, TryInto};
     use quic_rpc::{message::RpcMsg, server::RpcChannel, Listener, RpcClient, Service};
     use serde::{Deserialize, Serialize};
+
+    use super::iroh;
 
     #[derive(Debug, Serialize, Deserialize, From, TryInto)]
     pub enum Request {
@@ -271,6 +271,8 @@ mod calc {
     //! This is a library providing a service, and a client. E.g. iroh-bytes or iroh-hypermerge.
     //! It does not use any `super` imports, it is completely decoupled.
 
+    use std::fmt::Debug;
+
     use anyhow::{bail, Result};
     use derive_more::{From, TryInto};
     use futures_lite::{Stream, StreamExt};
@@ -280,7 +282,6 @@ mod calc {
         RpcClient, Service,
     };
     use serde::{Deserialize, Serialize};
-    use std::fmt::Debug;
 
     #[derive(Debug, Serialize, Deserialize)]
     pub struct AddRequest(pub i64, pub i64);
@@ -385,6 +386,12 @@ mod clock {
     //! This is a library providing a service, and a client. E.g. iroh-bytes or iroh-hypermerge.
     //! It does not use any `super` imports, it is completely decoupled.
 
+    use std::{
+        fmt::Debug,
+        sync::{Arc, RwLock},
+        time::Duration,
+    };
+
     use anyhow::Result;
     use derive_more::{From, TryInto};
     use futures_lite::{stream::Boxed as BoxStream, Stream, StreamExt};
@@ -395,11 +402,6 @@ mod clock {
         RpcClient, Service,
     };
     use serde::{Deserialize, Serialize};
-    use std::{
-        fmt::Debug,
-        sync::{Arc, RwLock},
-        time::Duration,
-    };
     use tokio::sync::Notify;
 
     #[derive(Debug, Serialize, Deserialize)]

--- a/examples/split/client/src/main.rs
+++ b/examples/split/client/src/main.rs
@@ -1,15 +1,11 @@
 #![allow(unknown_lints, non_local_definitions)]
 
-use std::net::SocketAddr;
-use std::sync::Arc;
+use std::{net::SocketAddr, sync::Arc};
 
 use anyhow::Result;
-use futures::sink::SinkExt;
-use futures::stream::StreamExt;
-use quic_rpc::transport::quinn::QuinnConnector;
-use quic_rpc::RpcClient;
-use quinn::crypto::rustls::QuicClientConfig;
-use quinn::{ClientConfig, Endpoint};
+use futures::{sink::SinkExt, stream::StreamExt};
+use quic_rpc::{transport::quinn::QuinnConnector, RpcClient};
+use quinn::{crypto::rustls::QuicClientConfig, ClientConfig, Endpoint};
 use types::compute::*;
 
 // types::create_compute_client!(ComputeClient);

--- a/examples/split/server/src/main.rs
+++ b/examples/split/server/src/main.rs
@@ -1,11 +1,9 @@
+use std::{net::SocketAddr, sync::Arc};
+
 use async_stream::stream;
 use futures::stream::{Stream, StreamExt};
-use quic_rpc::server::run_server_loop;
-use quic_rpc::transport::quinn::QuinnListener;
+use quic_rpc::{server::run_server_loop, transport::quinn::QuinnListener};
 use quinn::{Endpoint, ServerConfig};
-use std::net::SocketAddr;
-use std::sync::Arc;
-
 use types::compute::*;
 
 #[derive(Clone)]

--- a/examples/split/types/src/lib.rs
+++ b/examples/split/types/src/lib.rs
@@ -1,7 +1,8 @@
 pub mod compute {
+    use std::fmt::Debug;
+
     use quic_rpc::rpc_service;
     use serde::{Deserialize, Serialize};
-    use std::fmt::Debug;
 
     /// compute the square of a number
     #[derive(Debug, Serialize, Deserialize)]

--- a/examples/store.rs
+++ b/examples/store.rs
@@ -1,4 +1,6 @@
 #![allow(clippy::enum_variant_names)]
+use std::{fmt::Debug, result};
+
 use async_stream::stream;
 use derive_more::{From, TryInto};
 use futures_lite::{Stream, StreamExt};
@@ -9,7 +11,6 @@ use quic_rpc::{
     *,
 };
 use serde::{Deserialize, Serialize};
-use std::{fmt::Debug, result};
 
 type Cid = [u8; 32];
 #[derive(Debug, Serialize, Deserialize)]

--- a/quic-rpc-derive/src/lib.rs
+++ b/quic-rpc-derive/src/lib.rs
@@ -1,7 +1,8 @@
+use std::collections::{BTreeMap, HashSet};
+
 use proc_macro::TokenStream;
 use proc_macro2::{Span, TokenStream as TokenStream2};
 use quote::{quote, ToTokens};
-use std::collections::{BTreeMap, HashSet};
 use syn::{
     parse::{Parse, ParseStream},
     parse_macro_input,

--- a/src/client.rs
+++ b/src/client.rs
@@ -1,19 +1,20 @@
 //! Client side api
 //!
 //! The main entry point is [RpcClient].
-use crate::{
-    transport::{boxed::BoxableConnector, mapped::MappedConnector, StreamTypes},
-    Connector, Service,
-};
-use futures_lite::Stream;
-use futures_sink::Sink;
-
-use pin_project::pin_project;
 use std::{
     fmt::Debug,
     marker::PhantomData,
     pin::Pin,
     task::{Context, Poll},
+};
+
+use futures_lite::Stream;
+use futures_sink::Sink;
+use pin_project::pin_project;
+
+use crate::{
+    transport::{boxed::BoxableConnector, mapped::MappedConnector, StreamTypes},
+    Connector, Service,
 };
 
 /// Type alias for a boxed connection to a specific service

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,9 +13,9 @@
 //! # Example
 //! ```
 //! # async fn example() -> anyhow::Result<()> {
-//! use quic_rpc::{message::RpcMsg, Service, RpcClient, RpcServer};
-//! use serde::{Serialize, Deserialize};
 //! use derive_more::{From, TryInto};
+//! use quic_rpc::{message::RpcMsg, RpcClient, RpcServer, Service};
+//! use serde::{Deserialize, Serialize};
 //!
 //! // Define your messages
 //! #[derive(Debug, Serialize, Deserialize)]
@@ -39,13 +39,13 @@
 //! }
 //!
 //! impl Service for PingService {
-//!   type Req = PingRequest;
-//!   type Res = PingResponse;
+//!     type Req = PingRequest;
+//!     type Res = PingResponse;
 //! }
 //!
 //! // Define interaction patterns for each request type
 //! impl RpcMsg<PingService> for Ping {
-//!   type Response = Pong;
+//!     type Response = Pong;
 //! }
 //!
 //! // create a transport channel, here a memory channel for testing
@@ -53,7 +53,7 @@
 //!
 //! // client side
 //! // create the rpc client given the channel and the service type
-//! let mut client = RpcClient::<PingService,_>::new(client);
+//! let mut client = RpcClient::<PingService, _>::new(client);
 //!
 //! // call the service
 //! let res = client.rpc(Ping).await?;
@@ -64,12 +64,12 @@
 //!
 //! let handler = Handler;
 //! loop {
-//!   // accept connections
-//!   let (msg, chan) = server.accept().await?.read_first().await?;
-//!   // dispatch the message to the appropriate handler
-//!   match msg {
-//!     PingRequest::Ping(ping) => chan.rpc(ping, handler, Handler::ping).await?,
-//!   }
+//!     // accept connections
+//!     let (msg, chan) = server.accept().await?.read_first().await?;
+//!     // dispatch the message to the appropriate handler
+//!     match msg {
+//!         PingRequest::Ping(ping) => chan.rpc(ping, handler, Handler::ping).await?,
+//!     }
 //! }
 //!
 //! // the handler. For a more complex example, this would contain any state
@@ -78,21 +78,22 @@
 //! struct Handler;
 //!
 //! impl Handler {
-//!   // the handle fn for a Ping request.
+//!     // the handle fn for a Ping request.
 //!
-//!   // The return type is the response type for the service.
-//!   // Note that this must take self by value, not by reference.
-//!   async fn ping(self, _req: Ping) -> Pong {
-//!     Pong
-//!   }
+//!     // The return type is the response type for the service.
+//!     // Note that this must take self by value, not by reference.
+//!     async fn ping(self, _req: Ping) -> Pong {
+//!         Pong
+//!     }
 //! }
 //! # Ok(())
 //! # }
 //! ```
 #![deny(missing_docs)]
 #![deny(rustdoc::broken_intra_doc_links)]
-use serde::{de::DeserializeOwned, Serialize};
 use std::fmt::{Debug, Display};
+
+use serde::{de::DeserializeOwned, Serialize};
 pub mod client;
 pub mod message;
 pub mod server;

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -111,7 +111,6 @@
 ///    server_handle.await??;
 ///    Ok(())
 /// }
-///
 /// ```
 ///
 /// The generation of the macros in `CreateDispatch` and `CreateClient`

--- a/src/message.rs
+++ b/src/message.rs
@@ -1,13 +1,15 @@
 //! Service definition
 //!
 //! Traits to define the behaviour of messages for services
-use crate::Service;
 use std::fmt::Debug;
 
-pub use crate::pattern::bidi_streaming::{BidiStreaming, BidiStreamingMsg};
-pub use crate::pattern::client_streaming::{ClientStreaming, ClientStreamingMsg};
-pub use crate::pattern::rpc::{Rpc, RpcMsg};
-pub use crate::pattern::server_streaming::{ServerStreaming, ServerStreamingMsg};
+pub use crate::pattern::{
+    bidi_streaming::{BidiStreaming, BidiStreamingMsg},
+    client_streaming::{ClientStreaming, ClientStreamingMsg},
+    rpc::{Rpc, RpcMsg},
+    server_streaming::{ServerStreaming, ServerStreamingMsg},
+};
+use crate::Service;
 
 /// Declares the interaction pattern for a message and a service.
 ///

--- a/src/pattern/bidi_streaming.rs
+++ b/src/pattern/bidi_streaming.rs
@@ -1,5 +1,11 @@
 //! Bidirectional stream interaction pattern.
 
+use std::{
+    error,
+    fmt::{self, Debug},
+    result,
+};
+
 use futures_lite::{Stream, StreamExt};
 use futures_util::{FutureExt, SinkExt};
 
@@ -9,12 +15,6 @@ use crate::{
     server::{race2, RpcChannel, RpcServerError, UpdateStream},
     transport::{ConnectionErrors, Connector, StreamTypes},
     RpcClient, Service,
-};
-
-use std::{
-    error,
-    fmt::{self, Debug},
-    result,
 };
 
 /// Bidirectional streaming interaction pattern

--- a/src/pattern/client_streaming.rs
+++ b/src/pattern/client_streaming.rs
@@ -1,5 +1,11 @@
 //! Client streaming interaction pattern.
 
+use std::{
+    error,
+    fmt::{self, Debug},
+    result,
+};
+
 use futures_lite::{future::Boxed, Future, StreamExt};
 use futures_util::{FutureExt, SinkExt, TryFutureExt};
 
@@ -9,12 +15,6 @@ use crate::{
     server::{race2, RpcChannel, RpcServerError, UpdateStream},
     transport::{ConnectionErrors, StreamTypes},
     Connector, RpcClient, Service,
-};
-
-use std::{
-    error,
-    fmt::{self, Debug},
-    result,
 };
 
 /// Client streaming interaction pattern

--- a/src/pattern/rpc.rs
+++ b/src/pattern/rpc.rs
@@ -1,5 +1,11 @@
 //! RPC interaction pattern.
 
+use std::{
+    error,
+    fmt::{self, Debug},
+    result,
+};
+
 use futures_lite::{Future, StreamExt};
 use futures_util::{FutureExt, SinkExt};
 
@@ -8,12 +14,6 @@ use crate::{
     server::{race2, RpcChannel, RpcServerError},
     transport::{ConnectionErrors, StreamTypes},
     Connector, RpcClient, Service,
-};
-
-use std::{
-    error,
-    fmt::{self, Debug},
-    result,
 };
 
 /// Rpc interaction pattern

--- a/src/pattern/server_streaming.rs
+++ b/src/pattern/server_streaming.rs
@@ -1,5 +1,11 @@
 //! Server streaming interaction pattern.
 
+use std::{
+    error,
+    fmt::{self, Debug},
+    result,
+};
+
 use futures_lite::{Stream, StreamExt};
 use futures_util::{FutureExt, SinkExt, TryFutureExt};
 
@@ -9,12 +15,6 @@ use crate::{
     server::{race2, RpcChannel, RpcServerError},
     transport::{ConnectionErrors, Connector, StreamTypes},
     RpcClient, Service,
-};
-
-use std::{
-    error,
-    fmt::{self, Debug},
-    result,
 };
 
 /// Server streaming interaction pattern

--- a/src/pattern/try_server_streaming.rs
+++ b/src/pattern/try_server_streaming.rs
@@ -1,5 +1,11 @@
 //! Fallible server streaming interaction pattern.
 
+use std::{
+    error,
+    fmt::{self, Debug},
+    result,
+};
+
 use futures_lite::{Future, Stream, StreamExt};
 use futures_util::{FutureExt, SinkExt, TryFutureExt};
 use serde::{Deserialize, Serialize};
@@ -10,12 +16,6 @@ use crate::{
     server::{race2, RpcChannel, RpcServerError},
     transport::{self, ConnectionErrors, StreamTypes},
     Connector, RpcClient, Service,
-};
-
-use std::{
-    error,
-    fmt::{self, Debug},
-    result,
 };
 
 /// A guard message to indicate that the stream has been created.

--- a/src/server.rs
+++ b/src/server.rs
@@ -1,6 +1,20 @@
 //! Server side api
 //!
 //! The main entry point is [RpcServer]
+use std::{
+    error,
+    fmt::{self, Debug},
+    marker::PhantomData,
+    pin::Pin,
+    result,
+    task::{self, Poll},
+};
+
+use futures_lite::{Future, Stream, StreamExt};
+use futures_util::{SinkExt, TryStreamExt};
+use pin_project::pin_project;
+use tokio::sync::oneshot;
+
 use crate::{
     transport::{
         self,
@@ -10,18 +24,6 @@ use crate::{
     },
     Listener, RpcMessage, Service,
 };
-use futures_lite::{Future, Stream, StreamExt};
-use futures_util::{SinkExt, TryStreamExt};
-use pin_project::pin_project;
-use std::{
-    error,
-    fmt::{self, Debug},
-    marker::PhantomData,
-    pin::Pin,
-    result,
-    task::{self, Poll},
-};
-use tokio::sync::oneshot;
 
 /// Stream types on the server side
 ///

--- a/src/transport/boxed.rs
+++ b/src/transport/boxed.rs
@@ -2,6 +2,7 @@
 
 use std::{
     fmt::Debug,
+    future::Future,
     pin::Pin,
     task::{Context, Poll},
 };
@@ -10,11 +11,9 @@ use futures_lite::FutureExt;
 use futures_sink::Sink;
 use futures_util::{future::BoxFuture, SinkExt, Stream, StreamExt, TryStreamExt};
 use pin_project::pin_project;
-use std::future::Future;
-
-use crate::RpcMessage;
 
 use super::{ConnectionErrors, StreamTypes};
+use crate::RpcMessage;
 type BoxedFuture<'a, T> = Pin<Box<dyn Future<Output = T> + Send + Sync + 'a>>;
 
 enum SendSinkInner<T: RpcMessage> {

--- a/src/transport/combined.rs
+++ b/src/transport/combined.rs
@@ -1,14 +1,16 @@
 //! Transport that combines two other transports
-use super::{ConnectionErrors, Connector, Listener, LocalAddr, StreamTypes};
-use futures_lite::Stream;
-use futures_sink::Sink;
-use pin_project::pin_project;
 use std::{
     error, fmt,
     fmt::Debug,
     pin::Pin,
     task::{Context, Poll},
 };
+
+use futures_lite::Stream;
+use futures_sink::Sink;
+use pin_project::pin_project;
+
+use super::{ConnectionErrors, Connector, Listener, LocalAddr, StreamTypes};
 
 /// A connection that combines two other connections
 #[derive(Debug, Clone)]

--- a/src/transport/flume.rs
+++ b/src/transport/flume.rs
@@ -1,17 +1,17 @@
 //! Memory transport implementation using [flume]
 //!
 //! [flume]: https://docs.rs/flume/
+use core::fmt;
+use std::{error, fmt::Display, marker::PhantomData, pin::Pin, result, task::Poll};
+
 use futures_lite::{Future, Stream};
 use futures_sink::Sink;
 
+use super::StreamTypes;
 use crate::{
     transport::{ConnectionErrors, Connector, Listener, LocalAddr},
     RpcMessage,
 };
-use core::fmt;
-use std::{error, fmt::Display, marker::PhantomData, pin::Pin, result, task::Poll};
-
-use super::StreamTypes;
 
 /// Error when receiving from a channel
 ///

--- a/src/transport/hyper.rs
+++ b/src/transport/hyper.rs
@@ -6,8 +6,6 @@ use std::{
     sync::Arc, task::Poll,
 };
 
-use crate::transport::{ConnectionErrors, Connector, Listener, LocalAddr, StreamTypes};
-use crate::RpcMessage;
 use bytes::Bytes;
 use flume::{Receiver, Sender};
 use futures_lite::{Stream, StreamExt};
@@ -18,9 +16,13 @@ use hyper::{
     service::{make_service_fn, service_fn},
     Body, Client, Request, Response, Server, StatusCode, Uri,
 };
-use tokio::sync::mpsc;
-use tokio::task::JoinHandle;
+use tokio::{sync::mpsc, task::JoinHandle};
 use tracing::{debug, event, trace, Level};
+
+use crate::{
+    transport::{ConnectionErrors, Connector, Listener, LocalAddr, StreamTypes},
+    RpcMessage,
+};
 
 struct HyperConnectionInner {
     client: Box<dyn Requester>,

--- a/src/transport/iroh_net.rs
+++ b/src/transport/iroh_net.rs
@@ -1,10 +1,5 @@
 //! iroh-net transport implementation based on [iroh-net](https://crates.io/crates/iroh-net)
 
-use crate::{
-    transport::{ConnectionErrors, Connector, Listener, LocalAddr},
-    RpcMessage,
-};
-
 use std::{
     collections::BTreeSet,
     fmt,
@@ -31,6 +26,10 @@ use tracing::{debug_span, Instrument};
 use super::{
     util::{FramedBincodeRead, FramedBincodeWrite},
     StreamTypes,
+};
+use crate::{
+    transport::{ConnectionErrors, Connector, Listener, LocalAddr},
+    RpcMessage,
 };
 
 const MAX_FRAME_LENGTH: usize = 1024 * 1024 * 16;

--- a/src/transport/mapped.rs
+++ b/src/transport/mapped.rs
@@ -9,9 +9,8 @@ use futures_lite::{Stream, StreamExt};
 use futures_util::SinkExt;
 use pin_project::pin_project;
 
-use crate::{RpcError, RpcMessage};
-
 use super::{ConnectionErrors, Connector, StreamTypes};
+use crate::{RpcError, RpcMessage};
 
 /// A connection that maps input and output types
 #[derive(Debug)]
@@ -249,15 +248,15 @@ where
 #[cfg(feature = "flume-transport")]
 mod tests {
 
+    use serde::{Deserialize, Serialize};
+    use testresult::TestResult;
+
+    use super::*;
     use crate::{
         server::{BoxedChannelTypes, RpcChannel},
         transport::Listener,
         RpcClient, RpcServer,
     };
-    use serde::{Deserialize, Serialize};
-    use testresult::TestResult;
-
-    use super::*;
 
     #[derive(Debug, Clone, Serialize, Deserialize, derive_more::From, derive_more::TryInto)]
     enum Request {

--- a/src/transport/misc/mod.rs
+++ b/src/transport/misc/mod.rs
@@ -1,14 +1,14 @@
 //! Miscellaneous transport utilities
+use std::convert::Infallible;
+
 use futures_lite::stream;
 use futures_sink::Sink;
 
+use super::StreamTypes;
 use crate::{
     transport::{ConnectionErrors, Listener},
     RpcMessage,
 };
-use std::convert::Infallible;
-
-use super::StreamTypes;
 
 /// A dummy listener that does nothing
 ///

--- a/src/transport/mod.rs
+++ b/src/transport/mod.rs
@@ -17,16 +17,17 @@
 //! types are defined by implementing the [`StreamTypes`] trait.
 //!
 //! Errors for both sides are defined by implementing the [`ConnectionErrors`] trait.
+use std::{
+    fmt::{self, Debug, Display},
+    net::SocketAddr,
+};
+
 use boxed::{BoxableConnector, BoxableListener, BoxedConnector, BoxedListener};
 use futures_lite::{Future, Stream};
 use futures_sink::Sink;
 use mapped::MappedConnector;
 
 use crate::{RpcError, RpcMessage};
-use std::{
-    fmt::{self, Debug, Display},
-    net::SocketAddr,
-};
 
 pub mod boxed;
 pub mod combined;

--- a/src/transport/quinn.rs
+++ b/src/transport/quinn.rs
@@ -1,24 +1,29 @@
 //! QUIC transport implementation based on [quinn](https://crates.io/crates/quinn)
-use crate::{
-    transport::{ConnectionErrors, Connector, Listener, LocalAddr},
-    RpcMessage,
+use std::{
+    fmt, io,
+    marker::PhantomData,
+    net::SocketAddr,
+    pin::Pin,
+    result,
+    sync::Arc,
+    task::{Context, Poll},
 };
+
 use futures_lite::{Future, Stream, StreamExt};
 use futures_sink::Sink;
 use futures_util::FutureExt;
 use pin_project::pin_project;
-use serde::de::DeserializeOwned;
-use serde::Serialize;
-use std::net::SocketAddr;
-use std::sync::Arc;
-use std::task::{Context, Poll};
-use std::{fmt, io, marker::PhantomData, pin::Pin, result};
+use serde::{de::DeserializeOwned, Serialize};
 use tokio::sync::oneshot;
 use tracing::{debug_span, Instrument};
 
 use super::{
     util::{FramedBincodeRead, FramedBincodeWrite},
     StreamTypes,
+};
+use crate::{
+    transport::{ConnectionErrors, Connector, Listener, LocalAddr},
+    RpcMessage,
 };
 
 const MAX_FRAME_LENGTH: usize = 1024 * 1024 * 16;

--- a/tests/math.rs
+++ b/tests/math.rs
@@ -5,6 +5,11 @@
     feature = "iroh-net-transport",
 ))]
 #![allow(dead_code)]
+use std::{
+    io::{self, Write},
+    result,
+};
+
 use async_stream::stream;
 use derive_more::{From, TryInto};
 use futures_buffered::BufferedStreamExt;
@@ -20,10 +25,6 @@ use quic_rpc::{
     Connector, Listener, RpcClient, RpcServer, Service,
 };
 use serde::{Deserialize, Serialize};
-use std::{
-    io::{self, Write},
-    result,
-};
 use thousands::Separable;
 
 /// compute the square of a number


### PR DESCRIPTION
using

cargo fmt --all -- --config unstable_features=true --config imports_granularity=Crate,group_imports=StdExternalCrate,reorder_imports=true,format_code_in_doc_comments=true