### PR TITLE
feat: Add flatten util

### DIFF
--- a/src/pattern/mod.rs
+++ b/src/pattern/mod.rs
@@ -9,3 +9,4 @@ pub mod client_streaming;
 pub mod rpc;
 pub mod server_streaming;
 pub mod try_server_streaming;
+pub mod util;

--- a/src/pattern/util.rs
+++ b/src/pattern/util.rs
@@ -1,0 +1,20 @@
+//! Utility functions for working with streams
+use futures_lite::{Stream, StreamExt};
+
+/// Flatten a stream of results of results into a stream of results
+///
+/// This is frequently useful for streaming responses if you want to combine
+/// the application errors with the transport errors.
+pub fn flatten<T, E1, E2, E3>(
+    s: impl Stream<Item = Result<Result<T, E1>, E2>>,
+) -> impl Stream<Item = Result<T, E3>>
+where
+    E1: Into<E3> + Send + Sync + 'static,
+    E2: Into<E3> + Send + Sync + 'static,
+{
+    s.map(|res| match res {
+        Ok(Ok(res)) => Ok(res),
+        Ok(Err(err)) => Err(err.into()),
+        Err(err) => Err(err.into()),
+    })
+}


### PR DESCRIPTION
I use it all the time to flatten streams, so why not.

in iroh-blobs:
```rust

    /// List all complete blobs.
    pub async fn list(&self) -> Result<impl Stream<Item = Result<BlobInfo>>> {
        let stream = self.rpc.server_streaming(ListRequest).await?;
        Ok(flatten(stream))
    }

    /// List all incomplete (partial) blobs.
    pub async fn list_incomplete(&self) -> Result<impl Stream<Item = Result<IncompleteBlobInfo>>> {
        let stream = self.rpc.server_streaming(ListIncompleteRequest).await?;
        Ok(flatten(stream))
    }
    ```

in iroh-docs 3x, 