### PR TITLE
chore: release v0.17.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3190,7 +3190,7 @@ dependencies = [
 
 [[package]]
 name = "quic-rpc"
-version = "0.17.0"
+version = "0.17.1"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -3226,7 +3226,7 @@ dependencies = [
 
 [[package]]
 name = "quic-rpc-derive"
-version = "0.17.0"
+version = "0.17.1"
 dependencies = [
  "derive_more",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "quic-rpc"
-version = "0.17.0"
+version = "0.17.1"
 edition = "2021"
 authors = ["Rüdiger Klaehn <rklaehn@protonmail.com>", "n0 team"]
 keywords = ["api", "protocol", "network", "rpc"]

--- a/quic-rpc-derive/Cargo.toml
+++ b/quic-rpc-derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "quic-rpc-derive"
-version = "0.17.0"
+version = "0.17.1"
 edition = "2021"
 authors = ["Rüdiger Klaehn <rklaehn@protonmail.com>"]
 keywords = ["api", "protocol", "network", "rpc", "macro"]


### PR DESCRIPTION
Release v0.17.1

- bugfix for the quinn-transport: the bytes dependency was missing