### PR TITLE
feat: use postcard encoding for all transports that require serialization

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2989,7 +2989,6 @@ dependencies = [
  "thousands",
  "tokio",
  "tokio-serde",
- "tokio-serde-postcard",
  "tokio-util",
  "tracing",
  "tracing-subscriber",
@@ -4161,18 +4160,6 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "pin-project",
-]
-
-[[package]]
-name = "tokio-serde-postcard"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9bc47334cd92ae09ac4ae741108a3a7437c3d2c75c38c957b93dbc066984329"
-dependencies = [
- "bytes",
- "postcard",
- "serde",
- "tokio-serde",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -154,6 +154,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "atomic-polyfill"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8cf2bce30dfe09ef0bfaef228b9d414faaf7e563035494d7fe092dba54b300f4"
+dependencies = [
+ "critical-section",
+]
+
+[[package]]
 name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -219,15 +228,6 @@ name = "base64ct"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
-
-[[package]]
-name = "bincode"
-version = "1.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
-dependencies = [
- "serde",
-]
 
 [[package]]
 name = "bitflags"
@@ -437,6 +437,12 @@ name = "crc-catalog"
 version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19d374276b40fb8bbdee95aef7c7fa6b5316ec764510eb64b8dd0e2ed0d7e7f5"
+
+[[package]]
+name = "critical-section"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "790eea4361631c5e7d22598ecd5723ff611904e3344ce8720784c93e3d83d40b"
 
 [[package]]
 name = "crossbeam-utils"
@@ -1225,6 +1231,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "hash32"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0c35f58762feb77d74ebe43bdbc3210f09be9fe6742234d573bacc26ed92b67"
+dependencies = [
+ "byteorder",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1235,6 +1250,20 @@ name = "hashbrown"
 version = "0.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a9bfc1af68b1726ea47d3d5109de126281def866b33970e10fbab11b5dafab3"
+
+[[package]]
+name = "heapless"
+version = "0.7.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdc6457c0eb62c71aac4bc17216026d8410337c4126773b9c5daba343f17964f"
+dependencies = [
+ "atomic-polyfill",
+ "hash32",
+ "rustc_version",
+ "serde",
+ "spin",
+ "stable_deref_trait",
+]
 
 [[package]]
 name = "heck"
@@ -2767,6 +2796,7 @@ dependencies = [
  "cobs",
  "embedded-io 0.4.0",
  "embedded-io 0.6.1",
+ "heapless",
  "postcard-derive",
  "serde",
 ]
@@ -2934,7 +2964,6 @@ version = "0.15.0"
 dependencies = [
  "anyhow",
  "async-stream",
- "bincode",
  "bytes",
  "derive_more",
  "educe",
@@ -2950,6 +2979,7 @@ dependencies = [
  "iroh-quinn",
  "nested_enum_utils",
  "pin-project",
+ "postcard",
  "proc-macro2",
  "rcgen",
  "serde",
@@ -4127,13 +4157,10 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "911a61637386b789af998ee23f50aa30d5fd7edcec8d6d3dedae5e5815205466"
 dependencies = [
- "bincode",
  "bytes",
- "educe",
  "futures-core",
  "futures-sink",
  "pin-project",
- "serde",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2984,6 +2984,7 @@ dependencies = [
  "rcgen",
  "serde",
  "slab",
+ "smallvec",
  "tempfile",
  "testresult",
  "thousands",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -230,6 +230,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
 
 [[package]]
+name = "bincode"
+version = "1.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4201,10 +4210,13 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "caf600e7036b17782571dd44fa0a5cea3c82f60db5137f774a325a76a0d6852b"
 dependencies = [
+ "bincode",
  "bytes",
+ "educe",
  "futures-core",
  "futures-sink",
  "pin-project",
+ "serde",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2959,6 +2959,7 @@ dependencies = [
  "thousands",
  "tokio",
  "tokio-serde",
+ "tokio-serde-postcard",
  "tokio-util",
  "tracing",
  "tracing-subscriber",
@@ -4133,6 +4134,18 @@ dependencies = [
  "futures-sink",
  "pin-project",
  "serde",
+]
+
+[[package]]
+name = "tokio-serde-postcard"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9bc47334cd92ae09ac4ae741108a3a7437c3d2c75c38c957b93dbc066984329"
+dependencies = [
+ "bytes",
+ "postcard",
+ "serde",
+ "tokio-serde",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,6 @@ description = "A streaming rpc system based on quic"
 rust-version = "1.76"
 
 [dependencies]
-bincode = { version = "1.3.3", optional = true }
 bytes = { version = "1", optional = true }
 derive_more = { version = "1.0.0-beta.6", features = ["from", "try_into", "display"] }
 flume = { version = "0.11", optional = true }
@@ -26,7 +25,9 @@ pin-project = "1"
 quinn = { package = "iroh-quinn", version = "0.12", optional = true }
 serde = { version = "1.0.183", features = ["derive"] }
 tokio = { version = "1", default-features = false, features = ["macros", "sync"] }
-tokio-serde = { version = "0.8", features = ["bincode"], optional = true }
+tokio-serde = { version = "0.8", features = [], optional = true }
+tokio-serde-postcard = { version = "0.1.0", optional = true }
+postcard = { version = "1", optional = true }
 tokio-util = { version = "0.7", features = ["codec"], optional = true }
 tracing = "0.1"
 hex = "0.4.3"
@@ -36,7 +37,6 @@ anyhow = "1.0.73"
 # Indirect dependencies, is needed to make the minimal crates versions work
 educe = "0.4.20" # tokio-serde
 slab = "0.4.9" # iroh-quinn
-tokio-serde-postcard = "0.1.0"
 
 [dev-dependencies]
 anyhow = "1.0.73"
@@ -55,12 +55,12 @@ testresult = "0.4.1"
 nested_enum_utils = "0.1.0"
 
 [features]
-hyper-transport = ["dep:flume", "dep:hyper", "dep:bincode", "dep:bytes", "dep:tokio-serde", "dep:tokio-util"]
-quinn-transport = ["dep:flume", "dep:quinn", "dep:bincode", "dep:tokio-serde", "dep:tokio-util"]
+hyper-transport = ["dep:flume", "dep:hyper", "dep:postcard", "dep:bytes", "dep:tokio-serde", "dep:tokio-util"]
+quinn-transport = ["dep:flume", "dep:quinn", "dep:tokio-serde", "dep:tokio-serde-postcard", "dep:tokio-util"]
 flume-transport = ["dep:flume"]
-iroh-net-transport = ["dep:iroh-net", "dep:flume", "dep:quinn", "dep:bincode", "dep:tokio-serde", "dep:tokio-util"]
+iroh-net-transport = ["dep:iroh-net", "dep:flume", "dep:quinn", "dep:tokio-serde", "dep:tokio-serde-postcard", "dep:tokio-util"]
 macros = []
-default = ["flume-transport"]
+default = ["flume-transport", "hyper-transport"]
 
 [package.metadata.docs.rs]
 all-features = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,7 +61,7 @@ quinn-transport = ["dep:flume", "dep:quinn", "dep:postcard", "dep:tokio-serde", 
 flume-transport = ["dep:flume"]
 iroh-net-transport = ["dep:iroh-net", "dep:flume", "dep:quinn", "dep:postcard", "dep:tokio-serde", "tokio-util/codec"]
 macros = []
-default = ["flume-transport", "hyper-transport"]
+default = ["flume-transport"]
 
 [package.metadata.docs.rs]
 all-features = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,7 @@ anyhow = "1.0.73"
 # Indirect dependencies, is needed to make the minimal crates versions work
 educe = "0.4.20" # tokio-serde
 slab = "0.4.9" # iroh-quinn
+smallvec = "1.13.2"
 
 [dev-dependencies]
 anyhow = "1.0.73"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,8 +26,7 @@ quinn = { package = "iroh-quinn", version = "0.12", optional = true }
 serde = { version = "1.0.183", features = ["derive"] }
 tokio = { version = "1", default-features = false, features = ["macros", "sync"] }
 tokio-serde = { version = "0.8", features = [], optional = true }
-tokio-serde-postcard = { version = "0.1.0", optional = true }
-postcard = { version = "1", optional = true }
+postcard = { version = "1", features = ["use-std"], optional = true }
 tokio-util = { version = "0.7", features = ["codec"], optional = true }
 tracing = "0.1"
 hex = "0.4.3"
@@ -56,9 +55,9 @@ nested_enum_utils = "0.1.0"
 
 [features]
 hyper-transport = ["dep:flume", "dep:hyper", "dep:postcard", "dep:bytes", "dep:tokio-serde", "dep:tokio-util"]
-quinn-transport = ["dep:flume", "dep:quinn", "dep:tokio-serde", "dep:tokio-serde-postcard", "dep:tokio-util"]
+quinn-transport = ["dep:flume", "dep:quinn", "dep:tokio-serde", "dep:tokio-util"]
 flume-transport = ["dep:flume"]
-iroh-net-transport = ["dep:iroh-net", "dep:flume", "dep:quinn", "dep:tokio-serde", "dep:tokio-serde-postcard", "dep:tokio-util"]
+iroh-net-transport = ["dep:iroh-net", "dep:flume", "dep:quinn", "dep:tokio-serde", "dep:tokio-util"]
 macros = []
 default = ["flume-transport", "hyper-transport"]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,7 @@ anyhow = "1.0.73"
 # Indirect dependencies, is needed to make the minimal crates versions work
 educe = "0.4.20" # tokio-serde
 slab = "0.4.9" # iroh-quinn
+tokio-serde-postcard = "0.1.0"
 
 [dev-dependencies]
 anyhow = "1.0.73"

--- a/src/transport/boxed.rs
+++ b/src/transport/boxed.rs
@@ -158,7 +158,7 @@ impl<'a, In: RpcMessage, Out: RpcMessage> OpenFuture<'a, In, Out> {
     }
 }
 
-impl<'a, In: RpcMessage, Out: RpcMessage> Future for OpenFuture<'a, In, Out> {
+impl<In: RpcMessage, Out: RpcMessage> Future for OpenFuture<'_, In, Out> {
     type Output = anyhow::Result<(SendSink<Out>, RecvStream<In>)>;
 
     fn poll(self: Pin<&mut Self>, cx: &mut std::task::Context<'_>) -> Poll<Self::Output> {
@@ -199,7 +199,7 @@ impl<'a, In: RpcMessage, Out: RpcMessage> AcceptFuture<'a, In, Out> {
     }
 }
 
-impl<'a, In: RpcMessage, Out: RpcMessage> Future for AcceptFuture<'a, In, Out> {
+impl<In: RpcMessage, Out: RpcMessage> Future for AcceptFuture<'_, In, Out> {
     type Output = anyhow::Result<(SendSink<Out>, RecvStream<In>)>;
 
     fn poll(self: Pin<&mut Self>, cx: &mut std::task::Context<'_>) -> Poll<Self::Output> {

--- a/src/transport/iroh_net.rs
+++ b/src/transport/iroh_net.rs
@@ -24,7 +24,7 @@ use tokio::{sync::oneshot, task::yield_now};
 use tracing::{debug_span, Instrument};
 
 use super::{
-    util::{FramedBincodeRead, FramedBincodeWrite},
+    util::{FramedPostcardRead, FramedPostcardWrite},
     StreamTypes,
 };
 use crate::{
@@ -658,12 +658,12 @@ impl<In: RpcMessage, Out: RpcMessage> Connector for IrohNetConnector<In, Out> {
     }
 }
 
-/// A sink that wraps a quinn SendStream with length delimiting and bincode
+/// A sink that wraps a quinn SendStream with length delimiting and postcard
 ///
 /// If you want to send bytes directly, use [SendSink::into_inner] to get the
 /// underlying [quinn::SendStream].
 #[pin_project]
-pub struct SendSink<Out>(#[pin] FramedBincodeWrite<quinn::SendStream, Out>);
+pub struct SendSink<Out>(#[pin] FramedPostcardWrite<quinn::SendStream, Out>);
 
 impl<Out> fmt::Debug for SendSink<Out> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -673,7 +673,7 @@ impl<Out> fmt::Debug for SendSink<Out> {
 
 impl<Out: Serialize> SendSink<Out> {
     fn new(inner: quinn::SendStream) -> Self {
-        let inner = FramedBincodeWrite::new(inner, MAX_FRAME_LENGTH);
+        let inner = FramedPostcardWrite::new(inner, MAX_FRAME_LENGTH);
         Self(inner)
     }
 }
@@ -706,12 +706,12 @@ impl<Out: Serialize> Sink<Out> for SendSink<Out> {
     }
 }
 
-/// A stream that wraps a quinn RecvStream with length delimiting and bincode
+/// A stream that wraps a quinn RecvStream with length delimiting and postcard
 ///
 /// If you want to receive bytes directly, use [RecvStream::into_inner] to get
 /// the underlying [quinn::RecvStream].
 #[pin_project]
-pub struct RecvStream<In>(#[pin] FramedBincodeRead<quinn::RecvStream, In>);
+pub struct RecvStream<In>(#[pin] FramedPostcardRead<quinn::RecvStream, In>);
 
 impl<In> fmt::Debug for RecvStream<In> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -721,7 +721,7 @@ impl<In> fmt::Debug for RecvStream<In> {
 
 impl<In: DeserializeOwned> RecvStream<In> {
     fn new(inner: quinn::RecvStream) -> Self {
-        let inner = FramedBincodeRead::new(inner, MAX_FRAME_LENGTH);
+        let inner = FramedPostcardRead::new(inner, MAX_FRAME_LENGTH);
         Self(inner)
     }
 }

--- a/src/transport/mod.rs
+++ b/src/transport/mod.rs
@@ -42,11 +42,7 @@ pub mod misc;
 #[cfg(feature = "quinn-transport")]
 pub mod quinn;
 
-#[cfg(any(
-    feature = "quinn-transport",
-    feature = "hyper-transport",
-    feature = "iroh-net-transport"
-))]
+#[cfg(any(feature = "quinn-transport", feature = "iroh-net-transport"))]
 mod util;
 
 /// Errors that can happen when creating and using a [`Connector`] or [`Listener`].

--- a/src/transport/quinn.rs
+++ b/src/transport/quinn.rs
@@ -17,7 +17,7 @@ use tokio::sync::oneshot;
 use tracing::{debug_span, Instrument};
 
 use super::{
-    util::{FramedBincodeRead, FramedBincodeWrite},
+    util::{FramedPostcardRead, FramedPostcardWrite},
     StreamTypes,
 };
 
@@ -653,7 +653,7 @@ impl<In: RpcMessage, Out: RpcMessage> Connector for QuinnConnector<In, Out> {
 /// If you want to send bytes directly, use [SendSink::into_inner] to get the
 /// underlying [quinn::SendStream].
 #[pin_project]
-pub struct SendSink<Out>(#[pin] FramedBincodeWrite<quinn::SendStream, Out>);
+pub struct SendSink<Out>(#[pin] FramedPostcardWrite<quinn::SendStream, Out>);
 
 impl<Out> fmt::Debug for SendSink<Out> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -663,7 +663,7 @@ impl<Out> fmt::Debug for SendSink<Out> {
 
 impl<Out: Serialize> SendSink<Out> {
     fn new(inner: quinn::SendStream) -> Self {
-        let inner = FramedBincodeWrite::new(inner, MAX_FRAME_LENGTH);
+        let inner = FramedPostcardWrite::new(inner, MAX_FRAME_LENGTH);
         Self(inner)
     }
 }
@@ -710,7 +710,7 @@ impl<Out: Serialize> Sink<Out> for SendSink<Out> {
 /// If you want to receive bytes directly, use [RecvStream::into_inner] to get
 /// the underlying [quinn::RecvStream].
 #[pin_project]
-pub struct RecvStream<In>(#[pin] FramedBincodeRead<quinn::RecvStream, In>);
+pub struct RecvStream<In>(#[pin] FramedPostcardRead<quinn::RecvStream, In>);
 
 impl<In> fmt::Debug for RecvStream<In> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -720,7 +720,7 @@ impl<In> fmt::Debug for RecvStream<In> {
 
 impl<In: DeserializeOwned> RecvStream<In> {
     fn new(inner: quinn::RecvStream) -> Self {
-        let inner = FramedBincodeRead::new(inner, MAX_FRAME_LENGTH);
+        let inner = FramedPostcardRead::new(inner, MAX_FRAME_LENGTH);
         Self(inner)
     }
 }

--- a/src/transport/quinn.rs
+++ b/src/transport/quinn.rs
@@ -578,7 +578,7 @@ impl<'a, T> Receiver<'a, T> {
     }
 }
 
-impl<'a, T> Stream for Receiver<'a, T> {
+impl<T> Stream for Receiver<'_, T> {
     type Item = T;
 
     fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {

--- a/src/transport/quinn.rs
+++ b/src/transport/quinn.rs
@@ -653,7 +653,7 @@ impl<In: RpcMessage, Out: RpcMessage> Connector for QuinnConnector<In, Out> {
     }
 }
 
-/// A sink that wraps a quinn SendStream with length delimiting and bincode
+/// A sink that wraps a quinn SendStream with length delimiting and postcard
 ///
 /// If you want to send bytes directly, use [SendSink::into_inner] to get the
 /// underlying [quinn::SendStream].
@@ -710,7 +710,7 @@ impl<Out: Serialize> Sink<Out> for SendSink<Out> {
     }
 }
 
-/// A stream that wraps a quinn RecvStream with length delimiting and bincode
+/// A stream that wraps a quinn RecvStream with length delimiting and postcard
 ///
 /// If you want to receive bytes directly, use [RecvStream::into_inner] to get
 /// the underlying [quinn::RecvStream].

--- a/src/transport/util.rs
+++ b/src/transport/util.rs
@@ -1,436 +1,189 @@
-mod deps {
-    use std::{
-        pin::Pin,
-        task::{self, Poll},
-    };
+use std::{
+    pin::Pin,
+    task::{self, Poll},
+};
 
-    use futures_lite::Stream;
-    use futures_sink::Sink;
-    use pin_project::pin_project;
-    use serde::{de::DeserializeOwned, Serialize};
-    use tokio::io::{AsyncRead, AsyncWrite};
-    use tokio_util::codec::LengthDelimitedCodec;
+use futures_lite::Stream;
+use futures_sink::Sink;
+use pin_project::pin_project;
+use serde::{de::DeserializeOwned, Serialize};
+use tokio::io::{AsyncRead, AsyncWrite};
+use tokio_util::codec::LengthDelimitedCodec;
 
-    #[pin_project]
-    pub struct FramedPostcardRead<T, In>(
-        #[pin]
-        tokio_serde::SymmetricallyFramed<
-            tokio_util::codec::FramedRead<T, tokio_util::codec::LengthDelimitedCodec>,
-            In,
-            tokio_serde_postcard::SymmetricalPostcard<In>,
-        >,
-    );
+#[pin_project]
+pub struct FramedPostcardRead<T, In>(
+    #[pin]
+    tokio_serde::SymmetricallyFramed<
+        tokio_util::codec::FramedRead<T, tokio_util::codec::LengthDelimitedCodec>,
+        In,
+        tokio_serde_postcard::SymmetricalPostcard<In>,
+    >,
+);
 
-    impl<T: AsyncRead, In: DeserializeOwned> FramedPostcardRead<T, In> {
-        /// Wrap a socket in a length delimited codec and postcard encoding
-        pub fn new(inner: T, max_frame_length: usize) -> Self {
-            // configure length delimited codec with max frame length
-            let framing = LengthDelimitedCodec::builder()
-                .max_frame_length(max_frame_length)
-                .new_codec();
-            // create the actual framing. This turns the AsyncRead/AsyncWrite into a Stream/Sink of Bytes/BytesMut
-            let framed = tokio_util::codec::FramedRead::new(inner, framing);
-            let postcard = tokio_serde_postcard::Postcard::new();
-            // create the actual framing. This turns the Stream/Sink of Bytes/BytesMut into a Stream/Sink of In/Out
-            let framed = tokio_serde::Framed::new(framed, postcard);
-            Self(framed)
-        }
-    }
-
-    impl<T, In> FramedPostcardRead<T, In> {
-        /// Get the underlying binary stream
-        ///
-        /// This can be useful if you want to drop the framing and use the underlying stream directly
-        /// after exchanging some messages.
-        pub fn into_inner(self) -> T {
-            self.0.into_inner().into_inner()
-        }
-    }
-
-    impl<T: AsyncRead, In: DeserializeOwned> Stream for FramedPostcardRead<T, In> {
-        type Item = Result<In, std::io::Error>;
-
-        fn poll_next(self: Pin<&mut Self>, cx: &mut task::Context<'_>) -> Poll<Option<Self::Item>> {
-            Pin::new(&mut self.project().0).poll_next(cx)
-        }
-    }
-
-    /// Wrapper that wraps a bidirectional binary stream in a length delimited codec and postcard encoding
-    /// to get a bidirectional stream of rpc Messages
-    #[pin_project]
-    pub struct FramedPostcardWrite<T, Out>(
-        #[pin]
-        tokio_serde::SymmetricallyFramed<
-            tokio_util::codec::FramedWrite<T, tokio_util::codec::LengthDelimitedCodec>,
-            Out,
-            tokio_serde_postcard::SymmetricalPostcard<Out>,
-        >,
-    );
-
-    impl<T: AsyncWrite, Out: Serialize> FramedPostcardWrite<T, Out> {
-        /// Wrap a socket in a length delimited codec and postcard encoding
-        pub fn new(inner: T, max_frame_length: usize) -> Self {
-            // configure length delimited codec with max frame length
-            let framing = LengthDelimitedCodec::builder()
-                .max_frame_length(max_frame_length)
-                .new_codec();
-            // create the actual framing. This turns the AsyncRead/AsyncWrite into a Stream/Sink of Bytes/BytesMut
-            let framed = tokio_util::codec::FramedWrite::new(inner, framing);
-            let postcard = tokio_serde_postcard::SymmetricalPostcard::new();
-            // create the actual framing. This turns the Stream/Sink of Bytes/BytesMut into a Stream/Sink of In/Out
-            let framed = tokio_serde::SymmetricallyFramed::new(framed, postcard);
-            Self(framed)
-        }
-    }
-
-    impl<T, Out> FramedPostcardWrite<T, Out> {
-        /// Get the underlying binary stream
-        ///
-        /// This can be useful if you want to drop the framing and use the underlying stream directly
-        /// after exchanging some messages.
-        pub fn into_inner(self) -> T {
-            self.0.into_inner().into_inner()
-        }
-    }
-
-    impl<T: AsyncWrite, Out: Serialize> Sink<Out> for FramedPostcardWrite<T, Out> {
-        type Error = std::io::Error;
-
-        fn poll_ready(
-            self: Pin<&mut Self>,
-            cx: &mut task::Context<'_>,
-        ) -> Poll<Result<(), Self::Error>> {
-            Pin::new(&mut self.project().0).poll_ready(cx)
-        }
-
-        fn start_send(self: Pin<&mut Self>, item: Out) -> Result<(), Self::Error> {
-            Pin::new(&mut self.project().0).start_send(item)
-        }
-
-        fn poll_flush(
-            self: Pin<&mut Self>,
-            cx: &mut task::Context<'_>,
-        ) -> Poll<Result<(), Self::Error>> {
-            Pin::new(&mut self.project().0).poll_flush(cx)
-        }
-
-        fn poll_close(
-            self: Pin<&mut Self>,
-            cx: &mut task::Context<'_>,
-        ) -> Poll<Result<(), Self::Error>> {
-            Pin::new(&mut self.project().0).poll_close(cx)
-        }
-    }
-
-    mod tokio_serde_postcard {
-        use {
-            bytes::{BufMut as _, Bytes, BytesMut},
-            pin_project::pin_project,
-            serde::{Deserialize, Serialize},
-            std::{io, marker::PhantomData, pin::Pin},
-            tokio_serde::{Deserializer, Serializer},
-        };
-
-        #[pin_project]
-        pub struct Postcard<Item, SinkItem> {
-            #[pin]
-            buffer: Box<Option<BytesMut>>,
-            _marker: PhantomData<(Item, SinkItem)>,
-        }
-
-        impl<Item, SinkItem> Default for Postcard<Item, SinkItem> {
-            fn default() -> Self {
-                Self::new()
-            }
-        }
-
-        impl<Item, SinkItem> Postcard<Item, SinkItem> {
-            pub fn new() -> Self {
-                Self {
-                    buffer: Box::new(None),
-                    _marker: PhantomData,
-                }
-            }
-        }
-
-        pub type SymmetricalPostcard<T> = Postcard<T, T>;
-
-        impl<Item, SinkItem> Deserializer<Item> for Postcard<Item, SinkItem>
-        where
-            for<'a> Item: Deserialize<'a>,
-        {
-            type Error = io::Error;
-
-            fn deserialize(self: Pin<&mut Self>, src: &BytesMut) -> Result<Item, Self::Error> {
-                postcard::from_bytes(&src)
-                    .map_err(|err| io::Error::new(io::ErrorKind::InvalidData, err))
-            }
-        }
-
-        impl<Item, SinkItem> Serializer<SinkItem> for Postcard<Item, SinkItem>
-        where
-            SinkItem: Serialize,
-        {
-            type Error = io::Error;
-
-            fn serialize(self: Pin<&mut Self>, data: &SinkItem) -> Result<Bytes, Self::Error> {
-                let mut this = self.project();
-                let buffer = this.buffer.take().unwrap_or_default();
-                let mut buffer = postcard::to_io(data, buffer.writer())
-                    .map_err(|err| io::Error::new(io::ErrorKind::InvalidData, err))?
-                    .into_inner();
-                if buffer.len() <= 1024 {
-                    let res = buffer.split().freeze();
-                    this.buffer.replace(buffer);
-                    Ok(res)
-                } else {
-                    Ok(buffer.freeze())
-                }
-            }
-        }
+impl<T: AsyncRead, In: DeserializeOwned> FramedPostcardRead<T, In> {
+    /// Wrap a socket in a length delimited codec and postcard encoding
+    pub fn new(inner: T, max_frame_length: usize) -> Self {
+        // configure length delimited codec with max frame length
+        let framing = LengthDelimitedCodec::builder()
+            .max_frame_length(max_frame_length)
+            .new_codec();
+        // create the actual framing. This turns the AsyncRead/AsyncWrite into a Stream/Sink of Bytes/BytesMut
+        let framed = tokio_util::codec::FramedRead::new(inner, framing);
+        let postcard = tokio_serde_postcard::Postcard::new();
+        // create the actual framing. This turns the Stream/Sink of Bytes/BytesMut into a Stream/Sink of In/Out
+        let framed = tokio_serde::Framed::new(framed, postcard);
+        Self(framed)
     }
 }
 
-mod direct {
-    use futures_lite::{ready, Stream};
-    use futures_sink::Sink;
-    use pin_project::pin_project;
-    use postcard;
-    use serde::de::DeserializeOwned;
-    use serde::Serialize;
-    use smallvec::SmallVec;
-    use std::marker::PhantomData;
-    use std::pin::Pin;
-    use std::task::{Context, Poll};
-    use tokio::io::{AsyncRead, AsyncWrite, ReadBuf}; // Ensure the postcard crate is included in your Cargo.toml
-
-    #[pin_project]
-    /// A Sink that encodes messages into a framed stream with 32-bit big-endian length prefixes,
-    /// using Postcard for serialization.
-    pub struct FramedPostcardWrite<W, Out> {
-        #[pin]
-        inner: W,
-        buffer: SmallVec<[u8; 1024]>,
-        written: usize,
-        _phantom: PhantomData<Out>,
-    }
-
-    impl<W, Out> FramedPostcardWrite<W, Out> {
-        /// Creates a new `FramedPostcardWrite` with the provided `AsyncWrite`.
-        pub fn new(inner: W, max_frame_size: usize) -> Self
-        where
-            W: AsyncWrite,
-            Out: Serialize,
-        {
-            Self {
-                inner,
-                buffer: SmallVec::new(),
-                written: 0,
-                _phantom: PhantomData,
-            }
-        }
-
-        pub fn into_inner(self) -> W {
-            self.inner
-        }
-    }
-
-    impl<W, Out> Sink<Out> for FramedPostcardWrite<W, Out>
-    where
-        W: AsyncWrite,
-        Out: Serialize,
-    {
-        type Error = std::io::Error;
-
-        fn poll_ready(
-            self: Pin<&mut Self>,
-            _cx: &mut Context<'_>,
-        ) -> Poll<Result<(), Self::Error>> {
-            // Always ready to accept data.
-            Poll::Ready(Ok(()))
-        }
-
-        fn start_send(self: Pin<&mut Self>, item: Out) -> Result<(), Self::Error> {
-            let this = self.project();
-
-            // Serialize the item using Postcard.
-            let data = postcard::to_stdvec(&item).map_err(|e| {
-                std::io::Error::new(
-                    std::io::ErrorKind::InvalidData,
-                    format!("Serialization error: {}", e),
-                )
-            })?;
-            let len = data.len();
-
-            if len > u32::MAX as usize {
-                return Err(std::io::Error::new(
-                    std::io::ErrorKind::InvalidInput,
-                    "Item too large",
-                ));
-            }
-
-            // Encode length prefix in big-endian format.
-            let len_u32 = len as u32;
-            this.buffer.extend_from_slice(&len_u32.to_be_bytes());
-            this.buffer.extend_from_slice(&data);
-
-            Ok(())
-        }
-
-        fn poll_flush(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
-            let mut this = self.project();
-
-            while *this.written < this.buffer.len() {
-                match this
-                    .inner
-                    .as_mut()
-                    .poll_write(cx, &this.buffer[*this.written..])
-                {
-                    Poll::Ready(Ok(0)) => {
-                        return Poll::Ready(Err(std::io::Error::new(
-                            std::io::ErrorKind::WriteZero,
-                            "Failed to write data",
-                        )));
-                    }
-                    Poll::Ready(Ok(n)) => *this.written += n,
-                    Poll::Ready(Err(e)) => return Poll::Ready(Err(e)),
-                    Poll::Pending => return Poll::Pending,
-                }
-            }
-
-            // Clear the buffer once all data is written.
-            this.buffer.clear();
-            *this.written = 0;
-
-            // Ensure the inner writer is flushed.
-            this.inner.as_mut().poll_flush(cx)
-        }
-
-        fn poll_close(
-            mut self: Pin<&mut Self>,
-            cx: &mut Context<'_>,
-        ) -> Poll<Result<(), Self::Error>> {
-            // Flush any remaining data and close the inner writer.
-            ready!(self.as_mut().poll_flush(cx))?;
-            self.project().inner.poll_shutdown(cx)
-        }
-    }
-
-    #[pin_project]
-    /// A Stream that reads framed messages from an AsyncRead, deserializing them using Postcard.
+impl<T, In> FramedPostcardRead<T, In> {
+    /// Get the underlying binary stream
     ///
-    /// Each message is expected to be prefixed with a 32-bit big-endian length field.
-    pub struct FramedPostcardRead<R, In> {
+    /// This can be useful if you want to drop the framing and use the underlying stream directly
+    /// after exchanging some messages.
+    pub fn into_inner(self) -> T {
+        self.0.into_inner().into_inner()
+    }
+}
+
+impl<T: AsyncRead, In: DeserializeOwned> Stream for FramedPostcardRead<T, In> {
+    type Item = Result<In, std::io::Error>;
+
+    fn poll_next(self: Pin<&mut Self>, cx: &mut task::Context<'_>) -> Poll<Option<Self::Item>> {
+        Pin::new(&mut self.project().0).poll_next(cx)
+    }
+}
+
+/// Wrapper that wraps a bidirectional binary stream in a length delimited codec and postcard encoding
+/// to get a bidirectional stream of rpc Messages
+#[pin_project]
+pub struct FramedPostcardWrite<T, Out>(
+    #[pin]
+    tokio_serde::SymmetricallyFramed<
+        tokio_util::codec::FramedWrite<T, tokio_util::codec::LengthDelimitedCodec>,
+        Out,
+        tokio_serde_postcard::SymmetricalPostcard<Out>,
+    >,
+);
+
+impl<T: AsyncWrite, Out: Serialize> FramedPostcardWrite<T, Out> {
+    /// Wrap a socket in a length delimited codec and postcard encoding
+    pub fn new(inner: T, max_frame_length: usize) -> Self {
+        // configure length delimited codec with max frame length
+        let framing = LengthDelimitedCodec::builder()
+            .max_frame_length(max_frame_length)
+            .new_codec();
+        // create the actual framing. This turns the AsyncRead/AsyncWrite into a Stream/Sink of Bytes/BytesMut
+        let framed = tokio_util::codec::FramedWrite::new(inner, framing);
+        let postcard = tokio_serde_postcard::SymmetricalPostcard::new();
+        // create the actual framing. This turns the Stream/Sink of Bytes/BytesMut into a Stream/Sink of In/Out
+        let framed = tokio_serde::SymmetricallyFramed::new(framed, postcard);
+        Self(framed)
+    }
+}
+
+impl<T, Out> FramedPostcardWrite<T, Out> {
+    /// Get the underlying binary stream
+    ///
+    /// This can be useful if you want to drop the framing and use the underlying stream directly
+    /// after exchanging some messages.
+    pub fn into_inner(self) -> T {
+        self.0.into_inner().into_inner()
+    }
+}
+
+impl<T: AsyncWrite, Out: Serialize> Sink<Out> for FramedPostcardWrite<T, Out> {
+    type Error = std::io::Error;
+
+    fn poll_ready(
+        self: Pin<&mut Self>,
+        cx: &mut task::Context<'_>,
+    ) -> Poll<Result<(), Self::Error>> {
+        Pin::new(&mut self.project().0).poll_ready(cx)
+    }
+
+    fn start_send(self: Pin<&mut Self>, item: Out) -> Result<(), Self::Error> {
+        Pin::new(&mut self.project().0).start_send(item)
+    }
+
+    fn poll_flush(
+        self: Pin<&mut Self>,
+        cx: &mut task::Context<'_>,
+    ) -> Poll<Result<(), Self::Error>> {
+        Pin::new(&mut self.project().0).poll_flush(cx)
+    }
+
+    fn poll_close(
+        self: Pin<&mut Self>,
+        cx: &mut task::Context<'_>,
+    ) -> Poll<Result<(), Self::Error>> {
+        Pin::new(&mut self.project().0).poll_close(cx)
+    }
+}
+
+mod tokio_serde_postcard {
+    use std::{io, marker::PhantomData, pin::Pin};
+
+    use bytes::{BufMut as _, Bytes, BytesMut};
+    use pin_project::pin_project;
+    use serde::{Deserialize, Serialize};
+    use tokio_serde::{Deserializer, Serializer};
+
+    #[pin_project]
+    pub struct Postcard<Item, SinkItem> {
         #[pin]
-        inner: R,
-        buffer: SmallVec<[u8; 1024]>,
-        state: ReadState,
-        _phantom: PhantomData<In>,
+        buffer: Box<Option<BytesMut>>,
+        _marker: PhantomData<(Item, SinkItem)>,
     }
 
-    enum ReadState {
-        ReadingLength { buf: [u8; 4], read: usize },
-        ReadingData { len: usize, read: usize },
+    impl<Item, SinkItem> Default for Postcard<Item, SinkItem> {
+        fn default() -> Self {
+            Self::new()
+        }
     }
 
-    impl<R, In> FramedPostcardRead<R, In> {
-        /// Creates a new `FramedPostcardRead` with the provided `AsyncRead`.
-        pub fn new(inner: R, max_frame_size: usize) -> Self {
+    impl<Item, SinkItem> Postcard<Item, SinkItem> {
+        pub fn new() -> Self {
             Self {
-                inner,
-                buffer: SmallVec::new(),
-                state: ReadState::ReadingLength {
-                    buf: [0; 4],
-                    read: 0,
-                },
-                _phantom: PhantomData,
+                buffer: Box::new(None),
+                _marker: PhantomData,
             }
         }
+    }
 
-        pub fn into_inner(self) -> R {
-            self.inner
+    pub type SymmetricalPostcard<T> = Postcard<T, T>;
+
+    impl<Item, SinkItem> Deserializer<Item> for Postcard<Item, SinkItem>
+    where
+        for<'a> Item: Deserialize<'a>,
+    {
+        type Error = io::Error;
+
+        fn deserialize(self: Pin<&mut Self>, src: &BytesMut) -> Result<Item, Self::Error> {
+            postcard::from_bytes(&src)
+                .map_err(|err| io::Error::new(io::ErrorKind::InvalidData, err))
         }
     }
 
-    impl<R, In> Stream for FramedPostcardRead<R, In>
+    impl<Item, SinkItem> Serializer<SinkItem> for Postcard<Item, SinkItem>
     where
-        R: AsyncRead,
-        In: DeserializeOwned,
+        SinkItem: Serialize,
     {
-        type Item = Result<In, std::io::Error>;
+        type Error = io::Error;
 
-        fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        fn serialize(self: Pin<&mut Self>, data: &SinkItem) -> Result<Bytes, Self::Error> {
             let mut this = self.project();
-
-            loop {
-                match &mut this.state {
-                    ReadState::ReadingLength { buf, read } => {
-                        while *read < 4 {
-                            let mut read_buf = ReadBuf::new(&mut buf[*read..]);
-                            match this.inner.as_mut().poll_read(cx, &mut read_buf) {
-                                Poll::Ready(Ok(())) => {
-                                    let n = read_buf.filled().len();
-                                    if n == 0 {
-                                        if *read == 0 {
-                                            // EOF reached without reading any data.
-                                            return Poll::Ready(None);
-                                        } else {
-                                            return Poll::Ready(Some(Err(std::io::Error::new(
-                                                std::io::ErrorKind::UnexpectedEof,
-                                                "EOF while reading length prefix",
-                                            ))));
-                                        }
-                                    }
-                                    *read += n;
-                                }
-                                Poll::Ready(Err(e)) => return Poll::Ready(Some(Err(e))),
-                                Poll::Pending => return Poll::Pending,
-                            }
-                        }
-                        let len = u32::from_be_bytes(*buf) as usize;
-                        if len > (10 * 1024 * 1024) {
-                            // Arbitrary limit to prevent reading excessively large frames.
-                            return Poll::Ready(Some(Err(std::io::Error::new(
-                                std::io::ErrorKind::InvalidData,
-                                "Frame size too large",
-                            ))));
-                        }
-                        this.buffer.resize(len, 0);
-                        *this.state = ReadState::ReadingData { len, read: 0 };
-                    }
-                    ReadState::ReadingData { len, read } => {
-                        while *read < *len {
-                            let mut read_buf = ReadBuf::new(&mut this.buffer[*read..]);
-                            match this.inner.as_mut().poll_read(cx, &mut read_buf) {
-                                Poll::Ready(Ok(())) => {
-                                    let n = read_buf.filled().len();
-                                    if n == 0 {
-                                        return Poll::Ready(Some(Err(std::io::Error::new(
-                                            std::io::ErrorKind::UnexpectedEof,
-                                            "EOF while reading frame data",
-                                        ))));
-                                    }
-                                    *read += n;
-                                }
-                                Poll::Ready(Err(e)) => return Poll::Ready(Some(Err(e))),
-                                Poll::Pending => return Poll::Pending,
-                            }
-                        }
-                        // Deserialize the message using Postcard.
-                        let msg = postcard::from_bytes::<In>(&this.buffer)
-                            .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e))?;
-                        // Reset state for next message.
-                        *this.state = ReadState::ReadingLength {
-                            buf: [0; 4],
-                            read: 0,
-                        };
-                        this.buffer.clear();
-                        return Poll::Ready(Some(Ok(msg)));
-                    }
-                }
+            let buffer = this.buffer.take().unwrap_or_default();
+            let mut buffer = postcard::to_io(data, buffer.writer())
+                .map_err(|err| io::Error::new(io::ErrorKind::InvalidData, err))?
+                .into_inner();
+            if buffer.len() <= 1024 {
+                let res = buffer.split().freeze();
+                this.buffer.replace(buffer);
+                Ok(res)
+            } else {
+                Ok(buffer.freeze())
             }
         }
     }
 }
-
-pub use direct::*;

--- a/src/transport/util.rs
+++ b/src/transport/util.rs
@@ -3,16 +3,12 @@ use std::{
     task::{self, Poll},
 };
 
-use bincode::Options;
 use futures_lite::Stream;
 use futures_sink::Sink;
 use pin_project::pin_project;
 use serde::{de::DeserializeOwned, Serialize};
 use tokio::io::{AsyncRead, AsyncWrite};
 use tokio_util::codec::LengthDelimitedCodec;
-
-type BincodeEncoding =
-    bincode::config::WithOtherIntEncoding<bincode::DefaultOptions, bincode::config::FixintEncoding>;
 
 #[pin_project]
 pub struct FramedPostcardRead<T, In>(
@@ -25,7 +21,7 @@ pub struct FramedPostcardRead<T, In>(
 );
 
 impl<T: AsyncRead, In: DeserializeOwned> FramedPostcardRead<T, In> {
-    /// Wrap a socket in a length delimited codec and bincode with fast fixint encoding
+    /// Wrap a socket in a length delimited codec and postcard encoding
     pub fn new(inner: T, max_frame_length: usize) -> Self {
         // configure length delimited codec with max frame length
         let framing = LengthDelimitedCodec::builder()
@@ -58,7 +54,7 @@ impl<T: AsyncRead, In: DeserializeOwned> Stream for FramedPostcardRead<T, In> {
     }
 }
 
-/// Wrapper that wraps a bidirectional binary stream in a length delimited codec and bincode with fast fixint encoding
+/// Wrapper that wraps a bidirectional binary stream in a length delimited codec and postcard encoding
 /// to get a bidirectional stream of rpc Messages
 #[pin_project]
 pub struct FramedPostcardWrite<T, Out>(
@@ -71,7 +67,7 @@ pub struct FramedPostcardWrite<T, Out>(
 );
 
 impl<T: AsyncWrite, Out: Serialize> FramedPostcardWrite<T, Out> {
-    /// Wrap a socket in a length delimited codec and bincode with fast fixint encoding
+    /// Wrap a socket in a length delimited codec and postcard encoding
     pub fn new(inner: T, max_frame_length: usize) -> Self {
         // configure length delimited codec with max frame length
         let framing = LengthDelimitedCodec::builder()
@@ -79,9 +75,9 @@ impl<T: AsyncWrite, Out: Serialize> FramedPostcardWrite<T, Out> {
             .new_codec();
         // create the actual framing. This turns the AsyncRead/AsyncWrite into a Stream/Sink of Bytes/BytesMut
         let framed = tokio_util::codec::FramedWrite::new(inner, framing);
-        let bincode = tokio_serde_postcard::SymmetricalPostcard::new();
+        let postcard = tokio_serde_postcard::SymmetricalPostcard::new();
         // create the actual framing. This turns the Stream/Sink of Bytes/BytesMut into a Stream/Sink of In/Out
-        let framed = tokio_serde::SymmetricallyFramed::new(framed, bincode);
+        let framed = tokio_serde::SymmetricallyFramed::new(framed, postcard);
         Self(framed)
     }
 }
@@ -124,125 +120,3 @@ impl<T: AsyncWrite, Out: Serialize> Sink<Out> for FramedPostcardWrite<T, Out> {
         Pin::new(&mut self.project().0).poll_close(cx)
     }
 }
-
-/// Wrapper that wraps a bidirectional binary stream in a length delimited codec and bincode with fast fixint encoding
-/// to get a bidirectional stream of rpc Messages
-#[pin_project]
-pub struct FramedBincodeRead<T, In>(
-    #[pin]
-    tokio_serde::SymmetricallyFramed<
-        tokio_util::codec::FramedRead<T, tokio_util::codec::LengthDelimitedCodec>,
-        In,
-        tokio_serde::formats::SymmetricalBincode<In, BincodeEncoding>,
-    >,
-);
-
-impl<T: AsyncRead, In: DeserializeOwned> FramedBincodeRead<T, In> {
-    /// Wrap a socket in a length delimited codec and bincode with fast fixint encoding
-    pub fn new(inner: T, max_frame_length: usize) -> Self {
-        // configure length delimited codec with max frame length
-        let framing = LengthDelimitedCodec::builder()
-            .max_frame_length(max_frame_length)
-            .new_codec();
-        // create the actual framing. This turns the AsyncRead/AsyncWrite into a Stream/Sink of Bytes/BytesMut
-        let framed = tokio_util::codec::FramedRead::new(inner, framing);
-        // configure bincode with fixint encoding
-        let bincode_options: BincodeEncoding =
-            bincode::DefaultOptions::new().with_fixint_encoding();
-        let bincode = tokio_serde::formats::Bincode::from(bincode_options);
-        // create the actual framing. This turns the Stream/Sink of Bytes/BytesMut into a Stream/Sink of In/Out
-        let framed = tokio_serde::Framed::new(framed, bincode);
-        Self(framed)
-    }
-}
-
-impl<T, In> FramedBincodeRead<T, In> {
-    /// Get the underlying binary stream
-    ///
-    /// This can be useful if you want to drop the framing and use the underlying stream directly
-    /// after exchanging some messages.
-    pub fn into_inner(self) -> T {
-        self.0.into_inner().into_inner()
-    }
-}
-
-impl<T: AsyncRead, In: DeserializeOwned> Stream for FramedBincodeRead<T, In> {
-    type Item = Result<In, std::io::Error>;
-
-    fn poll_next(self: Pin<&mut Self>, cx: &mut task::Context<'_>) -> Poll<Option<Self::Item>> {
-        Pin::new(&mut self.project().0).poll_next(cx)
-    }
-}
-
-/// Wrapper that wraps a bidirectional binary stream in a length delimited codec and bincode with fast fixint encoding
-/// to get a bidirectional stream of rpc Messages
-#[pin_project]
-pub struct FramedBincodeWrite<T, Out>(
-    #[pin]
-    tokio_serde::SymmetricallyFramed<
-        tokio_util::codec::FramedWrite<T, tokio_util::codec::LengthDelimitedCodec>,
-        Out,
-        tokio_serde::formats::SymmetricalBincode<Out, BincodeEncoding>,
-    >,
-);
-
-impl<T: AsyncWrite, Out: Serialize> FramedBincodeWrite<T, Out> {
-    /// Wrap a socket in a length delimited codec and bincode with fast fixint encoding
-    pub fn new(inner: T, max_frame_length: usize) -> Self {
-        // configure length delimited codec with max frame length
-        let framing = LengthDelimitedCodec::builder()
-            .max_frame_length(max_frame_length)
-            .new_codec();
-        // create the actual framing. This turns the AsyncRead/AsyncWrite into a Stream/Sink of Bytes/BytesMut
-        let framed = tokio_util::codec::FramedWrite::new(inner, framing);
-        // configure bincode with fixint encoding
-        let bincode_options: BincodeEncoding =
-            bincode::DefaultOptions::new().with_fixint_encoding();
-        let bincode = tokio_serde::formats::SymmetricalBincode::from(bincode_options);
-        // create the actual framing. This turns the Stream/Sink of Bytes/BytesMut into a Stream/Sink of In/Out
-        let framed = tokio_serde::SymmetricallyFramed::new(framed, bincode);
-        Self(framed)
-    }
-}
-
-impl<T, Out> FramedBincodeWrite<T, Out> {
-    /// Get the underlying binary stream
-    ///
-    /// This can be useful if you want to drop the framing and use the underlying stream directly
-    /// after exchanging some messages.
-    pub fn into_inner(self) -> T {
-        self.0.into_inner().into_inner()
-    }
-}
-
-impl<T: AsyncWrite, Out: Serialize> Sink<Out> for FramedBincodeWrite<T, Out> {
-    type Error = std::io::Error;
-
-    fn poll_ready(
-        self: Pin<&mut Self>,
-        cx: &mut task::Context<'_>,
-    ) -> Poll<Result<(), Self::Error>> {
-        Pin::new(&mut self.project().0).poll_ready(cx)
-    }
-
-    fn start_send(self: Pin<&mut Self>, item: Out) -> Result<(), Self::Error> {
-        Pin::new(&mut self.project().0).start_send(item)
-    }
-
-    fn poll_flush(
-        self: Pin<&mut Self>,
-        cx: &mut task::Context<'_>,
-    ) -> Poll<Result<(), Self::Error>> {
-        Pin::new(&mut self.project().0).poll_flush(cx)
-    }
-
-    fn poll_close(
-        self: Pin<&mut Self>,
-        cx: &mut task::Context<'_>,
-    ) -> Poll<Result<(), Self::Error>> {
-        Pin::new(&mut self.project().0).poll_close(cx)
-    }
-}
-
-// fn assert_sink<T>(_: &impl Sink<T>) {}
-// fn assert_stream<T>(_: &impl Stream<Item = T>) {}

--- a/src/transport/util.rs
+++ b/src/transport/util.rs
@@ -1,189 +1,191 @@
-use std::{
-    pin::Pin,
-    task::{self, Poll},
-};
-
-use futures_lite::Stream;
-use futures_sink::Sink;
-use pin_project::pin_project;
-use serde::{de::DeserializeOwned, Serialize};
-use tokio::io::{AsyncRead, AsyncWrite};
-use tokio_util::codec::LengthDelimitedCodec;
-
-#[pin_project]
-pub struct FramedPostcardRead<T, In>(
-    #[pin]
-    tokio_serde::SymmetricallyFramed<
-        tokio_util::codec::FramedRead<T, tokio_util::codec::LengthDelimitedCodec>,
-        In,
-        tokio_serde_postcard::SymmetricalPostcard<In>,
-    >,
-);
-
-impl<T: AsyncRead, In: DeserializeOwned> FramedPostcardRead<T, In> {
-    /// Wrap a socket in a length delimited codec and postcard encoding
-    pub fn new(inner: T, max_frame_length: usize) -> Self {
-        // configure length delimited codec with max frame length
-        let framing = LengthDelimitedCodec::builder()
-            .max_frame_length(max_frame_length)
-            .new_codec();
-        // create the actual framing. This turns the AsyncRead/AsyncWrite into a Stream/Sink of Bytes/BytesMut
-        let framed = tokio_util::codec::FramedRead::new(inner, framing);
-        let postcard = tokio_serde_postcard::Postcard::new();
-        // create the actual framing. This turns the Stream/Sink of Bytes/BytesMut into a Stream/Sink of In/Out
-        let framed = tokio_serde::Framed::new(framed, postcard);
-        Self(framed)
-    }
-}
-
-impl<T, In> FramedPostcardRead<T, In> {
-    /// Get the underlying binary stream
-    ///
-    /// This can be useful if you want to drop the framing and use the underlying stream directly
-    /// after exchanging some messages.
-    pub fn into_inner(self) -> T {
-        self.0.into_inner().into_inner()
-    }
-}
-
-impl<T: AsyncRead, In: DeserializeOwned> Stream for FramedPostcardRead<T, In> {
-    type Item = Result<In, std::io::Error>;
-
-    fn poll_next(self: Pin<&mut Self>, cx: &mut task::Context<'_>) -> Poll<Option<Self::Item>> {
-        Pin::new(&mut self.project().0).poll_next(cx)
-    }
-}
-
-/// Wrapper that wraps a bidirectional binary stream in a length delimited codec and postcard encoding
-/// to get a bidirectional stream of rpc Messages
-#[pin_project]
-pub struct FramedPostcardWrite<T, Out>(
-    #[pin]
-    tokio_serde::SymmetricallyFramed<
-        tokio_util::codec::FramedWrite<T, tokio_util::codec::LengthDelimitedCodec>,
-        Out,
-        tokio_serde_postcard::SymmetricalPostcard<Out>,
-    >,
-);
-
-impl<T: AsyncWrite, Out: Serialize> FramedPostcardWrite<T, Out> {
-    /// Wrap a socket in a length delimited codec and postcard encoding
-    pub fn new(inner: T, max_frame_length: usize) -> Self {
-        // configure length delimited codec with max frame length
-        let framing = LengthDelimitedCodec::builder()
-            .max_frame_length(max_frame_length)
-            .new_codec();
-        // create the actual framing. This turns the AsyncRead/AsyncWrite into a Stream/Sink of Bytes/BytesMut
-        let framed = tokio_util::codec::FramedWrite::new(inner, framing);
-        let postcard = tokio_serde_postcard::SymmetricalPostcard::new();
-        // create the actual framing. This turns the Stream/Sink of Bytes/BytesMut into a Stream/Sink of In/Out
-        let framed = tokio_serde::SymmetricallyFramed::new(framed, postcard);
-        Self(framed)
-    }
-}
-
-impl<T, Out> FramedPostcardWrite<T, Out> {
-    /// Get the underlying binary stream
-    ///
-    /// This can be useful if you want to drop the framing and use the underlying stream directly
-    /// after exchanging some messages.
-    pub fn into_inner(self) -> T {
-        self.0.into_inner().into_inner()
-    }
-}
-
-impl<T: AsyncWrite, Out: Serialize> Sink<Out> for FramedPostcardWrite<T, Out> {
-    type Error = std::io::Error;
-
-    fn poll_ready(
-        self: Pin<&mut Self>,
-        cx: &mut task::Context<'_>,
-    ) -> Poll<Result<(), Self::Error>> {
-        Pin::new(&mut self.project().0).poll_ready(cx)
-    }
-
-    fn start_send(self: Pin<&mut Self>, item: Out) -> Result<(), Self::Error> {
-        Pin::new(&mut self.project().0).start_send(item)
-    }
-
-    fn poll_flush(
-        self: Pin<&mut Self>,
-        cx: &mut task::Context<'_>,
-    ) -> Poll<Result<(), Self::Error>> {
-        Pin::new(&mut self.project().0).poll_flush(cx)
-    }
-
-    fn poll_close(
-        self: Pin<&mut Self>,
-        cx: &mut task::Context<'_>,
-    ) -> Poll<Result<(), Self::Error>> {
-        Pin::new(&mut self.project().0).poll_close(cx)
-    }
-}
-
-mod tokio_serde_postcard {
-    use {
-        bytes::{BufMut as _, Bytes, BytesMut},
-        pin_project::pin_project,
-        serde::{Deserialize, Serialize},
-        std::{io, marker::PhantomData, pin::Pin},
-        tokio_serde::{Deserializer, Serializer},
+mod deps {
+    use std::{
+        pin::Pin,
+        task::{self, Poll},
     };
 
-    #[pin_project]
-    pub struct Postcard<Item, SinkItem> {
-        #[pin]
-        buffer: Box<Option<BytesMut>>,
-        _marker: PhantomData<(Item, SinkItem)>,
-    }
+    use futures_lite::Stream;
+    use futures_sink::Sink;
+    use pin_project::pin_project;
+    use serde::{de::DeserializeOwned, Serialize};
+    use tokio::io::{AsyncRead, AsyncWrite};
+    use tokio_util::codec::LengthDelimitedCodec;
 
-    impl<Item, SinkItem> Default for Postcard<Item, SinkItem> {
-        fn default() -> Self {
-            Self::new()
+    #[pin_project]
+    pub struct FramedPostcardRead<T, In>(
+        #[pin]
+        tokio_serde::SymmetricallyFramed<
+            tokio_util::codec::FramedRead<T, tokio_util::codec::LengthDelimitedCodec>,
+            In,
+            tokio_serde_postcard::SymmetricalPostcard<In>,
+        >,
+    );
+
+    impl<T: AsyncRead, In: DeserializeOwned> FramedPostcardRead<T, In> {
+        /// Wrap a socket in a length delimited codec and postcard encoding
+        pub fn new(inner: T, max_frame_length: usize) -> Self {
+            // configure length delimited codec with max frame length
+            let framing = LengthDelimitedCodec::builder()
+                .max_frame_length(max_frame_length)
+                .new_codec();
+            // create the actual framing. This turns the AsyncRead/AsyncWrite into a Stream/Sink of Bytes/BytesMut
+            let framed = tokio_util::codec::FramedRead::new(inner, framing);
+            let postcard = tokio_serde_postcard::Postcard::new();
+            // create the actual framing. This turns the Stream/Sink of Bytes/BytesMut into a Stream/Sink of In/Out
+            let framed = tokio_serde::Framed::new(framed, postcard);
+            Self(framed)
         }
     }
 
-    impl<Item, SinkItem> Postcard<Item, SinkItem> {
-        pub fn new() -> Self {
-            Self {
-                buffer: Box::new(None),
-                _marker: PhantomData,
+    impl<T, In> FramedPostcardRead<T, In> {
+        /// Get the underlying binary stream
+        ///
+        /// This can be useful if you want to drop the framing and use the underlying stream directly
+        /// after exchanging some messages.
+        pub fn into_inner(self) -> T {
+            self.0.into_inner().into_inner()
+        }
+    }
+
+    impl<T: AsyncRead, In: DeserializeOwned> Stream for FramedPostcardRead<T, In> {
+        type Item = Result<In, std::io::Error>;
+
+        fn poll_next(self: Pin<&mut Self>, cx: &mut task::Context<'_>) -> Poll<Option<Self::Item>> {
+            Pin::new(&mut self.project().0).poll_next(cx)
+        }
+    }
+
+    /// Wrapper that wraps a bidirectional binary stream in a length delimited codec and postcard encoding
+    /// to get a bidirectional stream of rpc Messages
+    #[pin_project]
+    pub struct FramedPostcardWrite<T, Out>(
+        #[pin]
+        tokio_serde::SymmetricallyFramed<
+            tokio_util::codec::FramedWrite<T, tokio_util::codec::LengthDelimitedCodec>,
+            Out,
+            tokio_serde_postcard::SymmetricalPostcard<Out>,
+        >,
+    );
+
+    impl<T: AsyncWrite, Out: Serialize> FramedPostcardWrite<T, Out> {
+        /// Wrap a socket in a length delimited codec and postcard encoding
+        pub fn new(inner: T, max_frame_length: usize) -> Self {
+            // configure length delimited codec with max frame length
+            let framing = LengthDelimitedCodec::builder()
+                .max_frame_length(max_frame_length)
+                .new_codec();
+            // create the actual framing. This turns the AsyncRead/AsyncWrite into a Stream/Sink of Bytes/BytesMut
+            let framed = tokio_util::codec::FramedWrite::new(inner, framing);
+            let postcard = tokio_serde_postcard::SymmetricalPostcard::new();
+            // create the actual framing. This turns the Stream/Sink of Bytes/BytesMut into a Stream/Sink of In/Out
+            let framed = tokio_serde::SymmetricallyFramed::new(framed, postcard);
+            Self(framed)
+        }
+    }
+
+    impl<T, Out> FramedPostcardWrite<T, Out> {
+        /// Get the underlying binary stream
+        ///
+        /// This can be useful if you want to drop the framing and use the underlying stream directly
+        /// after exchanging some messages.
+        pub fn into_inner(self) -> T {
+            self.0.into_inner().into_inner()
+        }
+    }
+
+    impl<T: AsyncWrite, Out: Serialize> Sink<Out> for FramedPostcardWrite<T, Out> {
+        type Error = std::io::Error;
+
+        fn poll_ready(
+            self: Pin<&mut Self>,
+            cx: &mut task::Context<'_>,
+        ) -> Poll<Result<(), Self::Error>> {
+            Pin::new(&mut self.project().0).poll_ready(cx)
+        }
+
+        fn start_send(self: Pin<&mut Self>, item: Out) -> Result<(), Self::Error> {
+            Pin::new(&mut self.project().0).start_send(item)
+        }
+
+        fn poll_flush(
+            self: Pin<&mut Self>,
+            cx: &mut task::Context<'_>,
+        ) -> Poll<Result<(), Self::Error>> {
+            Pin::new(&mut self.project().0).poll_flush(cx)
+        }
+
+        fn poll_close(
+            self: Pin<&mut Self>,
+            cx: &mut task::Context<'_>,
+        ) -> Poll<Result<(), Self::Error>> {
+            Pin::new(&mut self.project().0).poll_close(cx)
+        }
+    }
+
+    mod tokio_serde_postcard {
+        use {
+            bytes::{BufMut as _, Bytes, BytesMut},
+            pin_project::pin_project,
+            serde::{Deserialize, Serialize},
+            std::{io, marker::PhantomData, pin::Pin},
+            tokio_serde::{Deserializer, Serializer},
+        };
+
+        #[pin_project]
+        pub struct Postcard<Item, SinkItem> {
+            #[pin]
+            buffer: Box<Option<BytesMut>>,
+            _marker: PhantomData<(Item, SinkItem)>,
+        }
+
+        impl<Item, SinkItem> Default for Postcard<Item, SinkItem> {
+            fn default() -> Self {
+                Self::new()
             }
         }
-    }
 
-    pub type SymmetricalPostcard<T> = Postcard<T, T>;
-
-    impl<Item, SinkItem> Deserializer<Item> for Postcard<Item, SinkItem>
-    where
-        for<'a> Item: Deserialize<'a>,
-    {
-        type Error = io::Error;
-
-        fn deserialize(self: Pin<&mut Self>, src: &BytesMut) -> Result<Item, Self::Error> {
-            postcard::from_bytes(&src)
-                .map_err(|err| io::Error::new(io::ErrorKind::InvalidData, err))
+        impl<Item, SinkItem> Postcard<Item, SinkItem> {
+            pub fn new() -> Self {
+                Self {
+                    buffer: Box::new(None),
+                    _marker: PhantomData,
+                }
+            }
         }
-    }
 
-    impl<Item, SinkItem> Serializer<SinkItem> for Postcard<Item, SinkItem>
-    where
-        SinkItem: Serialize,
-    {
-        type Error = io::Error;
+        pub type SymmetricalPostcard<T> = Postcard<T, T>;
 
-        fn serialize(self: Pin<&mut Self>, data: &SinkItem) -> Result<Bytes, Self::Error> {
-            let mut this = self.project();
-            let buffer = this.buffer.take().unwrap_or_default();
-            let mut buffer = postcard::to_io(data, buffer.writer())
-                .map_err(|err| io::Error::new(io::ErrorKind::InvalidData, err))?
-                .into_inner();
-            if buffer.len() <= 1024 {
-                let res = buffer.split().freeze();
-                this.buffer.replace(buffer);
-                Ok(res)
-            } else {
-                Ok(buffer.freeze())
+        impl<Item, SinkItem> Deserializer<Item> for Postcard<Item, SinkItem>
+        where
+            for<'a> Item: Deserialize<'a>,
+        {
+            type Error = io::Error;
+
+            fn deserialize(self: Pin<&mut Self>, src: &BytesMut) -> Result<Item, Self::Error> {
+                postcard::from_bytes(&src)
+                    .map_err(|err| io::Error::new(io::ErrorKind::InvalidData, err))
+            }
+        }
+
+        impl<Item, SinkItem> Serializer<SinkItem> for Postcard<Item, SinkItem>
+        where
+            SinkItem: Serialize,
+        {
+            type Error = io::Error;
+
+            fn serialize(self: Pin<&mut Self>, data: &SinkItem) -> Result<Bytes, Self::Error> {
+                let mut this = self.project();
+                let buffer = this.buffer.take().unwrap_or_default();
+                let mut buffer = postcard::to_io(data, buffer.writer())
+                    .map_err(|err| io::Error::new(io::ErrorKind::InvalidData, err))?
+                    .into_inner();
+                if buffer.len() <= 1024 {
+                    let res = buffer.split().freeze();
+                    this.buffer.replace(buffer);
+                    Ok(res)
+                } else {
+                    Ok(buffer.freeze())
+                }
             }
         }
     }
@@ -213,19 +215,23 @@ mod direct {
         _phantom: PhantomData<Out>,
     }
 
-    impl<W, Out> FramedPostcardWrite<W, Out>
-    where
-        W: AsyncWrite,
-        Out: Serialize,
-    {
+    impl<W, Out> FramedPostcardWrite<W, Out> {
         /// Creates a new `FramedPostcardWrite` with the provided `AsyncWrite`.
-        pub fn new(inner: W) -> Self {
+        pub fn new(inner: W, max_frame_size: usize) -> Self
+        where
+            W: AsyncWrite,
+            Out: Serialize,
+        {
             Self {
                 inner,
                 buffer: SmallVec::new(),
                 written: 0,
                 _phantom: PhantomData,
             }
+        }
+
+        pub fn into_inner(self) -> W {
+            self.inner
         }
     }
 
@@ -327,12 +333,9 @@ mod direct {
         ReadingData { len: usize, read: usize },
     }
 
-    impl<R, In> FramedPostcardRead<R, In>
-    where
-        R: AsyncRead,
-    {
+    impl<R, In> FramedPostcardRead<R, In> {
         /// Creates a new `FramedPostcardRead` with the provided `AsyncRead`.
-        pub fn new(inner: R) -> Self {
+        pub fn new(inner: R, max_frame_size: usize) -> Self {
             Self {
                 inner,
                 buffer: SmallVec::new(),
@@ -342,6 +345,10 @@ mod direct {
                 },
                 _phantom: PhantomData,
             }
+        }
+
+        pub fn into_inner(self) -> R {
+            self.inner
         }
     }
 
@@ -425,3 +432,5 @@ mod direct {
         }
     }
 }
+
+pub use direct::*;

--- a/src/transport/util.rs
+++ b/src/transport/util.rs
@@ -13,6 +13,118 @@ use tokio_util::codec::LengthDelimitedCodec;
 
 type BincodeEncoding =
     bincode::config::WithOtherIntEncoding<bincode::DefaultOptions, bincode::config::FixintEncoding>;
+
+#[pin_project]
+pub struct FramedPostcardRead<T, In>(
+    #[pin]
+    tokio_serde::SymmetricallyFramed<
+        tokio_util::codec::FramedRead<T, tokio_util::codec::LengthDelimitedCodec>,
+        In,
+        tokio_serde_postcard::SymmetricalPostcard<In>,
+    >,
+);
+
+impl<T: AsyncRead, In: DeserializeOwned> FramedPostcardRead<T, In> {
+    /// Wrap a socket in a length delimited codec and bincode with fast fixint encoding
+    pub fn new(inner: T, max_frame_length: usize) -> Self {
+        // configure length delimited codec with max frame length
+        let framing = LengthDelimitedCodec::builder()
+            .max_frame_length(max_frame_length)
+            .new_codec();
+        // create the actual framing. This turns the AsyncRead/AsyncWrite into a Stream/Sink of Bytes/BytesMut
+        let framed = tokio_util::codec::FramedRead::new(inner, framing);
+        let postcard = tokio_serde_postcard::Postcard::new();
+        // create the actual framing. This turns the Stream/Sink of Bytes/BytesMut into a Stream/Sink of In/Out
+        let framed = tokio_serde::Framed::new(framed, postcard);
+        Self(framed)
+    }
+}
+
+impl<T, In> FramedPostcardRead<T, In> {
+    /// Get the underlying binary stream
+    ///
+    /// This can be useful if you want to drop the framing and use the underlying stream directly
+    /// after exchanging some messages.
+    pub fn into_inner(self) -> T {
+        self.0.into_inner().into_inner()
+    }
+}
+
+impl<T: AsyncRead, In: DeserializeOwned> Stream for FramedPostcardRead<T, In> {
+    type Item = Result<In, std::io::Error>;
+
+    fn poll_next(self: Pin<&mut Self>, cx: &mut task::Context<'_>) -> Poll<Option<Self::Item>> {
+        Pin::new(&mut self.project().0).poll_next(cx)
+    }
+}
+
+/// Wrapper that wraps a bidirectional binary stream in a length delimited codec and bincode with fast fixint encoding
+/// to get a bidirectional stream of rpc Messages
+#[pin_project]
+pub struct FramedPostcardWrite<T, Out>(
+    #[pin]
+    tokio_serde::SymmetricallyFramed<
+        tokio_util::codec::FramedWrite<T, tokio_util::codec::LengthDelimitedCodec>,
+        Out,
+        tokio_serde_postcard::SymmetricalPostcard<Out>,
+    >,
+);
+
+impl<T: AsyncWrite, Out: Serialize> FramedPostcardWrite<T, Out> {
+    /// Wrap a socket in a length delimited codec and bincode with fast fixint encoding
+    pub fn new(inner: T, max_frame_length: usize) -> Self {
+        // configure length delimited codec with max frame length
+        let framing = LengthDelimitedCodec::builder()
+            .max_frame_length(max_frame_length)
+            .new_codec();
+        // create the actual framing. This turns the AsyncRead/AsyncWrite into a Stream/Sink of Bytes/BytesMut
+        let framed = tokio_util::codec::FramedWrite::new(inner, framing);
+        let bincode = tokio_serde_postcard::SymmetricalPostcard::new();
+        // create the actual framing. This turns the Stream/Sink of Bytes/BytesMut into a Stream/Sink of In/Out
+        let framed = tokio_serde::SymmetricallyFramed::new(framed, bincode);
+        Self(framed)
+    }
+}
+
+impl<T, Out> FramedPostcardWrite<T, Out> {
+    /// Get the underlying binary stream
+    ///
+    /// This can be useful if you want to drop the framing and use the underlying stream directly
+    /// after exchanging some messages.
+    pub fn into_inner(self) -> T {
+        self.0.into_inner().into_inner()
+    }
+}
+
+impl<T: AsyncWrite, Out: Serialize> Sink<Out> for FramedPostcardWrite<T, Out> {
+    type Error = std::io::Error;
+
+    fn poll_ready(
+        self: Pin<&mut Self>,
+        cx: &mut task::Context<'_>,
+    ) -> Poll<Result<(), Self::Error>> {
+        Pin::new(&mut self.project().0).poll_ready(cx)
+    }
+
+    fn start_send(self: Pin<&mut Self>, item: Out) -> Result<(), Self::Error> {
+        Pin::new(&mut self.project().0).start_send(item)
+    }
+
+    fn poll_flush(
+        self: Pin<&mut Self>,
+        cx: &mut task::Context<'_>,
+    ) -> Poll<Result<(), Self::Error>> {
+        Pin::new(&mut self.project().0).poll_flush(cx)
+    }
+
+    fn poll_close(
+        self: Pin<&mut Self>,
+        cx: &mut task::Context<'_>,
+    ) -> Poll<Result<(), Self::Error>> {
+        Pin::new(&mut self.project().0).poll_close(cx)
+    }
+}
+
 /// Wrapper that wraps a bidirectional binary stream in a length delimited codec and bincode with fast fixint encoding
 /// to get a bidirectional stream of rpc Messages
 #[pin_project]

--- a/src/transport/util.rs
+++ b/src/transport/util.rs
@@ -188,3 +188,240 @@ mod tokio_serde_postcard {
         }
     }
 }
+
+mod direct {
+    use futures_lite::{ready, Stream};
+    use futures_sink::Sink;
+    use pin_project::pin_project;
+    use postcard;
+    use serde::de::DeserializeOwned;
+    use serde::Serialize;
+    use smallvec::SmallVec;
+    use std::marker::PhantomData;
+    use std::pin::Pin;
+    use std::task::{Context, Poll};
+    use tokio::io::{AsyncRead, AsyncWrite, ReadBuf}; // Ensure the postcard crate is included in your Cargo.toml
+
+    #[pin_project]
+    /// A Sink that encodes messages into a framed stream with 32-bit big-endian length prefixes,
+    /// using Postcard for serialization.
+    pub struct FramedPostcardWrite<W, Out> {
+        #[pin]
+        inner: W,
+        buffer: SmallVec<[u8; 1024]>,
+        written: usize,
+        _phantom: PhantomData<Out>,
+    }
+
+    impl<W, Out> FramedPostcardWrite<W, Out>
+    where
+        W: AsyncWrite,
+        Out: Serialize,
+    {
+        /// Creates a new `FramedPostcardWrite` with the provided `AsyncWrite`.
+        pub fn new(inner: W) -> Self {
+            Self {
+                inner,
+                buffer: SmallVec::new(),
+                written: 0,
+                _phantom: PhantomData,
+            }
+        }
+    }
+
+    impl<W, Out> Sink<Out> for FramedPostcardWrite<W, Out>
+    where
+        W: AsyncWrite,
+        Out: Serialize,
+    {
+        type Error = std::io::Error;
+
+        fn poll_ready(
+            self: Pin<&mut Self>,
+            _cx: &mut Context<'_>,
+        ) -> Poll<Result<(), Self::Error>> {
+            // Always ready to accept data.
+            Poll::Ready(Ok(()))
+        }
+
+        fn start_send(self: Pin<&mut Self>, item: Out) -> Result<(), Self::Error> {
+            let this = self.project();
+
+            // Serialize the item using Postcard.
+            let data = postcard::to_stdvec(&item).map_err(|e| {
+                std::io::Error::new(
+                    std::io::ErrorKind::InvalidData,
+                    format!("Serialization error: {}", e),
+                )
+            })?;
+            let len = data.len();
+
+            if len > u32::MAX as usize {
+                return Err(std::io::Error::new(
+                    std::io::ErrorKind::InvalidInput,
+                    "Item too large",
+                ));
+            }
+
+            // Encode length prefix in big-endian format.
+            let len_u32 = len as u32;
+            this.buffer.extend_from_slice(&len_u32.to_be_bytes());
+            this.buffer.extend_from_slice(&data);
+
+            Ok(())
+        }
+
+        fn poll_flush(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+            let mut this = self.project();
+
+            while *this.written < this.buffer.len() {
+                match this
+                    .inner
+                    .as_mut()
+                    .poll_write(cx, &this.buffer[*this.written..])
+                {
+                    Poll::Ready(Ok(0)) => {
+                        return Poll::Ready(Err(std::io::Error::new(
+                            std::io::ErrorKind::WriteZero,
+                            "Failed to write data",
+                        )));
+                    }
+                    Poll::Ready(Ok(n)) => *this.written += n,
+                    Poll::Ready(Err(e)) => return Poll::Ready(Err(e)),
+                    Poll::Pending => return Poll::Pending,
+                }
+            }
+
+            // Clear the buffer once all data is written.
+            this.buffer.clear();
+            *this.written = 0;
+
+            // Ensure the inner writer is flushed.
+            this.inner.as_mut().poll_flush(cx)
+        }
+
+        fn poll_close(
+            mut self: Pin<&mut Self>,
+            cx: &mut Context<'_>,
+        ) -> Poll<Result<(), Self::Error>> {
+            // Flush any remaining data and close the inner writer.
+            ready!(self.as_mut().poll_flush(cx))?;
+            self.project().inner.poll_shutdown(cx)
+        }
+    }
+
+    #[pin_project]
+    /// A Stream that reads framed messages from an AsyncRead, deserializing them using Postcard.
+    ///
+    /// Each message is expected to be prefixed with a 32-bit big-endian length field.
+    pub struct FramedPostcardRead<R, In> {
+        #[pin]
+        inner: R,
+        buffer: SmallVec<[u8; 1024]>,
+        state: ReadState,
+        _phantom: PhantomData<In>,
+    }
+
+    enum ReadState {
+        ReadingLength { buf: [u8; 4], read: usize },
+        ReadingData { len: usize, read: usize },
+    }
+
+    impl<R, In> FramedPostcardRead<R, In>
+    where
+        R: AsyncRead,
+    {
+        /// Creates a new `FramedPostcardRead` with the provided `AsyncRead`.
+        pub fn new(inner: R) -> Self {
+            Self {
+                inner,
+                buffer: SmallVec::new(),
+                state: ReadState::ReadingLength {
+                    buf: [0; 4],
+                    read: 0,
+                },
+                _phantom: PhantomData,
+            }
+        }
+    }
+
+    impl<R, In> Stream for FramedPostcardRead<R, In>
+    where
+        R: AsyncRead,
+        In: DeserializeOwned,
+    {
+        type Item = Result<In, std::io::Error>;
+
+        fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+            let mut this = self.project();
+
+            loop {
+                match &mut this.state {
+                    ReadState::ReadingLength { buf, read } => {
+                        while *read < 4 {
+                            let mut read_buf = ReadBuf::new(&mut buf[*read..]);
+                            match this.inner.as_mut().poll_read(cx, &mut read_buf) {
+                                Poll::Ready(Ok(())) => {
+                                    let n = read_buf.filled().len();
+                                    if n == 0 {
+                                        if *read == 0 {
+                                            // EOF reached without reading any data.
+                                            return Poll::Ready(None);
+                                        } else {
+                                            return Poll::Ready(Some(Err(std::io::Error::new(
+                                                std::io::ErrorKind::UnexpectedEof,
+                                                "EOF while reading length prefix",
+                                            ))));
+                                        }
+                                    }
+                                    *read += n;
+                                }
+                                Poll::Ready(Err(e)) => return Poll::Ready(Some(Err(e))),
+                                Poll::Pending => return Poll::Pending,
+                            }
+                        }
+                        let len = u32::from_be_bytes(*buf) as usize;
+                        if len > (10 * 1024 * 1024) {
+                            // Arbitrary limit to prevent reading excessively large frames.
+                            return Poll::Ready(Some(Err(std::io::Error::new(
+                                std::io::ErrorKind::InvalidData,
+                                "Frame size too large",
+                            ))));
+                        }
+                        this.buffer.resize(len, 0);
+                        *this.state = ReadState::ReadingData { len, read: 0 };
+                    }
+                    ReadState::ReadingData { len, read } => {
+                        while *read < *len {
+                            let mut read_buf = ReadBuf::new(&mut this.buffer[*read..]);
+                            match this.inner.as_mut().poll_read(cx, &mut read_buf) {
+                                Poll::Ready(Ok(())) => {
+                                    let n = read_buf.filled().len();
+                                    if n == 0 {
+                                        return Poll::Ready(Some(Err(std::io::Error::new(
+                                            std::io::ErrorKind::UnexpectedEof,
+                                            "EOF while reading frame data",
+                                        ))));
+                                    }
+                                    *read += n;
+                                }
+                                Poll::Ready(Err(e)) => return Poll::Ready(Some(Err(e))),
+                                Poll::Pending => return Poll::Pending,
+                            }
+                        }
+                        // Deserialize the message using Postcard.
+                        let msg = postcard::from_bytes::<In>(&this.buffer)
+                            .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e))?;
+                        // Reset state for next message.
+                        *this.state = ReadState::ReadingLength {
+                            buf: [0; 4],
+                            read: 0,
+                        };
+                        this.buffer.clear();
+                        return Poll::Ready(Some(Ok(msg)));
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/transport/util.rs
+++ b/src/transport/util.rs
@@ -160,8 +160,7 @@ mod tokio_serde_postcard {
         type Error = io::Error;
 
         fn deserialize(self: Pin<&mut Self>, src: &BytesMut) -> Result<Item, Self::Error> {
-            postcard::from_bytes(&src)
-                .map_err(|err| io::Error::new(io::ErrorKind::InvalidData, err))
+            postcard::from_bytes(src).map_err(|err| io::Error::new(io::ErrorKind::InvalidData, err))
         }
     }
 

--- a/tests/hyper.rs
+++ b/tests/hyper.rs
@@ -1,4 +1,5 @@
 #![cfg(feature = "hyper-transport")]
+#![cfg(feature = "macros")]
 use std::{assert, net::SocketAddr, result};
 
 use ::hyper::Uri;


### PR DESCRIPTION
Implements https://github.com/n0-computer/quic-rpc/issues/108

Not sure about this. I like postcard because of the simplicity, but there is a slight perf decrease:

quinn transport:

main:

RPC seq 24_188 rps                                                              
RPC par 204_800 rps                                                             
bidi seq 303_453 rps 

this branch:

RPC seq 23_582 rps                                                              
RPC par 198_579 rps                                                             
bidi seq 254_606 rps

hyper transport:

main:

RPC seq 16_149 rps
RPC par 73_340 rps
bidi seq 535_791 rps

this branch:

RPC seq 15_223 rps
RPC par 73_061 rps
bidi seq 531_071 rps

Probably not worth obsessing about though. Pretty sure byte arrays will perform similarly in both cases. And I saw that toko-serde allocates a Bytes for every single item being deserialized. So there is some perf improvement to be had there...