### PR TITLE
feat: Accept handler

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ quinn = { package = "iroh-quinn", version = "0.12", optional = true }
 serde = { version = "1.0.183", features = ["derive"] }
 tokio = { version = "1", default-features = false, features = ["macros", "sync"] }
 tokio-serde = { version = "0.8", features = ["bincode"], optional = true }
-tokio-util = { version = "0.7", features = ["codec"], optional = true }
+tokio-util = { version = "0.7", features = ["rt"] }
 tracing = "0.1"
 hex = "0.4.3"
 futures = { version = "0.3.30", optional = true }
@@ -52,12 +52,13 @@ proc-macro2 = "1.0.66"
 futures-buffered = "0.2.4"
 testresult = "0.4.1"
 nested_enum_utils = "0.1.0"
+tokio-util = { version = "0.7", features = ["rt"] }
 
 [features]
-hyper-transport = ["dep:flume", "dep:hyper", "dep:bincode", "dep:bytes", "dep:tokio-serde", "dep:tokio-util"]
-quinn-transport = ["dep:flume", "dep:quinn", "dep:bincode", "dep:tokio-serde", "dep:tokio-util"]
+hyper-transport = ["dep:flume", "dep:hyper", "dep:bincode", "dep:bytes", "dep:tokio-serde", "tokio-util/codec"]
+quinn-transport = ["dep:flume", "dep:quinn", "dep:bincode", "dep:tokio-serde", "tokio-util/codec"]
 flume-transport = ["dep:flume"]
-iroh-net-transport = ["dep:iroh-net", "dep:flume", "dep:quinn", "dep:bincode", "dep:tokio-serde", "dep:tokio-util"]
+iroh-net-transport = ["dep:iroh-net", "dep:flume", "dep:quinn", "dep:bincode", "dep:tokio-serde", "tokio-util/codec"]
 macros = []
 default = ["flume-transport"]
 

--- a/tests/iroh-net.rs
+++ b/tests/iroh-net.rs
@@ -2,10 +2,13 @@
 
 use iroh_net::{key::SecretKey, NodeAddr};
 use quic_rpc::{transport, RpcClient, RpcServer};
-use tokio::task::JoinHandle;
+use testresult::TestResult;
+
+use crate::transport::iroh_net::{IrohNetConnector, IrohNetListener};
 
 mod math;
 use math::*;
+use tokio_util::task::AbortOnDropHandle;
 mod util;
 
 const ALPN: &[u8] = b"quic-rpc/iroh-net/test";
@@ -44,13 +47,10 @@ impl Endpoints {
     }
 }
 
-fn run_server(server: iroh_net::Endpoint) -> JoinHandle<anyhow::Result<()>> {
-    tokio::task::spawn(async move {
-        let connection = transport::iroh_net::IrohNetListener::new(server)?;
-        let server = RpcServer::new(connection);
-        ComputeService::server(server).await?;
-        anyhow::Ok(())
-    })
+fn run_server(server: iroh_net::Endpoint) -> AbortOnDropHandle<()> {
+    let connection = IrohNetListener::new(server).unwrap();
+    let server = RpcServer::new(connection);
+    ComputeService::server(server)
 }
 
 // #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
@@ -64,17 +64,12 @@ async fn iroh_net_channel_bench() -> anyhow::Result<()> {
         server_node_addr,
     } = Endpoints::new().await?;
     tracing::debug!("Starting server");
-    let server_handle = run_server(server);
+    let _server_handle = run_server(server);
     tracing::debug!("Starting client");
 
-    let client = RpcClient::new(transport::iroh_net::IrohNetConnector::new(
-        client,
-        server_node_addr,
-        ALPN.into(),
-    ));
+    let client = RpcClient::new(IrohNetConnector::new(client, server_node_addr, ALPN.into()));
     tracing::debug!("Starting benchmark");
     bench(client, 50000).await?;
-    server_handle.abort();
     Ok(())
 }
 
@@ -86,11 +81,9 @@ async fn iroh_net_channel_smoke() -> anyhow::Result<()> {
         server,
         server_node_addr,
     } = Endpoints::new().await?;
-    let server_handle = run_server(server);
-    let client_connection =
-        transport::iroh_net::IrohNetConnector::new(client, server_node_addr, ALPN.into());
+    let _server_handle = run_server(server);
+    let client_connection = IrohNetConnector::new(client, server_node_addr, ALPN.into());
     smoke_test(client_connection).await?;
-    server_handle.abort();
     Ok(())
 }
 
@@ -99,7 +92,7 @@ async fn iroh_net_channel_smoke() -> anyhow::Result<()> {
 ///
 /// This is a regression test.
 #[tokio::test]
-async fn server_away_and_back() -> anyhow::Result<()> {
+async fn server_away_and_back() -> TestResult<()> {
     tracing_subscriber::fmt::try_init().ok();
     tracing::info!("Creating endpoints");
 
@@ -128,7 +121,7 @@ async fn server_away_and_back() -> anyhow::Result<()> {
     // create the RPC Server
     let connection = transport::iroh_net::IrohNetListener::new(server_endpoint.clone())?;
     let server = RpcServer::new(connection);
-    let server_handle = tokio::task::spawn(ComputeService::server_bounded(server, 1));
+    let server_handle = tokio::spawn(ComputeService::server_bounded(server, 1));
 
     // wait a bit for connection due to Windows test failing on CI
     tokio::time::sleep(tokio::time::Duration::from_millis(300)).await;
@@ -151,7 +144,7 @@ async fn server_away_and_back() -> anyhow::Result<()> {
     // make the server run again
     let connection = transport::iroh_net::IrohNetListener::new(server_endpoint.clone())?;
     let server = RpcServer::new(connection);
-    let server_handle = tokio::task::spawn(ComputeService::server_bounded(server, 5));
+    let server_handle = tokio::spawn(ComputeService::server_bounded(server, 5));
 
     // wait a bit for connection due to Windows test failing on CI
     tokio::time::sleep(tokio::time::Duration::from_millis(300)).await;
@@ -163,7 +156,6 @@ async fn server_away_and_back() -> anyhow::Result<()> {
     // server is running, this should work
     let SqrResponse(response) = client.rpc(Sqr(3)).await?;
     assert_eq!(response, 9);
-
     server_handle.abort();
     Ok(())
 }


### PR DESCRIPTION
This adds a fn to RpcServer to run an accept loop, as well as a fn that spawns an accept loop.

This is to DRY the various places where we now have accept loops, such as

https://github.com/n0-computer/iroh-blobs/pull/11
https://github.com/n0-computer/iroh-docs/pull/7
https://github.com/n0-computer/iroh-gossip/pull/7

This also allows making the tests a bit shorter - you don't have to call abort explicitly anymore on the server JoinHandle.