### PR TITLE
fix: add back bytes dependency for quinn transport

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,7 +56,7 @@ tokio-util = { version = "0.7", features = ["rt"] }
 
 [features]
 hyper-transport = ["dep:flume", "dep:hyper", "dep:postcard", "dep:bytes", "dep:tokio-serde", "tokio-util/codec"]
-quinn-transport = ["dep:flume", "dep:quinn", "dep:postcard", "dep:tokio-serde", "tokio-util/codec"]
+quinn-transport = ["dep:flume", "dep:quinn", "dep:postcard", "dep:bytes", "dep:tokio-serde", "tokio-util/codec"]
 flume-transport = ["dep:flume"]
 iroh-transport = ["dep:iroh", "dep:flume", "dep:postcard", "dep:tokio-serde", "tokio-util/codec"]
 macros = []


### PR DESCRIPTION
the bytes dependency was missing for the quinn transport. Having this dependency optional is a bit silly since if you use tokio in 99% of all cases you have it anyway. But still, this fixes it.

This was not caught by cargo test --all-features because the hyper feature does add it. I think it was introduced by the switch to postcard.