### PR TITLE
Add connection setup helpers to the quinn transport.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3196,6 +3196,7 @@ dependencies = [
  "async-stream",
  "bytes",
  "derive_more",
+ "document-features",
  "flume",
  "futures",
  "futures-buffered",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3879,8 +3879,6 @@ dependencies = [
  "futures",
  "iroh-quinn",
  "quic-rpc",
- "rcgen",
- "rustls",
  "tokio",
  "tracing-subscriber",
  "types",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3210,6 +3210,7 @@ dependencies = [
  "postcard",
  "proc-macro2",
  "rcgen",
+ "rustls",
  "serde",
  "slab",
  "smallvec",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,6 +67,10 @@ default = ["flume-transport"]
 
 [package.metadata.docs.rs]
 all-features = true
+rustdoc-args = ["--cfg", "quicrpc_docsrs"]
+
+[lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = ["cfg(quicrpc_docsrs)"] }
 
 [[example]]
 name = "errors"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,8 @@ postcard = { version = "1", features = ["use-std"], optional = true }
 tracing = "0.1"
 futures = { version = "0.3.30", optional = true }
 anyhow = "1.0.73"
+rcgen = { version = "0.13", optional = true }
+rustls = { version = "0.23", default-features = false, features = ["ring"], optional = true }
 
 # Indirect dependencies, is needed to make the minimal crates versions work
 slab = "0.4.9" # iroh-quinn
@@ -60,6 +62,7 @@ quinn-transport = ["dep:flume", "dep:quinn", "dep:postcard", "dep:bytes", "dep:t
 flume-transport = ["dep:flume"]
 iroh-transport = ["dep:iroh", "dep:flume", "dep:postcard", "dep:tokio-serde", "tokio-util/codec"]
 macros = []
+test-utils = ["dep:rcgen", "dep:rustls"]
 default = ["flume-transport"]
 
 [package.metadata.docs.rs]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,7 @@ rustls = { version = "0.23", default-features = false, features = ["ring"], opti
 slab = "0.4.9" # iroh-quinn
 smallvec = "1.13.2"
 time = "0.3.36" # serde
+document-features = "0.2.10"
 
 [dev-dependencies]
 anyhow = "1.0.73"
@@ -57,12 +58,19 @@ nested_enum_utils = "0.1.0"
 tokio-util = { version = "0.7", features = ["rt"] }
 
 [features]
+## HTTP transport using the `hyper` crate
 hyper-transport = ["dep:flume", "dep:hyper", "dep:postcard", "dep:bytes", "dep:tokio-serde", "tokio-util/codec"]
+## QUIC transport using the `iroh-quinn` crate
 quinn-transport = ["dep:flume", "dep:quinn", "dep:postcard", "dep:bytes", "dep:tokio-serde", "tokio-util/codec"]
+## In memory transport using the `flume` crate
 flume-transport = ["dep:flume"]
+## p2p QUIC transport using the `iroh` crate
 iroh-transport = ["dep:iroh", "dep:flume", "dep:postcard", "dep:tokio-serde", "tokio-util/codec"]
+## Macros for creating request handlers
 macros = []
+## Utilities for testing
 test-utils = ["dep:rcgen", "dep:rustls"]
+## Default, includes the memory transport
 default = ["flume-transport"]
 
 [package.metadata.docs.rs]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,6 @@ rust-version = "1.76"
 
 [dependencies]
 bytes = { version = "1", optional = true }
-derive_more = { version = "1.0.0-beta.6", features = ["from", "try_into", "display"] }
 flume = { version = "0.11", optional = true }
 futures-lite = "2.3.0"
 futures-sink = "0.3.30"
@@ -23,26 +22,29 @@ hyper = { version = "0.14.16", features = ["full"], optional = true }
 iroh = { version = "0.29", optional = true }
 pin-project = "1"
 quinn = { package = "iroh-quinn", version = "0.12", optional = true }
-serde = { version = "1.0", features = ["derive"] }
+serde = { version = "1", features = ["derive"] }
 tokio = { version = "1", default-features = false, features = ["macros", "sync"] }
 tokio-serde = { version = "0.9", features = ["bincode"], optional = true }
 tokio-util = { version = "0.7", features = ["rt"] }
 postcard = { version = "1", features = ["use-std"], optional = true }
 tracing = "0.1"
 futures = { version = "0.3.30", optional = true }
-anyhow = "1.0.73"
+anyhow = "1"
+document-features = "0.2"
+# for test-utils
 rcgen = { version = "0.13", optional = true }
+# for test-utils
 rustls = { version = "0.23", default-features = false, features = ["ring"], optional = true }
 
 # Indirect dependencies, is needed to make the minimal crates versions work
 slab = "0.4.9" # iroh-quinn
 smallvec = "1.13.2"
 time = "0.3.36" # serde
-document-features = "0.2.10"
 
 [dev-dependencies]
-anyhow = "1.0.73"
+anyhow = "1"
 async-stream = "0.3.3"
+derive_more = { version = "1", features = ["from", "try_into", "display"] }
 
 serde = { version = "1", features = ["derive"] }
 tokio = { version = "1", features = ["full"] }

--- a/DOCS.md
+++ b/DOCS.md
@@ -1,0 +1,32 @@
+Building docs for this crate is a bit complex. There are lots of feature flags,
+so we want feature flag markers in the docs, especially for the transports.
+
+There is an experimental cargo doc feature that adds feature flag markers. To
+get those, run docs with this command line:
+
+```rust
+RUSTDOCFLAGS="--cfg quicrpc_docsrs" cargo +nightly doc --all-features --no-deps --open
+```
+
+This sets the flag `quicrpc_docsrs` when creating docs, which triggers statements
+like below that add feature flag markers. Note that you *need* nightly for this feature
+as of now.
+
+```
+#[cfg_attr(quicrpc_docsrs, doc(cfg(feature = "flume-transport")))]
+```
+
+The feature is *enabled* using this statement in lib.rs:
+
+```
+#![cfg_attr(quicrpc_docsrs, feature(doc_cfg))]
+```
+
+We tell [docs.rs] to use the `quicrpc_docsrs` config using these statements
+in Cargo.toml:
+
+```
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "quicrpc_docsrs"]
+```

--- a/README.md
+++ b/README.md
@@ -94,3 +94,8 @@ This may change in the future as quic implementations get more optimized.
 [quinn]: https://docs.rs/quinn/
 [flume]: https://docs.rs/flume/
 [grpc]: https://grpc.io/
+
+# Docs
+
+Properly building docs for this crate is quite complex. For all the gory details,
+see [DOCS.md].

--- a/examples/split/client/Cargo.toml
+++ b/examples/split/client/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2021"
 [dependencies]
 anyhow = "1.0.14"
 futures = "0.3.26"
-quic-rpc = { path = "../../..", features = ["quinn-transport", "macros"] }
+quic-rpc = { path = "../../..", features = ["quinn-transport", "macros", "test-utils"] }
 quinn = { package = "iroh-quinn", version = "0.12" }
 rustls = { version = "0.23", default-features = false, features = ["ring"] }
 tracing-subscriber = "0.3.16"

--- a/examples/split/server/Cargo.toml
+++ b/examples/split/server/Cargo.toml
@@ -10,9 +10,7 @@ anyhow = "1.0.14"
 async-stream = "0.3.3"
 futures = "0.3.26"
 tracing-subscriber = "0.3.16"
-quic-rpc = { path = "../../..", features = ["quinn-transport", "macros"] }
+quic-rpc = { path = "../../..", features = ["quinn-transport", "macros", "test-utils"] }
 quinn = { package = "iroh-quinn", version = "0.12" }
-rcgen = "0.13"
-rustls = { version = "0.23", default-features = false, features = ["ring"] }
 tokio = { version = "1", features = ["full"] }
 types = { path = "../types" }

--- a/examples/split/types/Cargo.toml
+++ b/examples/split/types/Cargo.toml
@@ -8,4 +8,4 @@ edition = "2021"
 [dependencies]
 quic-rpc = { path = "../../..", features = ["macros"] }
 serde = { version = "1", features = ["derive"] }
-derive_more = { version = "1.0.0-beta.6", features = ["from", "try_into"] }
+derive_more = { version = "1", features = ["from", "try_into"] }

--- a/quic-rpc-derive/Cargo.toml
+++ b/quic-rpc-derive/Cargo.toml
@@ -13,12 +13,12 @@ description = "Macros for quic-rpc"
 proc-macro = true
 
 [dependencies]
-syn = { version = "1.0", features = ["full"] }
-quote = "1.0"
-proc-macro2 = "1.0"
+syn = { version = "1", features = ["full"] }
+quote = "1"
+proc-macro2 = "1"
 quic-rpc = { version = "0.17", path = ".." }
 
 [dev-dependencies]
 derive_more = { version = "1", features = ["from", "try_into", "display"] }
 serde = { version = "1", features = ["serde_derive"] }
-trybuild = "1.0.96"
+trybuild = "1.0"

--- a/quic-rpc-derive/Cargo.toml
+++ b/quic-rpc-derive/Cargo.toml
@@ -19,6 +19,6 @@ proc-macro2 = "1.0"
 quic-rpc = { version = "0.17", path = ".." }
 
 [dev-dependencies]
-derive_more = "1.0.0-beta.6"
-serde = { version = "1.0.203", features = ["serde_derive"] }
+derive_more = { version = "1", features = ["from", "try_into", "display"] }
+serde = { version = "1", features = ["serde_derive"] }
 trybuild = "1.0.96"

--- a/src/client.rs
+++ b/src/client.rs
@@ -35,6 +35,18 @@ pub type FlumeConnector<S> =
 pub type QuinnConnector<S> =
     crate::transport::quinn::QuinnConnector<<S as Service>::Res, <S as Service>::Req>;
 
+#[cfg(feature = "iroh-transport")]
+#[cfg_attr(quicrpc_docsrs, doc(cfg(feature = "iroh-transport")))]
+/// A quinn connector for the given [`Service`]
+pub type IrohConnector<S> =
+    crate::transport::iroh::IrohConnector<<S as Service>::Res, <S as Service>::Req>;
+
+#[cfg(feature = "hyper-transport")]
+#[cfg_attr(quicrpc_docsrs, doc(cfg(feature = "hyper-transport")))]
+/// A quinn connector for the given [`Service`]
+pub type HyperConnector<S> =
+    crate::transport::hyper::HyperConnector<<S as Service>::Res, <S as Service>::Req>;
+
 /// Sync version of `future::stream::BoxStream`.
 pub type BoxStreamSync<'a, T> = Pin<Box<dyn Stream<Item = T> + Send + Sync + 'a>>;
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -23,6 +23,18 @@ use crate::{
 pub type BoxedConnector<S> =
     crate::transport::boxed::BoxedConnector<<S as crate::Service>::Res, <S as crate::Service>::Req>;
 
+#[cfg(feature = "flume-transport")]
+#[cfg_attr(quicrpc_docsrs, doc(cfg(feature = "flume-transport")))]
+/// A flume connector for the given [`Service`]
+pub type FlumeConnector<S> =
+    crate::transport::flume::FlumeConnector<<S as Service>::Res, <S as Service>::Req>;
+
+#[cfg(feature = "quinn-transport")]
+#[cfg_attr(quicrpc_docsrs, doc(cfg(feature = "quinn-transport")))]
+/// A quinn connector for the given [`Service`]
+pub type QuinnConnector<S> =
+    crate::transport::quinn::QuinnConnector<<S as Service>::Res, <S as Service>::Req>;
+
 /// Sync version of `future::stream::BoxStream`.
 pub type BoxStreamSync<'a, T> = Pin<Box<dyn Stream<Item = T> + Send + Sync + 'a>>;
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -35,17 +35,17 @@ pub type FlumeConnector<S> =
 pub type QuinnConnector<S> =
     crate::transport::quinn::QuinnConnector<<S as Service>::Res, <S as Service>::Req>;
 
-#[cfg(feature = "iroh-transport")]
-#[cfg_attr(quicrpc_docsrs, doc(cfg(feature = "iroh-transport")))]
-/// A quinn connector for the given [`Service`]
-pub type IrohConnector<S> =
-    crate::transport::iroh::IrohConnector<<S as Service>::Res, <S as Service>::Req>;
-
 #[cfg(feature = "hyper-transport")]
 #[cfg_attr(quicrpc_docsrs, doc(cfg(feature = "hyper-transport")))]
-/// A quinn connector for the given [`Service`]
+/// A hyper connector for the given [`Service`]
 pub type HyperConnector<S> =
     crate::transport::hyper::HyperConnector<<S as Service>::Res, <S as Service>::Req>;
+
+#[cfg(feature = "iroh-transport")]
+#[cfg_attr(quicrpc_docsrs, doc(cfg(feature = "iroh-transport")))]
+/// An iroh connector for the given [`Service`]
+pub type IrohConnector<S> =
+    crate::transport::iroh::IrohConnector<<S as Service>::Res, <S as Service>::Req>;
 
 /// Sync version of `future::stream::BoxStream`.
 pub type BoxStreamSync<'a, T> = Pin<Box<dyn Stream<Item = T> + Send + Sync + 'a>>;

--- a/src/client.rs
+++ b/src/client.rs
@@ -17,9 +17,7 @@ use crate::{
     Connector, Service,
 };
 
-/// Type alias for a boxed connection to a specific service
-///
-/// This is a convenience type alias for a boxed connection to a specific service.
+/// A boxed connector for the given [`Service`]
 pub type BoxedConnector<S> =
     crate::transport::boxed::BoxedConnector<<S as crate::Service>::Res, <S as crate::Service>::Req>;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -208,6 +208,9 @@ pub use flume_helpers::*;
 mod quinn_helpers {
 
     use super::{transport, Service};
+    #[cfg(feature = "test-utils")]
+    use super::{RpcClient, RpcServer};
+
     /// A quinn listener for the given service
     pub type QuinnListener<S> =
         transport::quinn::QuinnListener<<S as Service>::Req, <S as Service>::Res>;
@@ -221,10 +224,9 @@ mod quinn_helpers {
     ///
     /// This is useful for testing the quinn transport.
     pub fn quinn_channel<S: Service>() -> anyhow::Result<(
-        super::RpcServer<S, QuinnListener<S>>,
-        super::RpcClient<S, QuinnConnector<S>>,
+        RpcServer<S, QuinnListener<S>>,
+        RpcClient<S, QuinnConnector<S>>,
     )> {
-        use super::{RpcClient, RpcServer};
         let bind_addr: std::net::SocketAddr = ([0, 0, 0, 0], 0).into();
         let (server_endpoint, cert_der) = transport::quinn::make_server_endpoint(bind_addr)?;
         let addr = server_endpoint.local_addr()?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,6 +10,10 @@
 //!
 //! See the [README](https://github.com/n0-computer/quic-rpc/blob/main/README.md)
 //!
+//! # Features
+//!
+#![doc = document_features::document_features!()]
+//!
 //! # Example
 //! ```
 //! # async fn example() -> anyhow::Result<()> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -91,6 +91,7 @@
 //! ```
 #![deny(missing_docs)]
 #![deny(rustdoc::broken_intra_doc_links)]
+#![cfg_attr(quicrpc_docsrs, feature(doc_cfg))]
 use std::fmt::{Debug, Display};
 
 use serde::{de::DeserializeOwned, Serialize};
@@ -179,17 +180,18 @@ pub trait Listener<S: Service>: transport::Listener<In = S::Req, Out = S::Res> {
 impl<T: transport::Listener<In = S::Req, Out = S::Res>, S: Service> Listener<S> for T {}
 
 #[cfg(feature = "flume-transport")]
+#[cfg_attr(quicrpc_docsrs, doc(cfg(feature = "flume-transport")))]
 mod flume_helpers {
     use super::{transport, RpcClient, RpcServer, Service};
-    /// A flume listener for the given service
+    /// A flume listener for the given [`Service`]
     pub type FlumeListener<S> =
         transport::flume::FlumeListener<<S as Service>::Req, <S as Service>::Res>;
 
-    /// A flume connector for the given service
+    /// A flume connector for the given [`Service`]
     pub type FlumeConnector<S> =
         transport::flume::FlumeConnector<<S as Service>::Res, <S as Service>::Req>;
 
-    /// Create a pair of client and server using a flume channel
+    /// Create a pair of [`RpcServer`] and [`RpcClient`] for the given [`Service`] type using a flume channel
     pub fn flume_channel<S: Service>(
         size: usize,
     ) -> (
@@ -205,24 +207,27 @@ mod flume_helpers {
 pub use flume_helpers::*;
 
 #[cfg(feature = "quinn-transport")]
+#[cfg_attr(quicrpc_docsrs, doc(cfg(feature = "quinn-transport")))]
 mod quinn_helpers {
-
     use super::{transport, Service};
     #[cfg(feature = "test-utils")]
     use super::{RpcClient, RpcServer};
 
-    /// A quinn listener for the given service
+    /// A quinn listener for the given [`Service`]
     pub type QuinnListener<S> =
         transport::quinn::QuinnListener<<S as Service>::Req, <S as Service>::Res>;
 
-    /// A quinn connector for the given service
+    /// A quinn connector for the given [`Service`]
     pub type QuinnConnector<S> =
         transport::quinn::QuinnConnector<<S as Service>::Res, <S as Service>::Req>;
 
     #[cfg(feature = "test-utils")]
-    /// Create a pair of client and server that are connected via a local network connection.
+    #[cfg_attr(quicrpc_docsrs, doc(cfg(feature = "test-utils")))]
+    /// Create a pair of [`RpcServer`] and [`RpcClient`] for the given [`Service`] type using a quinn channel
     ///
-    /// This is useful for testing the quinn transport.
+    /// This is using a network connection using the local network. It is useful for testing remote services
+    /// in a more realistic way than the memory transport.
+    #[allow(clippy::type_complexity)]
     pub fn quinn_channel<S: Service>() -> anyhow::Result<(
         RpcServer<S, QuinnListener<S>>,
         RpcClient<S, QuinnConnector<S>>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,9 +10,6 @@
 //!
 //! See the [README](https://github.com/n0-computer/quic-rpc/blob/main/README.md)
 //!
-//! # Features
-#![doc = document_features::document_features!()]
-//!
 //! # Example
 //! ```
 //! # async fn example() -> anyhow::Result<()> {
@@ -92,6 +89,9 @@
 //! # Ok(())
 //! # }
 //! ```
+//!
+//! # Features
+#![doc = document_features::document_features!()]
 #![deny(missing_docs)]
 #![deny(rustdoc::broken_intra_doc_links)]
 #![cfg_attr(quicrpc_docsrs, feature(doc_cfg))]
@@ -105,6 +105,7 @@ pub mod transport;
 pub use client::RpcClient;
 pub use server::RpcServer;
 #[cfg(feature = "macros")]
+#[cfg_attr(quicrpc_docsrs, doc(cfg(feature = "macros")))]
 mod macros;
 
 pub mod pattern;

--- a/src/server.rs
+++ b/src/server.rs
@@ -46,6 +46,18 @@ pub type BoxedChannelTypes<S> = crate::transport::boxed::BoxedStreamTypes<
 pub type BoxedListener<S> =
     crate::transport::boxed::BoxedListener<<S as crate::Service>::Req, <S as crate::Service>::Res>;
 
+#[cfg(feature = "flume-transport")]
+#[cfg_attr(quicrpc_docsrs, doc(cfg(feature = "flume-transport")))]
+/// A flume listener for the given [`Service`]
+pub type FlumeListener<S> =
+    crate::transport::flume::FlumeListener<<S as Service>::Req, <S as Service>::Res>;
+
+#[cfg(feature = "quinn-transport")]
+#[cfg_attr(quicrpc_docsrs, doc(cfg(feature = "quinn-transport")))]
+/// A quinn listener for the given [`Service`]
+pub type QuinnListener<S> =
+    crate::transport::quinn::QuinnListener<<S as Service>::Req, <S as Service>::Res>;
+
 /// A server for a specific service.
 ///
 /// This is a wrapper around a [`Listener`] that serves as the entry point for the server DSL.

--- a/src/server.rs
+++ b/src/server.rs
@@ -42,7 +42,7 @@ pub type BoxedChannelTypes<S> = crate::transport::boxed::BoxedStreamTypes<
     <S as crate::Service>::Res,
 >;
 
-/// Type alias for a service endpoint
+/// A boxed listener for the given [`Service`]
 pub type BoxedListener<S> =
     crate::transport::boxed::BoxedListener<<S as crate::Service>::Req, <S as crate::Service>::Res>;
 

--- a/src/server.rs
+++ b/src/server.rs
@@ -58,6 +58,18 @@ pub type FlumeListener<S> =
 pub type QuinnListener<S> =
     crate::transport::quinn::QuinnListener<<S as Service>::Req, <S as Service>::Res>;
 
+#[cfg(feature = "hyper-transport")]
+#[cfg_attr(quicrpc_docsrs, doc(cfg(feature = "hyper-transport")))]
+/// A hyper listener for the given [`Service`]
+pub type HyperListener<S> =
+    crate::transport::hyper::HyperListener<<S as Service>::Req, <S as Service>::Res>;
+
+#[cfg(feature = "iroh-transport")]
+#[cfg_attr(quicrpc_docsrs, doc(cfg(feature = "iroh-transport")))]
+/// An iroh listener for the given [`Service`]
+pub type IrohListener<S> =
+    crate::transport::iroh::IrohListener<<S as Service>::Req, <S as Service>::Res>;
+
 /// A server for a specific service.
 ///
 /// This is a wrapper around a [`Listener`] that serves as the entry point for the server DSL.

--- a/src/transport/mod.rs
+++ b/src/transport/mod.rs
@@ -32,17 +32,25 @@ use crate::{RpcError, RpcMessage};
 pub mod boxed;
 pub mod combined;
 #[cfg(feature = "flume-transport")]
+#[cfg_attr(quicrpc_docsrs, doc(cfg(feature = "flume-transport")))]
 pub mod flume;
 #[cfg(feature = "hyper-transport")]
+#[cfg_attr(quicrpc_docsrs, doc(cfg(feature = "hyper-transport")))]
 pub mod hyper;
 #[cfg(feature = "iroh-transport")]
+#[cfg_attr(quicrpc_docsrs, doc(cfg(feature = "iroh-transport")))]
 pub mod iroh;
 pub mod mapped;
 pub mod misc;
 #[cfg(feature = "quinn-transport")]
+#[cfg_attr(quicrpc_docsrs, doc(cfg(feature = "quinn-transport")))]
 pub mod quinn;
 
 #[cfg(any(feature = "quinn-transport", feature = "iroh-transport"))]
+#[cfg_attr(
+    quicrpc_docsrs,
+    doc(cfg(any(feature = "quinn-transport", feature = "iroh-transport")))
+)]
 mod util;
 
 /// Errors that can happen when creating and using a [`Connector`] or [`Listener`].

--- a/src/transport/quinn.rs
+++ b/src/transport/quinn.rs
@@ -803,3 +803,146 @@ pub fn get_handshake_data(
         server_name: tls_connection.server_name.clone(),
     })
 }
+
+#[cfg(feature = "test-utils")]
+mod quinn_setup_utils {
+    use std::{net::SocketAddr, sync::Arc};
+
+    use anyhow::Result;
+    use quinn::{crypto::rustls::QuicClientConfig, ClientConfig, Endpoint, ServerConfig};
+
+    /// Builds default quinn client config and trusts given certificates.
+    ///
+    /// ## Args
+    ///
+    /// - server_certs: a list of trusted certificates in DER format.
+    pub fn configure_client(server_certs: &[&[u8]]) -> Result<ClientConfig> {
+        let mut certs = rustls::RootCertStore::empty();
+        for cert in server_certs {
+            let cert = rustls::pki_types::CertificateDer::from(cert.to_vec());
+            certs.add(cert)?;
+        }
+
+        let crypto_client_config = rustls::ClientConfig::builder_with_provider(Arc::new(
+            rustls::crypto::ring::default_provider(),
+        ))
+        .with_protocol_versions(&[&rustls::version::TLS13])
+        .expect("valid versions")
+        .with_root_certificates(certs)
+        .with_no_client_auth();
+        let quic_client_config =
+            quinn::crypto::rustls::QuicClientConfig::try_from(crypto_client_config)?;
+
+        Ok(ClientConfig::new(Arc::new(quic_client_config)))
+    }
+
+    /// Constructs a QUIC endpoint configured for use a client only.
+    ///
+    /// ## Args
+    ///
+    /// - server_certs: list of trusted certificates.
+    pub fn make_client_endpoint(bind_addr: SocketAddr, server_certs: &[&[u8]]) -> Result<Endpoint> {
+        let client_cfg = configure_client(server_certs)?;
+        let mut endpoint = Endpoint::client(bind_addr)?;
+        endpoint.set_default_client_config(client_cfg);
+        Ok(endpoint)
+    }
+
+    /// Create a server endpoint with a self-signed certificate
+    ///
+    /// Returns the server endpoint and the certificate in DER format
+    pub fn make_server_endpoint(bind_addr: SocketAddr) -> Result<(Endpoint, Vec<u8>)> {
+        let (server_config, server_cert) = configure_server()?;
+        let endpoint = Endpoint::server(server_config, bind_addr)?;
+        Ok((endpoint, server_cert))
+    }
+
+    /// Create a quinn server config with a self-signed certificate
+    ///
+    /// Returns the server config and the certificate in DER format
+    pub fn configure_server() -> anyhow::Result<(ServerConfig, Vec<u8>)> {
+        let cert = rcgen::generate_simple_self_signed(vec!["localhost".into()])?;
+        let cert_der = cert.cert.der();
+        let priv_key = rustls::pki_types::PrivatePkcs8KeyDer::from(cert.key_pair.serialize_der());
+        let cert_chain = vec![cert_der.clone()];
+
+        let mut server_config = ServerConfig::with_single_cert(cert_chain, priv_key.into())?;
+        Arc::get_mut(&mut server_config.transport)
+            .unwrap()
+            .max_concurrent_uni_streams(0_u8.into());
+
+        Ok((server_config, cert_der.to_vec()))
+    }
+
+    /// Constructs a QUIC endpoint that trusts all certificates.
+    ///
+    /// This is useful for testing and local connections, but should be used with care.
+    pub fn make_insecure_client_endpoint(bind_addr: SocketAddr) -> Result<Endpoint> {
+        let crypto = rustls::ClientConfig::builder()
+            .dangerous()
+            .with_custom_certificate_verifier(Arc::new(SkipServerVerification))
+            .with_no_client_auth();
+
+        let client_cfg = QuicClientConfig::try_from(crypto)?;
+        let client_cfg = ClientConfig::new(Arc::new(client_cfg));
+        let mut endpoint = Endpoint::client(bind_addr)?;
+        endpoint.set_default_client_config(client_cfg);
+        Ok(endpoint)
+    }
+
+    #[derive(Debug)]
+    struct SkipServerVerification;
+
+    impl rustls::client::danger::ServerCertVerifier for SkipServerVerification {
+        fn verify_server_cert(
+            &self,
+            _end_entity: &rustls::pki_types::CertificateDer<'_>,
+            _intermediates: &[rustls::pki_types::CertificateDer<'_>],
+            _server_name: &rustls::pki_types::ServerName<'_>,
+            _ocsp_response: &[u8],
+            _now: rustls::pki_types::UnixTime,
+        ) -> Result<rustls::client::danger::ServerCertVerified, rustls::Error> {
+            Ok(rustls::client::danger::ServerCertVerified::assertion())
+        }
+
+        fn verify_tls12_signature(
+            &self,
+            _message: &[u8],
+            _cert: &rustls::pki_types::CertificateDer<'_>,
+            _dss: &rustls::DigitallySignedStruct,
+        ) -> Result<rustls::client::danger::HandshakeSignatureValid, rustls::Error> {
+            Ok(rustls::client::danger::HandshakeSignatureValid::assertion())
+        }
+
+        fn verify_tls13_signature(
+            &self,
+            _message: &[u8],
+            _cert: &rustls::pki_types::CertificateDer<'_>,
+            _dss: &rustls::DigitallySignedStruct,
+        ) -> Result<rustls::client::danger::HandshakeSignatureValid, rustls::Error> {
+            Ok(rustls::client::danger::HandshakeSignatureValid::assertion())
+        }
+
+        fn supported_verify_schemes(&self) -> Vec<rustls::SignatureScheme> {
+            use rustls::SignatureScheme::*;
+            // list them all, we don't care.
+            vec![
+                RSA_PKCS1_SHA1,
+                ECDSA_SHA1_Legacy,
+                RSA_PKCS1_SHA256,
+                ECDSA_NISTP256_SHA256,
+                RSA_PKCS1_SHA384,
+                ECDSA_NISTP384_SHA384,
+                RSA_PKCS1_SHA512,
+                ECDSA_NISTP521_SHA512,
+                RSA_PSS_SHA256,
+                RSA_PSS_SHA384,
+                RSA_PSS_SHA512,
+                ED25519,
+                ED448,
+            ]
+        }
+    }
+}
+#[cfg(feature = "test-utils")]
+pub use quinn_setup_utils::*;


### PR DESCRIPTION
Copying and updating these gets really old.

This also fixes a bug in the fn make_insecure_client_endpoint that would not support any verification schemes, causing the split example to fail.

We also add some top level type aliases and fns for creating channels for mem and testing.

We get a dependency on rcgen and rustls, but only if you set the "test-utils" feature flag. Everybody that wants to use the quinn transport is going to want such tests in their crate, and this way we can do the whole setup only once.