### PR TITLE
Try to get feature flags in docs to work

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3879,8 +3879,6 @@ dependencies = [
  "futures",
  "iroh-quinn",
  "quic-rpc",
- "rcgen",
- "rustls",
  "tokio",
  "tracing-subscriber",
  "types",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,10 +67,10 @@ default = ["flume-transport"]
 
 [package.metadata.docs.rs]
 all-features = true
-rustdoc-args = ["--cfg", "iroh_docsrs"]
+rustdoc-args = ["--cfg", "quicrpc_docsrs"]
 
 [lints.rust]
-unexpected_cfgs = { level = "warn", check-cfg = ["cfg(iroh_docsrs)"] }
+unexpected_cfgs = { level = "warn", check-cfg = ["cfg(quicrpc_docsrs)"] }
 
 [[example]]
 name = "errors"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,6 +67,10 @@ default = ["flume-transport"]
 
 [package.metadata.docs.rs]
 all-features = true
+rustdoc-args = ["--cfg", "iroh_docsrs"]
+
+[lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = ["cfg(iroh_docsrs)"] }
 
 [[example]]
 name = "errors"

--- a/DOCS.md
+++ b/DOCS.md
@@ -1,0 +1,32 @@
+Building docs for this crate is a bit complex. There are lots of feature flags,
+so we want feature flag markers in the docs, especially for the transports.
+
+There is an experimental cargo doc feature that adds feature flag markers. To
+get those, run docs with this command line:
+
+```rust
+RUSTDOCFLAGS="--cfg quicrpc_docsrs" cargo +nightly doc --all-features --no-deps --open
+```
+
+This sets the flag `quicrpc_docsrs` when creating docs, which triggers statements
+like below that add feature flag markers. Note that you *need* nightly for this feature
+as of now.
+
+```
+#[cfg_attr(quicrpc_docsrs, doc(cfg(feature = "flume-transport")))]
+```
+
+The feature is *enabled* using this statement in lib.rs:
+
+```
+#![cfg_attr(quicrpc_docsrs, feature(doc_cfg))]
+```
+
+We tell [docs.rs] to use the `quicrpc_docsrs` config using these statements
+in Cargo.toml:
+
+```
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "quicrpc_docsrs"]
+```

--- a/README.md
+++ b/README.md
@@ -94,3 +94,8 @@ This may change in the future as quic implementations get more optimized.
 [quinn]: https://docs.rs/quinn/
 [flume]: https://docs.rs/flume/
 [grpc]: https://grpc.io/
+
+# Docs
+
+Properly building docs for this crate is quite complex. For all the gory details,
+see [DOCS.md].

--- a/examples/split/server/Cargo.toml
+++ b/examples/split/server/Cargo.toml
@@ -10,9 +10,7 @@ anyhow = "1.0.14"
 async-stream = "0.3.3"
 futures = "0.3.26"
 tracing-subscriber = "0.3.16"
-quic-rpc = { path = "../../..", features = ["quinn-transport", "macros"] }
+quic-rpc = { path = "../../..", features = ["quinn-transport", "macros", "test-utils"] }
 quinn = { package = "iroh-quinn", version = "0.12" }
-rcgen = "0.13"
-rustls = { version = "0.23", default-features = false, features = ["ring"] }
 tokio = { version = "1", features = ["full"] }
 types = { path = "../types" }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -179,16 +179,10 @@ pub trait Listener<S: Service>: transport::Listener<In = S::Req, Out = S::Res> {
 
 impl<T: transport::Listener<In = S::Req, Out = S::Res>, S: Service> Listener<S> for T {}
 
-
-#[cfg(feature = "flume-transport")]
-#[cfg_attr(iroh_docsrs, doc(cfg(feature = "flume-transport")))]
-/// A struct that needs the flume transport feature flag
-pub struct INeedFlumeTransport;
-
 #[cfg(feature = "flume-transport")]
 #[cfg_attr(iroh_docsrs, doc(cfg(feature = "flume-transport")))]
 /// foo
-pub mod flume_helpers {
+mod flume_helpers {
     use super::{transport, RpcClient, RpcServer, Service};
     /// A flume listener for the given service
     #[cfg_attr(iroh_docsrs, doc(cfg(feature = "flume-transport")))]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -91,7 +91,7 @@
 //! ```
 #![deny(missing_docs)]
 #![deny(rustdoc::broken_intra_doc_links)]
-#![cfg_attr(iroh_docsrs, feature(doc_cfg))]
+#![cfg_attr(quicrpc_docsrs, feature(doc_cfg))]
 use std::fmt::{Debug, Display};
 
 use serde::{de::DeserializeOwned, Serialize};
@@ -180,7 +180,7 @@ pub trait Listener<S: Service>: transport::Listener<In = S::Req, Out = S::Res> {
 impl<T: transport::Listener<In = S::Req, Out = S::Res>, S: Service> Listener<S> for T {}
 
 #[cfg(feature = "flume-transport")]
-#[cfg_attr(iroh_docsrs, doc(cfg(feature = "flume-transport")))]
+#[cfg_attr(quicrpc_docsrs, doc(cfg(feature = "flume-transport")))]
 mod flume_helpers {
     use super::{transport, RpcClient, RpcServer, Service};
     /// A flume listener for the given [`Service`]
@@ -207,7 +207,7 @@ mod flume_helpers {
 pub use flume_helpers::*;
 
 #[cfg(feature = "quinn-transport")]
-#[cfg_attr(iroh_docsrs, doc(cfg(feature = "quinn-transport")))]
+#[cfg_attr(quicrpc_docsrs, doc(cfg(feature = "quinn-transport")))]
 mod quinn_helpers {
     use super::{transport, Service};
     #[cfg(feature = "test-utils")]
@@ -222,7 +222,7 @@ mod quinn_helpers {
         transport::quinn::QuinnConnector<<S as Service>::Res, <S as Service>::Req>;
 
     #[cfg(feature = "test-utils")]
-    #[cfg_attr(iroh_docsrs, doc(cfg(feature = "test-utils")))]
+    #[cfg_attr(quicrpc_docsrs, doc(cfg(feature = "test-utils")))]
     /// Create a pair of [`RpcServer`] and [`RpcClient`] for the given [`Service`] type using a quinn channel
     ///
     /// This is using a network connection using the local network. It is useful for testing remote services

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -181,21 +181,17 @@ impl<T: transport::Listener<In = S::Req, Out = S::Res>, S: Service> Listener<S> 
 
 #[cfg(feature = "flume-transport")]
 #[cfg_attr(iroh_docsrs, doc(cfg(feature = "flume-transport")))]
-/// foo
 mod flume_helpers {
     use super::{transport, RpcClient, RpcServer, Service};
-    /// A flume listener for the given service
-    #[cfg_attr(iroh_docsrs, doc(cfg(feature = "flume-transport")))]
+    /// A flume listener for the given [`Service`]
     pub type FlumeListener<S> =
         transport::flume::FlumeListener<<S as Service>::Req, <S as Service>::Res>;
 
-    /// A flume connector for the given service
-    #[cfg_attr(iroh_docsrs, doc(cfg(feature = "flume-transport")))]
+    /// A flume connector for the given [`Service`]
     pub type FlumeConnector<S> =
         transport::flume::FlumeConnector<<S as Service>::Res, <S as Service>::Req>;
 
-    /// Create a pair of client and server using a flume channel
-    #[cfg_attr(iroh_docsrs, doc(cfg(feature = "flume-transport")))]
+    /// Create a pair of [`RpcServer`] and [`RpcClient`] for the given [`Service`] type using a flume channel
     pub fn flume_channel<S: Service>(
         size: usize,
     ) -> (
@@ -211,26 +207,30 @@ mod flume_helpers {
 pub use flume_helpers::*;
 
 #[cfg(feature = "quinn-transport")]
+#[cfg_attr(iroh_docsrs, doc(cfg(feature = "quinn-transport")))]
 mod quinn_helpers {
-
     use super::{transport, Service};
-    /// A quinn listener for the given service
+    #[cfg(feature = "test-utils")]
+    use super::{RpcClient, RpcServer};
+
+    /// A quinn listener for the given [`Service`]
     pub type QuinnListener<S> =
         transport::quinn::QuinnListener<<S as Service>::Req, <S as Service>::Res>;
 
-    /// A quinn connector for the given service
+    /// A quinn connector for the given [`Service`]
     pub type QuinnConnector<S> =
         transport::quinn::QuinnConnector<<S as Service>::Res, <S as Service>::Req>;
 
     #[cfg(feature = "test-utils")]
-    /// Create a pair of client and server that are connected via a local network connection.
+    #[cfg_attr(iroh_docsrs, doc(cfg(feature = "test-utils")))]
+    /// Create a pair of [`RpcServer`] and [`RpcClient`] for the given [`Service`] type using a quinn channel
     ///
-    /// This is useful for testing the quinn transport.
+    /// This is using a network connection using the local network. It is useful for testing remote services
+    /// in a more realistic way than the memory transport.
     pub fn quinn_channel<S: Service>() -> anyhow::Result<(
-        super::RpcServer<S, QuinnListener<S>>,
-        super::RpcClient<S, QuinnConnector<S>>,
+        RpcServer<S, QuinnListener<S>>,
+        RpcClient<S, QuinnConnector<S>>,
     )> {
-        use super::{RpcClient, RpcServer};
         let bind_addr: std::net::SocketAddr = ([0, 0, 0, 0], 0).into();
         let (server_endpoint, cert_der) = transport::quinn::make_server_endpoint(bind_addr)?;
         let addr = server_endpoint.local_addr()?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -91,6 +91,7 @@
 //! ```
 #![deny(missing_docs)]
 #![deny(rustdoc::broken_intra_doc_links)]
+#![cfg_attr(iroh_docsrs, feature(doc_cfg))]
 use std::fmt::{Debug, Display};
 
 use serde::{de::DeserializeOwned, Serialize};
@@ -178,18 +179,29 @@ pub trait Listener<S: Service>: transport::Listener<In = S::Req, Out = S::Res> {
 
 impl<T: transport::Listener<In = S::Req, Out = S::Res>, S: Service> Listener<S> for T {}
 
+
 #[cfg(feature = "flume-transport")]
-mod flume_helpers {
+#[cfg_attr(iroh_docsrs, doc(cfg(feature = "flume-transport")))]
+/// A struct that needs the flume transport feature flag
+pub struct INeedFlumeTransport;
+
+#[cfg(feature = "flume-transport")]
+#[cfg_attr(iroh_docsrs, doc(cfg(feature = "flume-transport")))]
+/// foo
+pub mod flume_helpers {
     use super::{transport, RpcClient, RpcServer, Service};
     /// A flume listener for the given service
+    #[cfg_attr(iroh_docsrs, doc(cfg(feature = "flume-transport")))]
     pub type FlumeListener<S> =
         transport::flume::FlumeListener<<S as Service>::Req, <S as Service>::Res>;
 
     /// A flume connector for the given service
+    #[cfg_attr(iroh_docsrs, doc(cfg(feature = "flume-transport")))]
     pub type FlumeConnector<S> =
         transport::flume::FlumeConnector<<S as Service>::Res, <S as Service>::Req>;
 
     /// Create a pair of client and server using a flume channel
+    #[cfg_attr(iroh_docsrs, doc(cfg(feature = "flume-transport")))]
     pub fn flume_channel<S: Service>(
         size: usize,
     ) -> (

--- a/src/transport/mod.rs
+++ b/src/transport/mod.rs
@@ -32,23 +32,23 @@ use crate::{RpcError, RpcMessage};
 pub mod boxed;
 pub mod combined;
 #[cfg(feature = "flume-transport")]
-#[cfg_attr(iroh_docsrs, doc(cfg(feature = "flume-transport")))]
+#[cfg_attr(quicrpc_docsrs, doc(cfg(feature = "flume-transport")))]
 pub mod flume;
 #[cfg(feature = "hyper-transport")]
-#[cfg_attr(iroh_docsrs, doc(cfg(feature = "hyper-transport")))]
+#[cfg_attr(quicrpc_docsrs, doc(cfg(feature = "hyper-transport")))]
 pub mod hyper;
 #[cfg(feature = "iroh-transport")]
-#[cfg_attr(iroh_docsrs, doc(cfg(feature = "iroh-transport")))]
+#[cfg_attr(quicrpc_docsrs, doc(cfg(feature = "iroh-transport")))]
 pub mod iroh;
 pub mod mapped;
 pub mod misc;
 #[cfg(feature = "quinn-transport")]
-#[cfg_attr(iroh_docsrs, doc(cfg(feature = "quinn-transport")))]
+#[cfg_attr(quicrpc_docsrs, doc(cfg(feature = "quinn-transport")))]
 pub mod quinn;
 
 #[cfg(any(feature = "quinn-transport", feature = "iroh-transport"))]
 #[cfg_attr(
-    iroh_docsrs,
+    quicrpc_docsrs,
     doc(cfg(any(feature = "quinn-transport", feature = "iroh-transport")))
 )]
 mod util;

--- a/src/transport/mod.rs
+++ b/src/transport/mod.rs
@@ -32,17 +32,25 @@ use crate::{RpcError, RpcMessage};
 pub mod boxed;
 pub mod combined;
 #[cfg(feature = "flume-transport")]
+#[cfg_attr(iroh_docsrs, doc(cfg(feature = "flume-transport")))]
 pub mod flume;
 #[cfg(feature = "hyper-transport")]
+#[cfg_attr(iroh_docsrs, doc(cfg(feature = "hyper-transport")))]
 pub mod hyper;
 #[cfg(feature = "iroh-transport")]
+#[cfg_attr(iroh_docsrs, doc(cfg(feature = "iroh-transport")))]
 pub mod iroh;
 pub mod mapped;
 pub mod misc;
 #[cfg(feature = "quinn-transport")]
+#[cfg_attr(iroh_docsrs, doc(cfg(feature = "quinn-transport")))]
 pub mod quinn;
 
 #[cfg(any(feature = "quinn-transport", feature = "iroh-transport"))]
+#[cfg_attr(
+    iroh_docsrs,
+    doc(cfg(any(feature = "quinn-transport", feature = "iroh-transport")))
+)]
 mod util;
 
 /// Errors that can happen when creating and using a [`Connector`] or [`Listener`].


### PR DESCRIPTION
no luck so far...

Building docs locally using this command line:

```
RUSTFLAGS="--cfg iroh_docsrs" cargo +nightly doc --all-features --no-deps
```

Yet the feature flag blobs are nowhere to be seen.

![image](https://github.com/user-attachments/assets/0d5dbe71-8c56-4e06-9abe-5002602c7b8a)


I am about to give up and just manually put a "Needs `flume-transport` feature flag." in the docs.