### PR TITLE
refactor: rename iroh-net transport to iroh-transport

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,7 +58,7 @@ tokio-util = { version = "0.7", features = ["rt"] }
 hyper-transport = ["dep:flume", "dep:hyper", "dep:postcard", "dep:bytes", "dep:tokio-serde", "tokio-util/codec"]
 quinn-transport = ["dep:flume", "dep:quinn", "dep:postcard", "dep:tokio-serde", "tokio-util/codec"]
 flume-transport = ["dep:flume"]
-iroh-net-transport = ["dep:iroh-net", "dep:flume", "dep:quinn", "dep:postcard", "dep:tokio-serde", "tokio-util/codec"]
+iroh-transport = ["dep:iroh-net", "dep:flume", "dep:quinn", "dep:postcard", "dep:tokio-serde", "tokio-util/codec"]
 macros = []
 default = ["flume-transport"]
 

--- a/src/transport/boxed.rs
+++ b/src/transport/boxed.rs
@@ -397,9 +397,9 @@ impl<In: RpcMessage, Out: RpcMessage> BoxableListener<In, Out>
     }
 }
 
-#[cfg(feature = "iroh-net-transport")]
+#[cfg(feature = "iroh-transport")]
 impl<In: RpcMessage, Out: RpcMessage> BoxableConnector<In, Out>
-    for super::iroh_net::IrohNetConnector<In, Out>
+    for super::iroh::IrohConnector<In, Out>
 {
     fn clone_box(&self) -> Box<dyn BoxableConnector<In, Out>> {
         Box::new(self.clone())
@@ -418,9 +418,9 @@ impl<In: RpcMessage, Out: RpcMessage> BoxableConnector<In, Out>
     }
 }
 
-#[cfg(feature = "iroh-net-transport")]
+#[cfg(feature = "iroh-transport")]
 impl<In: RpcMessage, Out: RpcMessage> BoxableListener<In, Out>
-    for super::iroh_net::IrohNetListener<In, Out>
+    for super::iroh::IrohListener<In, Out>
 {
     fn clone_box(&self) -> Box<dyn BoxableListener<In, Out>> {
         Box::new(self.clone())

--- a/src/transport/mod.rs
+++ b/src/transport/mod.rs
@@ -35,14 +35,14 @@ pub mod combined;
 pub mod flume;
 #[cfg(feature = "hyper-transport")]
 pub mod hyper;
-#[cfg(feature = "iroh-net-transport")]
-pub mod iroh_net;
+#[cfg(feature = "iroh-transport")]
+pub mod iroh;
 pub mod mapped;
 pub mod misc;
 #[cfg(feature = "quinn-transport")]
 pub mod quinn;
 
-#[cfg(any(feature = "quinn-transport", feature = "iroh-net-transport"))]
+#[cfg(any(feature = "quinn-transport", feature = "iroh-transport"))]
 mod util;
 
 /// Errors that can happen when creating and using a [`Connector`] or [`Listener`].

--- a/tests/math.rs
+++ b/tests/math.rs
@@ -2,7 +2,7 @@
     feature = "flume-transport",
     feature = "hyper-transport",
     feature = "quinn-transport",
-    feature = "iroh-net-transport",
+    feature = "iroh-transport",
 ))]
 #![allow(dead_code)]
 use std::{

--- a/tests/slow_math.rs
+++ b/tests/slow_math.rs
@@ -2,7 +2,7 @@
     feature = "flume-transport",
     feature = "hyper-transport",
     feature = "quinn-transport",
-    feature = "iroh-net-transport",
+    feature = "iroh-transport",
 ))]
 mod math;
 use std::result;


### PR DESCRIPTION
renamed
- the module iroh_net -> iroh
- the connector IrohNetConnector to IrohConnector
- the listener IrohNetListener to IrohListener
- the feature flag "iroh-net-transport" to "iroh-transport"

The reason for this that while previously iroh was the networking part and a number of canonical protocols, now we changed the naming to make iroh the networking stack and the *ability* to have custom protocols. 

See https://www.iroh.computer/blog/road-to-1-0

Also, I think it also just reads nicer.