### PR TITLE
chore: introduce a .rustfmt.toml file with configs for  automatic formatting

### DIFF
--- a/.rustfmt.toml
+++ b/.rustfmt.toml
@@ -1,0 +1,15 @@
+edition                     = "2024"
+unstable_features           = true
+imports_granularity         = "Crate"
+group_imports               = "StdExternalCrate"
+reorder_imports             = true
+format_code_in_doc_comments = true
+force_explicit_abi          = true
+max_width                   = 100
+merge_derives               = true
+newline_style               = "Unix"
+remove_nested_parens        = true
+reorder_modules             = true
+use_field_init_shorthand    = false
+use_small_heuristics        = "Default"
+use_try_shorthand           = false


### PR DESCRIPTION
Based on https://github.com/n0-computer/quic-rpc/pull/113 with some other tweaks. All files already formatted, just introducing this config file so we have a more normalized formatting.