### PR TITLE
chore: Remove `cc` version pinning

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -276,9 +276,9 @@ checksum = "9ac0150caa2ae65ca5bd83f25c7de183dea78d4d366469f148435e2acfbad0da"
 
 [[package]]
 name = "cc"
-version = "1.1.31"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2e7962b54006dcfcc61cb72735f4d89bb97061dd6a7ed882ec6b8ee53714c6f"
+checksum = "fd9de9f2205d5ef3fd67e685b0df337994ddd4495e2a28d185500d0e1edfea47"
 dependencies = [
  "shlex",
 ]
@@ -2942,7 +2942,6 @@ dependencies = [
  "async-stream",
  "bincode",
  "bytes",
- "cc",
  "derive_more",
  "flume",
  "futures",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,6 @@ description = "A streaming rpc system based on quic"
 rust-version = "1.76"
 
 [dependencies]
-cc = "=1.1.31" # enforce cc version, because of https://github.com/rust-lang/cc-rs/issues/1278
 bincode = { version = "1.3.3", optional = true }
 bytes = { version = "1", optional = true }
 derive_more = { version = "1.0.0-beta.6", features = ["from", "try_into", "display"] }


### PR DESCRIPTION
This is not necessary anymore. `cc` version 1.2 was released and fixes the issues that versions 1.32-1.37 had.