### PR TITLE
fix: Fuse oneshot channel

### DIFF
--- a/src/server.rs
+++ b/src/server.rs
@@ -455,6 +455,7 @@ impl<T> Future for UnwrapToPending<T> {
     type Output = T;
 
     fn poll(mut self: Pin<&mut Self>, cx: &mut task::Context<'_>) -> Poll<Self::Output> {
+        // todo: use is_terminated from tokio 1.44 here to avoid the fused wrapper
         match Pin::new(&mut self.0).poll(cx) {
             Poll::Ready(Ok(x)) => Poll::Ready(x),
             Poll::Ready(Err(_)) => Poll::Pending,

--- a/src/server.rs
+++ b/src/server.rs
@@ -329,7 +329,7 @@ where
 {
     pub(crate) fn new(recv: C::RecvStream) -> (Self, UnwrapToPending<RpcServerError<C>>) {
         let (error_send, error_recv) = oneshot::channel();
-        let error_recv = UnwrapToPending(error_recv);
+        let error_recv = UnwrapToPending(futures_lite::future::fuse(error_recv));
         (Self(recv, Some(error_send), PhantomData), error_recv)
     }
 }
@@ -449,7 +449,7 @@ impl<C: ConnectionErrors> fmt::Display for RpcServerError<C> {
 impl<C: ConnectionErrors> error::Error for RpcServerError<C> {}
 
 /// Take an oneshot receiver and just return Pending the underlying future returns `Err(oneshot::Canceled)`
-pub(crate) struct UnwrapToPending<T>(oneshot::Receiver<T>);
+pub(crate) struct UnwrapToPending<T>(futures_lite::future::Fuse<oneshot::Receiver<T>>);
 
 impl<T> Future for UnwrapToPending<T> {
     type Output = T;

--- a/src/server.rs
+++ b/src/server.rs
@@ -464,10 +464,25 @@ impl<T> Future for UnwrapToPending<T> {
 }
 
 pub(crate) async fn race2<T, A: Future<Output = T>, B: Future<Output = T>>(f1: A, f2: B) -> T {
-    tokio::select! {
-        x = f1 => x,
-        x = f2 => x,
-    }
+    // Pin the futures on the stack for polling
+    let mut f1 = std::pin::pin!(f1);
+    let mut f2 = std::pin::pin!(f2);
+
+    // Create a future that resolves when either f1 or f2 completes
+    std::future::poll_fn(|cx| {
+        // Poll both futures
+        match f1.as_mut().poll(cx) {
+            Poll::Ready(result) => return Poll::Ready(result),
+            Poll::Pending => {}
+        }
+        match f2.as_mut().poll(cx) {
+            Poll::Ready(result) => return Poll::Ready(result),
+            Poll::Pending => {}
+        }
+        // If neither is ready, yield back to the executor
+        Poll::Pending
+    })
+    .await
 }
 
 /// Run a server loop, invoking a handler callback for each request.


### PR DESCRIPTION
It seems that under some weird circumstances we get a situation where an oneshot channel is polled after completion. Oneshot channel is not fused for no good reason that I can see, so we get a panic.

This did not happen before, but now it happens more frequently and causes frequent test failures in iroh-blobs CI.

There is a way to detect an already terminated oneshot channel in tokio 1.44 from 2025-03-07, so we could just modify the poll fn of the wrapper to call that. But since I don't want to update the tokio dep for a patch, I just wrap it in a fuse. We can do the is_terminated thing once we get tokio 1.44.