### PR TITLE
feat: Tokio mem channel

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3220,6 +3220,7 @@ dependencies = [
  "time",
  "tokio",
  "tokio-serde",
+ "tokio-stream",
  "tokio-util",
  "tracing",
  "tracing-subscriber",
@@ -4466,9 +4467,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-stream"
-version = "0.1.16"
+version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f4e6ce100d0eb49a2734f8c0812bcd324cf357d21810932c5df6b96ef2b86f1"
+checksum = "eca58d7bba4a75707817a2c44174253f9236b2d5fbd055602e9d5c07c139a047"
 dependencies = [
  "futures-core",
  "pin-project-lite",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3210,6 +3210,7 @@ dependencies = [
  "postcard",
  "proc-macro2",
  "rcgen",
+ "rustls",
  "serde",
  "slab",
  "smallvec",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,8 @@ postcard = { version = "1", features = ["use-std"], optional = true }
 tracing = "0.1"
 futures = { version = "0.3.30", optional = true }
 anyhow = "1.0.73"
+rcgen = { version = "0.13", optional = true }
+rustls = { version = "0.23", default-features = false, features = ["ring"], optional = true }
 
 # Indirect dependencies, is needed to make the minimal crates versions work
 slab = "0.4.9" # iroh-quinn
@@ -60,6 +62,7 @@ quinn-transport = ["dep:flume", "dep:quinn", "dep:postcard", "dep:bytes", "dep:t
 flume-transport = ["dep:flume"]
 iroh-transport = ["dep:iroh", "dep:flume", "dep:postcard", "dep:tokio-serde", "tokio-util/codec"]
 macros = []
+test-utils = ["dep:rcgen", "dep:rustls"]
 default = ["flume-transport"]
 
 [package.metadata.docs.rs]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,7 @@ rustls = { version = "0.23", default-features = false, features = ["ring"], opti
 slab = "0.4.9" # iroh-quinn
 smallvec = "1.13.2"
 time = "0.3.36" # serde
+tokio-stream = "0.1.17"
 
 [dev-dependencies]
 anyhow = "1.0.73"

--- a/examples/errors.rs
+++ b/examples/errors.rs
@@ -58,7 +58,7 @@ async fn main() -> anyhow::Result<()> {
     let fs = Fs;
     let (server, client) = quic_rpc::transport::flume::channel(1);
     let client = RpcClient::<IoService, _>::new(client);
-    let server = RpcServer::new(server);
+    let mut server = RpcServer::new(server);
     let handle = tokio::task::spawn(async move {
         for _ in 0..1 {
             let (req, chan) = server.accept().await?.read_first().await?;

--- a/examples/split/client/Cargo.toml
+++ b/examples/split/client/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2021"
 [dependencies]
 anyhow = "1.0.14"
 futures = "0.3.26"
-quic-rpc = { path = "../../..", features = ["quinn-transport", "macros"] }
+quic-rpc = { path = "../../..", features = ["quinn-transport", "macros", "test-utils"] }
 quinn = { package = "iroh-quinn", version = "0.12" }
 rustls = { version = "0.23", default-features = false, features = ["ring"] }
 tracing-subscriber = "0.3.16"

--- a/examples/store.rs
+++ b/examples/store.rs
@@ -166,7 +166,7 @@ async fn main() -> anyhow::Result<()> {
     async fn server_future<C: Listener<StoreService>>(
         server: RpcServer<StoreService, C>,
     ) -> result::Result<(), RpcServerError<C>> {
-        let s = server;
+        let mut s = server;
         let store = Store;
         loop {
             let (req, chan) = s.accept().await?.read_first().await?;
@@ -239,7 +239,7 @@ async fn _main_unsugared() -> anyhow::Result<()> {
         type Req = u64;
         type Res = String;
     }
-    let (server, client) = flume::channel::<u64, String>(1);
+    let (mut server, client) = flume::channel::<u64, String>(1);
     let to_string_service = tokio::spawn(async move {
         let (mut send, mut recv) = server.accept().await?;
         while let Some(item) = recv.next().await {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -208,6 +208,9 @@ pub use flume_helpers::*;
 mod quinn_helpers {
 
     use super::{transport, Service};
+    #[cfg(feature = "test-utils")]
+    use super::{RpcClient, RpcServer};
+
     /// A quinn listener for the given service
     pub type QuinnListener<S> =
         transport::quinn::QuinnListener<<S as Service>::Req, <S as Service>::Res>;
@@ -221,10 +224,9 @@ mod quinn_helpers {
     ///
     /// This is useful for testing the quinn transport.
     pub fn quinn_channel<S: Service>() -> anyhow::Result<(
-        super::RpcServer<S, QuinnListener<S>>,
-        super::RpcClient<S, QuinnConnector<S>>,
+        RpcServer<S, QuinnListener<S>>,
+        RpcClient<S, QuinnConnector<S>>,
     )> {
-        use super::{RpcClient, RpcServer};
         let bind_addr: std::net::SocketAddr = ([0, 0, 0, 0], 0).into();
         let (server_endpoint, cert_der) = transport::quinn::make_server_endpoint(bind_addr)?;
         let addr = server_endpoint.local_addr()?;

--- a/src/server.rs
+++ b/src/server.rs
@@ -192,7 +192,7 @@ impl<S: Service, C: Listener<S>> Accepting<S, C> {
 impl<S: Service, C: Listener<S>> RpcServer<S, C> {
     /// Accepts a new channel from a client. The result is an [Accepting] object that
     /// can be used to read the first request.
-    pub async fn accept(&self) -> result::Result<Accepting<S, C>, RpcServerError<C>> {
+    pub async fn accept(&mut self) -> result::Result<Accepting<S, C>, RpcServerError<C>> {
         let (send, recv) = self.source.accept().await.map_err(RpcServerError::Accept)?;
         Ok(Accepting {
             send,
@@ -211,7 +211,7 @@ impl<S: Service, C: Listener<S>> RpcServer<S, C> {
     /// Each request will be handled in a separate task.
     ///
     /// It is the caller's responsibility to poll the returned future to drive the server.
-    pub async fn accept_loop<Fun, Fut, E>(self, handler: Fun)
+    pub async fn accept_loop<Fun, Fut, E>(mut self, handler: Fun)
     where
         S: Service,
         C: Listener<S>,
@@ -453,7 +453,7 @@ where
     F: FnMut(RpcChannel<S, C>, S::Req, T) -> Fut + Send + 'static,
     Fut: Future<Output = Result<(), RpcServerError<C>>> + Send + 'static,
 {
-    let server: RpcServer<S, C> = RpcServer::<S, C>::new(conn);
+    let mut server: RpcServer<S, C> = RpcServer::<S, C>::new(conn);
     loop {
         let (req, chan) = server.accept().await?.read_first().await?;
         let target = target.clone();

--- a/src/server.rs
+++ b/src/server.rs
@@ -64,15 +64,6 @@ pub struct RpcServer<S, C = BoxedListener<S>> {
     _p: PhantomData<S>,
 }
 
-impl<S, C: Clone> Clone for RpcServer<S, C> {
-    fn clone(&self) -> Self {
-        Self {
-            source: self.source.clone(),
-            _p: PhantomData,
-        }
-    }
-}
-
 impl<S: Service, C: Listener<S>> RpcServer<S, C> {
     /// Create a new rpc server for a specific service for a [Service] given a compatible
     /// [Listener].

--- a/src/transport/boxed.rs
+++ b/src/transport/boxed.rs
@@ -290,9 +290,6 @@ impl<In: RpcMessage, Out: RpcMessage> StreamTypes for BoxedStreamTypes<In, Out> 
 
 /// A boxable listener
 pub trait BoxableListener<In: RpcMessage, Out: RpcMessage>: Debug + Send + Sync + 'static {
-    /// Clone the listener and box it
-    fn clone_box(&self) -> Box<dyn BoxableListener<In, Out>>;
-
     /// Accept a channel from a remote client
     fn accept_bi_boxed(&self) -> AcceptFuture<In, Out>;
 
@@ -308,12 +305,6 @@ impl<In: RpcMessage, Out: RpcMessage> BoxedListener<In, Out> {
     /// Wrap a boxable listener into a box, transforming all the types to concrete types
     pub fn new(x: impl BoxableListener<In, Out>) -> Self {
         Self(Box::new(x))
-    }
-}
-
-impl<In: RpcMessage, Out: RpcMessage> Clone for BoxedListener<In, Out> {
-    fn clone(&self) -> Self {
-        Self(self.0.clone_box())
     }
 }
 
@@ -378,10 +369,6 @@ impl<In: RpcMessage, Out: RpcMessage> BoxableConnector<In, Out>
 impl<In: RpcMessage, Out: RpcMessage> BoxableListener<In, Out>
     for super::quinn::QuinnListener<In, Out>
 {
-    fn clone_box(&self) -> Box<dyn BoxableListener<In, Out>> {
-        Box::new(self.clone())
-    }
-
     fn accept_bi_boxed(&self) -> AcceptFuture<In, Out> {
         let f = async move {
             let (send, recv) = super::Listener::accept(self).await?;
@@ -422,10 +409,6 @@ impl<In: RpcMessage, Out: RpcMessage> BoxableConnector<In, Out>
 impl<In: RpcMessage, Out: RpcMessage> BoxableListener<In, Out>
     for super::iroh::IrohListener<In, Out>
 {
-    fn clone_box(&self) -> Box<dyn BoxableListener<In, Out>> {
-        Box::new(self.clone())
-    }
-
     fn accept_bi_boxed(&self) -> AcceptFuture<In, Out> {
         let f = async move {
             let (send, recv) = super::Listener::accept(self).await?;
@@ -458,10 +441,6 @@ impl<In: RpcMessage, Out: RpcMessage> BoxableConnector<In, Out>
 impl<In: RpcMessage, Out: RpcMessage> BoxableListener<In, Out>
     for super::flume::FlumeListener<In, Out>
 {
-    fn clone_box(&self) -> Box<dyn BoxableListener<In, Out>> {
-        Box::new(self.clone())
-    }
-
     fn accept_bi_boxed(&self) -> AcceptFuture<In, Out> {
         AcceptFuture::direct(super::Listener::accept(self))
     }

--- a/src/transport/combined.rs
+++ b/src/transport/combined.rs
@@ -241,9 +241,9 @@ impl<A: Listener, B: Listener<In = A::In, Out = A::Out>> StreamTypes for Combine
 }
 
 impl<A: Listener, B: Listener<In = A::In, Out = A::Out>> Listener for CombinedListener<A, B> {
-    async fn accept(&self) -> Result<(Self::SendSink, Self::RecvStream), Self::AcceptError> {
+    async fn accept(&mut self) -> Result<(Self::SendSink, Self::RecvStream), Self::AcceptError> {
         let a_fut = async {
-            if let Some(a) = &self.a {
+            if let Some(a) = &mut self.a {
                 let (send, recv) = a.accept().await.map_err(AcceptError::A)?;
                 Ok((SendSink::A(send), RecvStream::A(recv)))
             } else {
@@ -251,7 +251,7 @@ impl<A: Listener, B: Listener<In = A::In, Out = A::Out>> Listener for CombinedLi
             }
         };
         let b_fut = async {
-            if let Some(b) = &self.b {
+            if let Some(b) = &mut self.b {
                 let (send, recv) = b.accept().await.map_err(AcceptError::B)?;
                 Ok((SendSink::B(send), RecvStream::B(recv)))
             } else {

--- a/src/transport/flume.rs
+++ b/src/transport/flume.rs
@@ -203,7 +203,7 @@ impl<In: RpcMessage, Out: RpcMessage> StreamTypes for FlumeListener<In, Out> {
 
 impl<In: RpcMessage, Out: RpcMessage> Listener for FlumeListener<In, Out> {
     #[allow(refining_impl_trait)]
-    fn accept(&self) -> AcceptFuture<In, Out> {
+    fn accept(&mut self) -> AcceptFuture<In, Out> {
         AcceptFuture {
             wrapped: self.stream.clone().into_recv_async(),
             _p: PhantomData,

--- a/src/transport/hyper.rs
+++ b/src/transport/hyper.rs
@@ -631,7 +631,7 @@ impl<In: RpcMessage, Out: RpcMessage> Listener for HyperListener<In, Out> {
         &self.local_addr
     }
 
-    async fn accept(&self) -> Result<(Self::SendSink, Self::RecvStream), AcceptError> {
+    async fn accept(&mut self) -> Result<(Self::SendSink, Self::RecvStream), AcceptError> {
         let (recv, send) = self
             .channel
             .recv_async()

--- a/src/transport/iroh.rs
+++ b/src/transport/iroh.rs
@@ -283,7 +283,7 @@ impl<In: RpcMessage, Out: RpcMessage> StreamTypes for IrohListener<In, Out> {
 }
 
 impl<In: RpcMessage, Out: RpcMessage> Listener for IrohListener<In, Out> {
-    async fn accept(&self) -> Result<(Self::SendSink, Self::RecvStream), AcceptError> {
+    async fn accept(&mut self) -> Result<(Self::SendSink, Self::RecvStream), AcceptError> {
         let (send, recv) = self
             .inner
             .receiver

--- a/src/transport/mapped.rs
+++ b/src/transport/mapped.rs
@@ -298,7 +298,7 @@ mod tests {
         // create a listener / connector pair. Type will be inferred
         let (s, c) = crate::transport::flume::channel(32);
         // wrap the server in a RpcServer, this is where the service type is specified
-        let server = RpcServer::<FullService, _>::new(s.clone());
+        let mut server = RpcServer::<FullService, _>::new(s.clone());
         // when using a boxed transport, we can omit the transport type and use the default
         let _server_boxed: RpcServer<FullService> = RpcServer::<FullService>::new(s.boxed());
         // create a client in a RpcClient, this is where the service type is specified

--- a/src/transport/misc/mod.rs
+++ b/src/transport/misc/mod.rs
@@ -42,7 +42,7 @@ impl<In: RpcMessage, Out: RpcMessage> StreamTypes for DummyListener<In, Out> {
 }
 
 impl<In: RpcMessage, Out: RpcMessage> Listener for DummyListener<In, Out> {
-    async fn accept(&self) -> Result<(Self::SendSink, Self::RecvStream), Self::AcceptError> {
+    async fn accept(&mut self) -> Result<(Self::SendSink, Self::RecvStream), Self::AcceptError> {
         futures_lite::future::pending().await
     }
 

--- a/src/transport/mod.rs
+++ b/src/transport/mod.rs
@@ -41,6 +41,7 @@ pub mod mapped;
 pub mod misc;
 #[cfg(feature = "quinn-transport")]
 pub mod quinn;
+pub mod tokio;
 
 #[cfg(any(feature = "quinn-transport", feature = "iroh-transport"))]
 mod util;

--- a/src/transport/mod.rs
+++ b/src/transport/mod.rs
@@ -111,7 +111,7 @@ pub trait Listener: StreamTypes {
     /// Accept a new typed bidirectional channel on any of the connections we
     /// have currently opened.
     fn accept(
-        &self,
+        &mut self,
     ) -> impl Future<Output = Result<(Self::SendSink, Self::RecvStream), Self::AcceptError>> + Send;
 
     /// The local addresses this endpoint is bound to.

--- a/src/transport/mod.rs
+++ b/src/transport/mod.rs
@@ -46,7 +46,7 @@ pub mod quinn;
 mod util;
 
 /// Errors that can happen when creating and using a [`Connector`] or [`Listener`].
-pub trait ConnectionErrors: Debug + Clone + Send + Sync + 'static {
+pub trait ConnectionErrors: Debug + Send + Sync + 'static {
     /// Error when sending a message via a channel
     type SendError: RpcError;
     /// Error when receiving a message via a channel
@@ -78,7 +78,7 @@ pub trait StreamTypes: ConnectionErrors {
 /// A connection to a specific remote machine
 ///
 /// A connection can be used to open bidirectional typed channels using [`Connector::open`].
-pub trait Connector: StreamTypes {
+pub trait Connector: StreamTypes + Clone {
     /// Open a channel to the remote che
     fn open(
         &self,

--- a/src/transport/quinn.rs
+++ b/src/transport/quinn.rs
@@ -803,3 +803,146 @@ pub fn get_handshake_data(
         server_name: tls_connection.server_name.clone(),
     })
 }
+
+#[cfg(feature = "test-utils")]
+mod quinn_setup_utils {
+    use std::{net::SocketAddr, sync::Arc};
+
+    use anyhow::Result;
+    use quinn::{crypto::rustls::QuicClientConfig, ClientConfig, Endpoint, ServerConfig};
+
+    /// Builds default quinn client config and trusts given certificates.
+    ///
+    /// ## Args
+    ///
+    /// - server_certs: a list of trusted certificates in DER format.
+    pub fn configure_client(server_certs: &[&[u8]]) -> Result<ClientConfig> {
+        let mut certs = rustls::RootCertStore::empty();
+        for cert in server_certs {
+            let cert = rustls::pki_types::CertificateDer::from(cert.to_vec());
+            certs.add(cert)?;
+        }
+
+        let crypto_client_config = rustls::ClientConfig::builder_with_provider(Arc::new(
+            rustls::crypto::ring::default_provider(),
+        ))
+        .with_protocol_versions(&[&rustls::version::TLS13])
+        .expect("valid versions")
+        .with_root_certificates(certs)
+        .with_no_client_auth();
+        let quic_client_config =
+            quinn::crypto::rustls::QuicClientConfig::try_from(crypto_client_config)?;
+
+        Ok(ClientConfig::new(Arc::new(quic_client_config)))
+    }
+
+    /// Constructs a QUIC endpoint configured for use a client only.
+    ///
+    /// ## Args
+    ///
+    /// - server_certs: list of trusted certificates.
+    pub fn make_client_endpoint(bind_addr: SocketAddr, server_certs: &[&[u8]]) -> Result<Endpoint> {
+        let client_cfg = configure_client(server_certs)?;
+        let mut endpoint = Endpoint::client(bind_addr)?;
+        endpoint.set_default_client_config(client_cfg);
+        Ok(endpoint)
+    }
+
+    /// Create a server endpoint with a self-signed certificate
+    ///
+    /// Returns the server endpoint and the certificate in DER format
+    pub fn make_server_endpoint(bind_addr: SocketAddr) -> Result<(Endpoint, Vec<u8>)> {
+        let (server_config, server_cert) = configure_server()?;
+        let endpoint = Endpoint::server(server_config, bind_addr)?;
+        Ok((endpoint, server_cert))
+    }
+
+    /// Create a quinn server config with a self-signed certificate
+    ///
+    /// Returns the server config and the certificate in DER format
+    pub fn configure_server() -> anyhow::Result<(ServerConfig, Vec<u8>)> {
+        let cert = rcgen::generate_simple_self_signed(vec!["localhost".into()])?;
+        let cert_der = cert.cert.der();
+        let priv_key = rustls::pki_types::PrivatePkcs8KeyDer::from(cert.key_pair.serialize_der());
+        let cert_chain = vec![cert_der.clone()];
+
+        let mut server_config = ServerConfig::with_single_cert(cert_chain, priv_key.into())?;
+        Arc::get_mut(&mut server_config.transport)
+            .unwrap()
+            .max_concurrent_uni_streams(0_u8.into());
+
+        Ok((server_config, cert_der.to_vec()))
+    }
+
+    /// Constructs a QUIC endpoint that trusts all certificates.
+    ///
+    /// This is useful for testing and local connections, but should be used with care.
+    pub fn make_insecure_client_endpoint(bind_addr: SocketAddr) -> Result<Endpoint> {
+        let crypto = rustls::ClientConfig::builder()
+            .dangerous()
+            .with_custom_certificate_verifier(Arc::new(SkipServerVerification))
+            .with_no_client_auth();
+
+        let client_cfg = QuicClientConfig::try_from(crypto)?;
+        let client_cfg = ClientConfig::new(Arc::new(client_cfg));
+        let mut endpoint = Endpoint::client(bind_addr)?;
+        endpoint.set_default_client_config(client_cfg);
+        Ok(endpoint)
+    }
+
+    #[derive(Debug)]
+    struct SkipServerVerification;
+
+    impl rustls::client::danger::ServerCertVerifier for SkipServerVerification {
+        fn verify_server_cert(
+            &self,
+            _end_entity: &rustls::pki_types::CertificateDer<'_>,
+            _intermediates: &[rustls::pki_types::CertificateDer<'_>],
+            _server_name: &rustls::pki_types::ServerName<'_>,
+            _ocsp_response: &[u8],
+            _now: rustls::pki_types::UnixTime,
+        ) -> Result<rustls::client::danger::ServerCertVerified, rustls::Error> {
+            Ok(rustls::client::danger::ServerCertVerified::assertion())
+        }
+
+        fn verify_tls12_signature(
+            &self,
+            _message: &[u8],
+            _cert: &rustls::pki_types::CertificateDer<'_>,
+            _dss: &rustls::DigitallySignedStruct,
+        ) -> Result<rustls::client::danger::HandshakeSignatureValid, rustls::Error> {
+            Ok(rustls::client::danger::HandshakeSignatureValid::assertion())
+        }
+
+        fn verify_tls13_signature(
+            &self,
+            _message: &[u8],
+            _cert: &rustls::pki_types::CertificateDer<'_>,
+            _dss: &rustls::DigitallySignedStruct,
+        ) -> Result<rustls::client::danger::HandshakeSignatureValid, rustls::Error> {
+            Ok(rustls::client::danger::HandshakeSignatureValid::assertion())
+        }
+
+        fn supported_verify_schemes(&self) -> Vec<rustls::SignatureScheme> {
+            use rustls::SignatureScheme::*;
+            // list them all, we don't care.
+            vec![
+                RSA_PKCS1_SHA1,
+                ECDSA_SHA1_Legacy,
+                RSA_PKCS1_SHA256,
+                ECDSA_NISTP256_SHA256,
+                RSA_PKCS1_SHA384,
+                ECDSA_NISTP384_SHA384,
+                RSA_PKCS1_SHA512,
+                ECDSA_NISTP521_SHA512,
+                RSA_PSS_SHA256,
+                RSA_PSS_SHA384,
+                RSA_PSS_SHA512,
+                ED25519,
+                ED448,
+            ]
+        }
+    }
+}
+#[cfg(feature = "test-utils")]
+pub use quinn_setup_utils::*;

--- a/src/transport/quinn.rs
+++ b/src/transport/quinn.rs
@@ -207,7 +207,7 @@ impl<In: RpcMessage, Out: RpcMessage> StreamTypes for QuinnListener<In, Out> {
 }
 
 impl<In: RpcMessage, Out: RpcMessage> Listener for QuinnListener<In, Out> {
-    async fn accept(&self) -> Result<(Self::SendSink, Self::RecvStream), AcceptError> {
+    async fn accept(&mut self) -> Result<(Self::SendSink, Self::RecvStream), AcceptError> {
         let (send, recv) = self
             .inner
             .receiver

--- a/src/transport/tokio.rs
+++ b/src/transport/tokio.rs
@@ -1,0 +1,328 @@
+//! Memory transport implementation using [tokio::sync::mpsc::channel].
+use core::fmt;
+use std::{error, fmt::Display, pin::Pin, result, task::Poll};
+
+use futures_lite::{Future, Stream};
+use futures_sink::Sink;
+use tokio_stream::wrappers::ReceiverStream;
+use tokio_util::sync::PollSender;
+
+use super::StreamTypes;
+use crate::{
+    transport::{ConnectionErrors, Connector, Listener, LocalAddr},
+    RpcMessage,
+};
+
+/// Error when receiving from a channel
+///
+/// This type has zero inhabitants, so it is always safe to unwrap a result with this error type.
+#[derive(Debug)]
+pub enum RecvError {}
+
+impl fmt::Display for RecvError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Debug::fmt(self, f)
+    }
+}
+
+/// Sink for memory channels
+pub struct SendSink<T: RpcMessage>(pub(crate) tokio_util::sync::PollSender<T>);
+
+impl<T: RpcMessage> fmt::Debug for SendSink<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("SendSink").finish()
+    }
+}
+
+impl<T: RpcMessage> Sink<T> for SendSink<T> {
+    type Error = self::SendError;
+
+    fn poll_ready(
+        mut self: Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+    ) -> Poll<Result<(), Self::Error>> {
+        Pin::new(&mut self.0)
+            .poll_ready(cx)
+            .map_err(|_| SendError::ReceiverDropped)
+    }
+
+    fn start_send(mut self: Pin<&mut Self>, item: T) -> Result<(), Self::Error> {
+        Pin::new(&mut self.0)
+            .start_send(item)
+            .map_err(|_| SendError::ReceiverDropped)
+    }
+
+    fn poll_flush(
+        mut self: Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+    ) -> Poll<Result<(), Self::Error>> {
+        Pin::new(&mut self.0)
+            .poll_flush(cx)
+            .map_err(|_| SendError::ReceiverDropped)
+    }
+
+    fn poll_close(
+        mut self: Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+    ) -> Poll<Result<(), Self::Error>> {
+        Pin::new(&mut self.0)
+            .poll_close(cx)
+            .map_err(|_| SendError::ReceiverDropped)
+    }
+}
+
+/// Stream for memory channels
+pub struct RecvStream<T: RpcMessage>(pub(crate) tokio_stream::wrappers::ReceiverStream<T>);
+
+impl<T: RpcMessage> fmt::Debug for RecvStream<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("RecvStream").finish()
+    }
+}
+
+impl<T: RpcMessage> Stream for RecvStream<T> {
+    type Item = result::Result<T, self::RecvError>;
+
+    fn poll_next(
+        mut self: Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+    ) -> Poll<Option<Self::Item>> {
+        match Pin::new(&mut self.0).poll_next(cx) {
+            Poll::Ready(Some(v)) => Poll::Ready(Some(Ok(v))),
+            Poll::Ready(None) => Poll::Ready(None),
+            Poll::Pending => Poll::Pending,
+        }
+    }
+}
+
+impl error::Error for RecvError {}
+
+/// A flume based listener.
+///
+/// Created using [channel].
+pub struct MemListener<In: RpcMessage, Out: RpcMessage> {
+    #[allow(clippy::type_complexity)]
+    stream: tokio::sync::Mutex<tokio::sync::mpsc::Receiver<(SendSink<Out>, RecvStream<In>)>>,
+}
+
+impl<In: RpcMessage, Out: RpcMessage> fmt::Debug for MemListener<In, Out> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("FlumeListener")
+            .field("stream", &self.stream)
+            .finish()
+    }
+}
+
+impl<In: RpcMessage, Out: RpcMessage> ConnectionErrors for MemListener<In, Out> {
+    type SendError = self::SendError;
+    type RecvError = self::RecvError;
+    type OpenError = self::OpenError;
+    type AcceptError = self::AcceptError;
+}
+
+type Socket<In, Out> = (self::SendSink<Out>, self::RecvStream<In>);
+
+/// Future returned by [FlumeConnection::open]
+pub struct OpenFuture<In: RpcMessage, Out: RpcMessage> {
+    inner: PollSender<Socket<Out, In>>,
+    send: Option<Socket<Out, In>>,
+    res: Option<Socket<In, Out>>,
+}
+
+impl<In: RpcMessage, Out: RpcMessage> fmt::Debug for OpenFuture<In, Out> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("OpenBiFuture").finish()
+    }
+}
+
+impl<In: RpcMessage, Out: RpcMessage> OpenFuture<In, Out> {
+    fn new(
+        inner: PollSender<Socket<Out, In>>,
+        send: Socket<Out, In>,
+        res: Socket<In, Out>,
+    ) -> Self {
+        Self {
+            inner,
+            send: Some(send),
+            res: Some(res),
+        }
+    }
+}
+
+impl<In: RpcMessage, Out: RpcMessage> Future for OpenFuture<In, Out> {
+    type Output = result::Result<Socket<In, Out>, self::OpenError>;
+
+    fn poll(
+        mut self: Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<Self::Output> {
+        match Pin::new(&mut self.inner).poll_reserve(cx) {
+            Poll::Ready(Ok(())) => {
+                let Some(item) = self.send.take() else {
+                    return Poll::Pending;
+                };
+                let Ok(_) = self.inner.send_item(item) else {
+                    return Poll::Ready(Err(self::OpenError::RemoteDropped));
+                };
+                self.res
+                    .take()
+                    .map(|x| Poll::Ready(Ok(x)))
+                    .unwrap_or(Poll::Pending)
+            }
+            Poll::Ready(Err(_)) => Poll::Ready(Err(self::OpenError::RemoteDropped)),
+            Poll::Pending => Poll::Pending,
+        }
+    }
+}
+
+impl<In: RpcMessage, Out: RpcMessage> StreamTypes for MemListener<In, Out> {
+    type In = In;
+    type Out = Out;
+    type SendSink = SendSink<Out>;
+    type RecvStream = RecvStream<In>;
+}
+
+impl<In: RpcMessage, Out: RpcMessage> Listener for MemListener<In, Out> {
+    async fn accept(&self) -> Result<(Self::SendSink, Self::RecvStream), AcceptError> {
+        let mut stream = self.stream.lock().await;
+        match stream.recv().await {
+            Some((send, recv)) => Ok((send, recv)),
+            None => Err(AcceptError::RemoteDropped),
+        }
+    }
+
+    fn local_addr(&self) -> &[LocalAddr] {
+        &[LocalAddr::Mem]
+    }
+}
+
+impl<In: RpcMessage, Out: RpcMessage> ConnectionErrors for MemConnector<In, Out> {
+    type SendError = self::SendError;
+    type RecvError = self::RecvError;
+    type OpenError = self::OpenError;
+    type AcceptError = self::AcceptError;
+}
+
+impl<In: RpcMessage, Out: RpcMessage> StreamTypes for MemConnector<In, Out> {
+    type In = In;
+    type Out = Out;
+    type SendSink = SendSink<Out>;
+    type RecvStream = RecvStream<In>;
+}
+
+impl<In: RpcMessage, Out: RpcMessage> Connector for MemConnector<In, Out> {
+    #[allow(refining_impl_trait)]
+    fn open(&self) -> OpenFuture<In, Out> {
+        let (local_send, remote_recv) = tokio::sync::mpsc::channel::<Out>(128);
+        let (remote_send, local_recv) = tokio::sync::mpsc::channel::<In>(128);
+        let remote_chan = (
+            SendSink(PollSender::new(remote_send)),
+            RecvStream(ReceiverStream::new(remote_recv)),
+        );
+        let local_chan = (
+            SendSink(PollSender::new(local_send)),
+            RecvStream(ReceiverStream::new(local_recv)),
+        );
+        let sender = PollSender::new(self.sink.clone());
+        OpenFuture::new(sender, remote_chan, local_chan)
+    }
+}
+
+/// A flume based connector.
+///
+/// Created using [channel].
+pub struct MemConnector<In: RpcMessage, Out: RpcMessage> {
+    #[allow(clippy::type_complexity)]
+    sink: tokio::sync::mpsc::Sender<(SendSink<In>, RecvStream<Out>)>,
+}
+
+impl<In: RpcMessage, Out: RpcMessage> Clone for MemConnector<In, Out> {
+    fn clone(&self) -> Self {
+        Self {
+            sink: self.sink.clone(),
+        }
+    }
+}
+
+impl<In: RpcMessage, Out: RpcMessage> fmt::Debug for MemConnector<In, Out> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("MemConnector")
+            .field("sink", &self.sink)
+            .finish()
+    }
+}
+
+/// AcceptError for mem channels.
+///
+/// There is not much that can go wrong with mem channels.
+#[derive(Debug)]
+pub enum AcceptError {
+    /// The remote side of the channel was dropped
+    RemoteDropped,
+}
+
+impl fmt::Display for AcceptError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Debug::fmt(self, f)
+    }
+}
+
+impl error::Error for AcceptError {}
+
+/// SendError for mem channels.
+///
+/// There is not much that can go wrong with mem channels.
+#[derive(Debug)]
+pub enum SendError {
+    /// Receiver was dropped
+    ReceiverDropped,
+}
+
+impl Display for SendError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Debug::fmt(self, f)
+    }
+}
+
+impl std::error::Error for SendError {}
+
+/// OpenError for mem channels.
+#[derive(Debug)]
+pub enum OpenError {
+    /// The remote side of the channel was dropped
+    RemoteDropped,
+}
+
+impl Display for OpenError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Debug::fmt(self, f)
+    }
+}
+
+impl std::error::Error for OpenError {}
+
+/// CreateChannelError for mem channels.
+///
+/// You can always create a mem channel, so there is no possible error.
+/// Nevertheless we need a type for it.
+#[derive(Debug, Clone, Copy)]
+pub enum CreateChannelError {}
+
+impl Display for CreateChannelError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Debug::fmt(self, f)
+    }
+}
+
+impl std::error::Error for CreateChannelError {}
+
+/// Create a flume listener and a connected flume connector.
+///
+/// `buffer` the size of the buffer for each channel. Keep this at a low value to get backpressure
+pub fn channel<Req: RpcMessage, Res: RpcMessage>(
+    buffer: usize,
+) -> (MemListener<Req, Res>, MemConnector<Res, Req>) {
+    let (sink, stream) = tokio::sync::mpsc::channel(buffer);
+    let stream = tokio::sync::Mutex::new(stream);
+    (MemListener { stream }, MemConnector { sink })
+}

--- a/tests/flume.rs
+++ b/tests/flume.rs
@@ -58,7 +58,7 @@ async fn flume_channel_mapped_bench() -> anyhow::Result<()> {
     }
     let (server, client) = flume::channel(1);
 
-    let server = RpcServer::<OuterService, _>::new(server);
+    let mut server = RpcServer::<OuterService, _>::new(server);
     let server_handle: tokio::task::JoinHandle<Result<(), RpcServerError<_>>> =
         tokio::task::spawn(async move {
             let service = ComputeService;

--- a/tests/hyper.rs
+++ b/tests/hyper.rs
@@ -163,7 +163,7 @@ async fn hyper_channel_errors() -> anyhow::Result<()> {
         Receiver<result::Result<(), RpcServerError<SC>>>,
     ) {
         let channel = HyperListener::serve(addr).unwrap();
-        let server = RpcServer::new(channel);
+        let mut server = RpcServer::new(channel);
         let (res_tx, res_rx) = flume::unbounded();
         let handle = tokio::spawn(async move {
             loop {

--- a/tests/math.rs
+++ b/tests/math.rs
@@ -222,46 +222,6 @@ impl ComputeService {
         tracing::info!(%count, "server finished");
         Ok(s)
     }
-
-    pub async fn server_par<C: Listener<ComputeService>>(
-        server: RpcServer<ComputeService, C>,
-        parallelism: usize,
-    ) -> result::Result<(), RpcServerError<C>> {
-        let s = server.clone();
-        let s2 = s.clone();
-        let service = ComputeService;
-        let request_stream = stream! {
-            loop {
-                yield s2.accept().await?.read_first().await;
-            }
-        };
-        let process_stream = request_stream.map(move |r| {
-            let service = service.clone();
-            async move {
-                let (req, chan) = r?;
-                use ComputeRequest::*;
-                #[rustfmt::skip]
-                match req {
-                    Sqr(msg) => chan.rpc(msg, service, ComputeService::sqr).await,
-                    Sum(msg) => chan.client_streaming(msg, service, ComputeService::sum).await,
-                    Fibonacci(msg) => chan.server_streaming(msg, service, ComputeService::fibonacci).await,
-                    Multiply(msg) => chan.bidi_streaming(msg, service, ComputeService::multiply).await,
-                    SumUpdate(_) => Err(RpcServerError::UnexpectedStartMessage)?,
-                    MultiplyUpdate(_) => Err(RpcServerError::UnexpectedStartMessage)?,
-                }?;
-                Ok::<_, RpcServerError<C>>(())
-            }
-        });
-        process_stream
-            .buffered_unordered(parallelism)
-            .for_each(|x| {
-                if let Err(e) = x {
-                    eprintln!("error: {e:?}");
-                }
-            })
-            .await;
-        Ok(())
-    }
 }
 
 pub async fn smoke_test<C: Connector<ComputeService>>(client: C) -> anyhow::Result<()> {

--- a/tests/math.rs
+++ b/tests/math.rs
@@ -197,7 +197,7 @@ impl ComputeService {
         count: usize,
     ) -> result::Result<RpcServer<ComputeService, C>, RpcServerError<C>> {
         tracing::info!(%count, "server running");
-        let s = server;
+        let mut s = server;
         let mut received = 0;
         let service = ComputeService;
         while received < count {

--- a/tests/slow_math.rs
+++ b/tests/slow_math.rs
@@ -111,7 +111,7 @@ impl ComputeService {
     pub async fn server<C: Listener<ComputeService>>(
         server: RpcServer<ComputeService, C>,
     ) -> result::Result<(), RpcServerError<C>> {
-        let s = server;
+        let mut s = server;
         let service = ComputeService;
         loop {
             let (req, chan) = s.accept().await?.read_first().await?;

--- a/tests/tokio.rs
+++ b/tests/tokio.rs
@@ -57,7 +57,7 @@ async fn tokio_channel_mapped_bench() -> anyhow::Result<()> {
     }
     let (server, client) = tkio::channel(1);
 
-    let server = RpcServer::<OuterService, _>::new(server);
+    let mut server = RpcServer::<OuterService, _>::new(server);
     let server_handle: tokio::task::JoinHandle<Result<(), RpcServerError<_>>> =
         tokio::task::spawn(async move {
             let service = ComputeService;

--- a/tests/tokio.rs
+++ b/tests/tokio.rs
@@ -1,0 +1,102 @@
+#![allow(non_local_definitions)]
+mod math;
+use math::*;
+use quic_rpc::{
+    server::{RpcChannel, RpcServerError},
+    transport::tokio as tkio,
+    RpcClient, RpcServer, Service,
+};
+use tokio_util::task::AbortOnDropHandle;
+
+#[tokio::test]
+async fn tokio_channel_bench() -> anyhow::Result<()> {
+    tracing_subscriber::fmt::try_init().ok();
+    let (server, client) = tkio::channel(1);
+
+    let server = RpcServer::<ComputeService, _>::new(server);
+    let _server_handle = AbortOnDropHandle::new(tokio::spawn(ComputeService::server(server)));
+    let client = RpcClient::<ComputeService, _>::new(client);
+    bench(client, 1000000).await?;
+    Ok(())
+}
+
+#[tokio::test]
+async fn tokio_channel_mapped_bench() -> anyhow::Result<()> {
+    use derive_more::{From, TryInto};
+    use serde::{Deserialize, Serialize};
+
+    tracing_subscriber::fmt::try_init().ok();
+
+    #[derive(Debug, Serialize, Deserialize, From, TryInto)]
+    enum OuterRequest {
+        Inner(InnerRequest),
+    }
+    #[derive(Debug, Serialize, Deserialize, From, TryInto)]
+    enum InnerRequest {
+        Compute(ComputeRequest),
+    }
+    #[derive(Debug, Serialize, Deserialize, From, TryInto)]
+    enum OuterResponse {
+        Inner(InnerResponse),
+    }
+    #[derive(Debug, Serialize, Deserialize, From, TryInto)]
+    enum InnerResponse {
+        Compute(ComputeResponse),
+    }
+    #[derive(Debug, Clone)]
+    struct OuterService;
+    impl Service for OuterService {
+        type Req = OuterRequest;
+        type Res = OuterResponse;
+    }
+    #[derive(Debug, Clone)]
+    struct InnerService;
+    impl Service for InnerService {
+        type Req = InnerRequest;
+        type Res = InnerResponse;
+    }
+    let (server, client) = tkio::channel(1);
+
+    let server = RpcServer::<OuterService, _>::new(server);
+    let server_handle: tokio::task::JoinHandle<Result<(), RpcServerError<_>>> =
+        tokio::task::spawn(async move {
+            let service = ComputeService;
+            loop {
+                let (req, chan) = server.accept().await?.read_first().await?;
+                let service = service.clone();
+                tokio::spawn(async move {
+                    let req: OuterRequest = req;
+                    match req {
+                        OuterRequest::Inner(InnerRequest::Compute(req)) => {
+                            let chan: RpcChannel<InnerService, _> = chan.map();
+                            let chan: RpcChannel<ComputeService, _> = chan.map();
+                            ComputeService::handle_rpc_request(service, req, chan).await
+                        }
+                    }
+                });
+            }
+        });
+
+    let client = RpcClient::<OuterService, _>::new(client);
+    let client: RpcClient<InnerService, _> = client.map();
+    let client: RpcClient<ComputeService, _> = client.map();
+    bench(client, 1000000).await?;
+    // dropping the client will cause the server to terminate
+    match server_handle.await? {
+        Err(RpcServerError::Accept(_)) => {}
+        e => panic!("unexpected termination result {e:?}"),
+    }
+    Ok(())
+}
+
+/// simple happy path test for all 4 patterns
+#[tokio::test]
+async fn tokio_channel_smoke() -> anyhow::Result<()> {
+    tracing_subscriber::fmt::try_init().ok();
+    let (server, client) = tkio::channel(1);
+
+    let server = RpcServer::<ComputeService, _>::new(server);
+    let _server_handle = AbortOnDropHandle::new(tokio::spawn(ComputeService::server(server)));
+    smoke_test(client).await?;
+    Ok(())
+}

--- a/tests/try.rs
+++ b/tests/try.rs
@@ -74,7 +74,7 @@ async fn try_server_streaming() -> anyhow::Result<()> {
     tracing_subscriber::fmt::try_init().ok();
     let (server, client) = flume::channel(1);
 
-    let server = RpcServer::<TryService, _>::new(server);
+    let mut server = RpcServer::<TryService, _>::new(server);
     let server_handle = tokio::task::spawn(async move {
         loop {
             let (req, chan) = server.accept().await?.read_first().await?;


### PR DESCRIPTION
This is a new attempt to do a mem transport based on `tokio::sync::mpsc::channel`, replacing https://github.com/n0-computer/quic-rpc/pull/86

The big problem of the former PR is that the listener is Clone, so there needs to be some ugly stuff to turn the tokio mpsc channel into a mpmc channel.

So this PR is an experiment to change Listener to be non-Clone and also take a &mut self in accept. Once you do that, implementing a mem channel using a mpsc channel becomes _much_ easier.

I have tried this out in a crate, iroh-blobs, that uses rpc in a pretty complex way, and have not found an issue adapting this. Being able to clone the place that does accept is a bit weird anyway, but I did it because both my favoured memory channel at the time (flume) and the networked channel (quinn) did support it.